### PR TITLE
Add probes, inject pod_namespace into helm repo

### DIFF
--- a/templates/multiclusterhub/base/repo/deployment.yaml
+++ b/templates/multiclusterhub/base/repo/deployment.yaml
@@ -22,7 +22,22 @@ spec:
         resources:
           limits:
             cpu: 50m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 50m
-            memory: 30Mi
+            memory: 50Mi
+        livenessProbe:
+          httpGet:
+            path: "/liveness"
+            scheme: HTTP
+            port: 3000
+        readinessProbe:
+          httpGet:
+            path: "/readiness"
+            scheme: HTTP
+            port: 3000
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace


### PR DESCRIPTION
Adds POD_NAMESPACE variable, needed for https://github.com/open-cluster-management/backlog/issues/824

Will also resolve https://github.com/open-cluster-management/backlog/issues/879 by allocating appropriate memory resources.