### PR TITLE
disable writing of mustGather logs

### DIFF
--- a/deploy/crds/operators.multicloud.ibm.com_v1alpha1_multicloudhub_cr.yaml
+++ b/deploy/crds/operators.multicloud.ibm.com_v1alpha1_multicloudhub_cr.yaml
@@ -35,4 +35,4 @@ spec:
     globalPullSecret:
       name: private-secret
     failedProvisionConfig:
-      skipGatherLogs: false
+      skipGatherLogs: true


### PR DESCRIPTION
disable writing of mustGather logs because they need persistent storage - hive team says this feature is rarely used


See https://github.com/open-cluster-management/backlog/issues/428