### PR TITLE
adding optional ipv6 boolean flag to top level of spec (although just…

### DIFF
--- a/build/_output/olm/multiclusterhub.crd.yaml
+++ b/build/_output/olm/multiclusterhub.crd.yaml
@@ -212,6 +212,9 @@
               ingressDomain:
                 description: Default domain for routes
                 type: string
+              ipv6:
+                description: Cluster is IPv6 environment
+                type: boolean
               mongo:
                 description: Spec of mongo
                 properties:

--- a/build/_output/olm/multiclusterhub.resources.yaml
+++ b/build/_output/olm/multiclusterhub.resources.yaml
@@ -231,6 +231,9 @@ data:
                   ingressDomain:
                     description: Default domain for routes
                     type: string
+                  ipv6:
+                    description: Cluster is IPv6 environment
+                    type: boolean
                   mongo:
                     description: Spec of mongo
                     properties:

--- a/deploy/crds/operators.open-cluster-management.io_multiclusterhubs_crd.yaml
+++ b/deploy/crds/operators.open-cluster-management.io_multiclusterhubs_crd.yaml
@@ -212,6 +212,9 @@ spec:
             ingressDomain:
               description: Default domain for routes
               type: string
+            ipv6:
+              description: Cluster is IPv6 environment
+              type: boolean
             mongo:
               description: Spec of mongo
               properties:

--- a/pkg/apis/operators/v1alpha1/multiclusterhub_types.go
+++ b/pkg/apis/operators/v1alpha1/multiclusterhub_types.go
@@ -32,6 +32,10 @@ type MultiClusterHubSpec struct {
 	// +optional
 	IngressDomain string `json:"ingressDomain,omitempty"`
 
+	// Flag for IPv6
+	// +optional
+	IPv6 bool `json:"ipv6"`
+
 	// Spec of NodeSelector
 	// +optional
 	NodeSelector *NodeSelector `json:"nodeSelector,omitempty"`
@@ -58,7 +62,7 @@ type Etcd struct {
 
 	// StorageSize for MultiCluster hub components (ex. 1Gi)
 	// +optional
-	Storage string `json:"storage,omiteempty"`
+	Storage string `json:"storage,omitempty"`
 }
 
 // NodeSelector defines the desired state of NodeSelector
@@ -253,7 +257,7 @@ type Mongo struct {
 
 	// StorageSize for MultiCluster hub components (ex. 1Gi)
 	// +optional
-	Storage string `json:"storage,omiteempty"`
+	Storage string `json:"storage,omitempty"`
 }
 
 // MultiClusterHubStatus defines the observed state of MultiClusterHub

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -200,6 +200,11 @@ func stringValueReplace(to_replace string, cr *operatorsv1alpha1.MultiClusterHub
 		imageTagSuffix = "-" + imageTagSuffix
 	}
 
+	mongoNetworkIPVersion := "ipv4"
+	if cr.Spec.IPv6 {
+		mongoNetworkIPVersion = "ipv6"
+	}
+
 	replaced = strings.ReplaceAll(replaced, "{{SUFFIX}}", string(imageTagSuffix))
 	replaced = strings.ReplaceAll(replaced, "{{IMAGEREPO}}", string(cr.Spec.ImageRepository))
 	replaced = strings.ReplaceAll(replaced, "{{PULLSECRET}}", string(cr.Spec.ImagePullSecret))
@@ -208,6 +213,7 @@ func stringValueReplace(to_replace string, cr *operatorsv1alpha1.MultiClusterHub
 	replaced = strings.ReplaceAll(replaced, "{{DOMAIN}}", string(cr.Spec.IngressDomain))
 	replaced = strings.ReplaceAll(replaced, "{{STORAGECLASS}}", string(cr.Spec.Mongo.StorageClass)) //Assuming this is specifically for Mongo.
 	replaced = strings.ReplaceAll(replaced, "{{STORAGE}}", string(cr.Spec.Mongo.Storage))
+	replaced = strings.ReplaceAll(replaced, "{{NETWORK_IP_VERSION}}", string(mongoNetworkIPVersion))
 
 	return replaced
 }

--- a/templates/multiclusterhub/base/subscriptions/mongodb/mongodb.yaml
+++ b/templates/multiclusterhub/base/subscriptions/mongodb/mongodb.yaml
@@ -15,7 +15,7 @@ spec:
           imageTagPostfix: "{{SUFFIX}}"
           imagePullSecrets:
           - "{{PULLSECRET}}"
-          network_ip_version: "ipv4"
+          network_ip_version: "{{NETWORK_IP_VERSION}}"
           auth:
             enabled: true
             existingAdminSecret: "mongodb-admin"


### PR DESCRIPTION
… used for mongodb right now)

The api type does _not_ have `omitempty` so the value _will_ show up when you run `oc get mch -o yaml`, but I think that's a good feature.

I don't have to supply any default behavior because the golang boolean zero value is `false`.

