### PR TITLE
Don't override configmap watcher in cert-webhook

### DIFF
--- a/templates/multiclusterhub/base/subscriptions/cert_manager/cert_manager_webhook.yaml
+++ b/templates/multiclusterhub/base/subscriptions/cert_manager/cert_manager_webhook.yaml
@@ -28,8 +28,3 @@ spec:
           serviceAccount:
             create: false
             name: default
-          watcher:
-            configmap:
-              name: extension-apiserver-authentication
-              namespace: "{{NAMESPACE}}"
-            optIn: true


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/927
Cert-manager webhook update: https://github.com/open-cluster-management/cert-manager-webhook-chart/pull/18