### PR TITLE
Finalize webhooks

### DIFF
--- a/pkg/controller/multiclusterhub/multiclusterhub_controller.go
+++ b/pkg/controller/multiclusterhub/multiclusterhub_controller.go
@@ -459,6 +459,9 @@ func (r *ReconcileMultiClusterHub) finalizeHub(reqLogger logr.Logger, m *operato
 	if err := r.cleanupClusterRoleBindings(reqLogger, m); err != nil {
 		return err
 	}
+	if err := r.cleanupMutatingWebhooks(reqLogger, m); err != nil {
+		return err
+	}
 
 	reqLogger.Info("Successfully finalized multiClusterHub")
 	return nil

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -194,6 +194,7 @@ func (r *Renderer) renderMutatingWebhookConfiguration(res *resource.Resource) (*
 	service := clientConfig["service"].(map[string]interface{})
 
 	service["namespace"] = r.cr.Namespace
+	addInstallerLabel(u, r.cr.GetName(), r.cr.GetNamespace())
 	return u, nil
 }
 


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/1310

Note: Had to use `AdmissionregistrationV1beta1` instead of v1 because the go modules are pinned to Kubernetes 1.15 even though we are supporting Kubernetes 1.16 and up. Updating to a more recent operator-sdk would bring this up to date