### PR TITLE
check mongo config

### DIFF
--- a/pkg/controller/multicloudhub/multicloudhub_controller.go
+++ b/pkg/controller/multicloudhub/multicloudhub_controller.go
@@ -112,6 +112,7 @@ func (r *ReconcileMultiCloudHub) Reconcile(request reconcile.Request) (reconcile
 		return *result, err
 	}
 
+	checkMultiCloudHubConfig(multiCloudHub)
 	//Render the templates with a specified CR
 	renderer := rendering.NewRenderer(multiCloudHub)
 	toDeploy, err := renderer.Render()
@@ -216,4 +217,28 @@ func generatePass(length int) string {
 		buf[i] = chars[nBig.Int64()]
 	}
 	return string(buf)
+}
+
+func checkMultiCloudHubConfig(multiCloudHub *operatorsv1alpha1.MultiCloudHub) {
+	if multiCloudHub.Spec.Mongo.Endpoints == "" {
+		multiCloudHub.Spec.Mongo.Endpoints = "multicloud-mongodb"
+	}
+
+	if multiCloudHub.Spec.Mongo.Endpoints == "multicloud-mongodb" {
+		if multiCloudHub.Spec.Mongo.ReplicaSet == "" {
+			multiCloudHub.Spec.Mongo.ReplicaSet = "rs0"
+		}
+
+		if multiCloudHub.Spec.Mongo.UserSecret == "" {
+			multiCloudHub.Spec.Mongo.UserSecret = "mongodb-admin"
+		}
+
+		if multiCloudHub.Spec.Mongo.CASecret == "" {
+			multiCloudHub.Spec.Mongo.CASecret = "multicloud-ca-cert"
+		}
+
+		if multiCloudHub.Spec.Mongo.TLSSecret == "" {
+			multiCloudHub.Spec.Mongo.TLSSecret = "multicloud-mongodb-client-cert"
+		}
+	}
 }

--- a/pkg/controller/multicloudhub/multicloudhub_controller_test.go
+++ b/pkg/controller/multicloudhub/multicloudhub_controller_test.go
@@ -1,6 +1,9 @@
 package multicloudhub
 
-import "testing"
+import (
+	operatorsv1alpha1 "github.com/open-cluster-management/multicloudhub-operator/pkg/apis/operators/v1alpha1"
+	"testing"
+)
 
 func Test_generatePass(t *testing.T) {
 	t.Run("Test length", func(t *testing.T) {
@@ -17,4 +20,23 @@ func Test_generatePass(t *testing.T) {
 			t.Errorf("generatePass() did not generate a unique password")
 		}
 	})
+}
+
+func Test_checkMultiCloudHubConfig(t *testing.T) {
+	mch := &operatorsv1alpha1.MultiCloudHub{
+		Spec: operatorsv1alpha1.MultiCloudHubSpec{
+			Mongo: operatorsv1alpha1.Mongo{
+				Endpoints: "",
+			},
+		},
+	}
+	checkMultiCloudHubConfig(mch)
+
+	if mch.Spec.Mongo.Endpoints != "multicloud-mongodb" ||
+		mch.Spec.Mongo.ReplicaSet != "rs0" ||
+		mch.Spec.Mongo.UserSecret != "mongodb-admin" ||
+		mch.Spec.Mongo.CASecret != "multicloud-ca-cert" ||
+		mch.Spec.Mongo.TLSSecret != "multicloud-mongodb-client-cert" {
+		t.Errorf("checkMultiCloudHubConfig test fail")
+	}
 }

--- a/pkg/rendering/patching/patcher.go
+++ b/pkg/rendering/patching/patcher.go
@@ -228,27 +228,30 @@ func generateMongoSecrets(mch *operatorsv1alpha1.MultiCloudHub) ([]corev1.EnvVar
 	envs := []corev1.EnvVar{}
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
-	envs = append(envs, corev1.EnvVar{
-		Name: "MONGO_USERNAME",
-		ValueFrom: &corev1.EnvVarSource{
-			SecretKeyRef: &corev1.SecretKeySelector{
-				Key: "user",
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "mongodb-admin",
+	if mch.Spec.Mongo.UserSecret != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name: "MONGO_ROOT_USERNAME",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: "user",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: mch.Spec.Mongo.UserSecret,
+					},
 				},
 			},
-		},
-	}, corev1.EnvVar{
-		Name: "MONGO_PASSWORD",
-		ValueFrom: &corev1.EnvVarSource{
-			SecretKeyRef: &corev1.SecretKeySelector{
-				Key: "password",
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "mongodb-admin",
+		}, corev1.EnvVar{
+			Name: "MONGO_ROOT_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: "password",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: mch.Spec.Mongo.UserSecret,
+					},
 				},
 			},
-		},
-	})
+		})
+	}
+
 	if mch.Spec.Mongo.CASecret != "" {
 		envs = append(envs, corev1.EnvVar{Name: "MONGO_SSLCA", Value: "/certs/mongodb-ca/tls.crt"})
 		volumes = append(volumes, corev1.Volume{


### PR DESCRIPTION
This PR is for:
1. fix mongo Env USERNAME and PASSWOR typo error.
2. revert mongo UserSecret "mongodb-admin"  using hard code. because user may use external mongo. related issue https://github.com/open-cluster-management/backlog/issues/727
3. check mongo config in multiCloudHub CR, set default values if user want to use default mongo.

@clyang82  please help to check the default config of mongo like service, secret names.