### PR TITLE
add imageRepository value for RCM subscription

### DIFF
--- a/templates/multiclusterhub/base/subscriptions/rcm/rcm.yaml
+++ b/templates/multiclusterhub/base/subscriptions/rcm/rcm.yaml
@@ -6,13 +6,15 @@ spec:
   channel: charts-v1
   name: rcm
   placement:
-    local: true 
+    local: true
   packageOverrides:
     - packageName: rcm
       packageOverrides:
       - path: spec.values
         value: |
           imageTagPostfix: "{{SUFFIX}}"
+          imageRepository: "{{IMAGEREPO}}"
+          imagePullSecret: "{{PULLSECRET}}"
           clusterController:
             image:
               repository: "{{IMAGEREPO}}"


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/648

matching chart PR https://github.com/open-cluster-management/rcm-chart/pull/21

these paramater are use for setting environment variable for the default registry and pull secret that will be use to deploy the endpoint operator and endpoint