### PR TITLE
enable mongo HA

### DIFF
--- a/pkg/controller/multiclusterhub/multiclusterhub_controller.go
+++ b/pkg/controller/multiclusterhub/multiclusterhub_controller.go
@@ -448,7 +448,7 @@ func (r *ReconcileMultiClusterHub) SetDefaults(m *operatorsv1alpha1.MultiCluster
 	}
 
 	if m.Spec.Mongo.ReplicaCount <= 0 {
-		m.Spec.Mongo.ReplicaCount = 1
+		m.Spec.Mongo.ReplicaCount = 3
 	}
 	return nil, nil
 }


### PR DESCRIPTION
By default, we need to enable the MongoDB HA, so we need to modify `Mongo.ReplicaCount` to `3`.  refer issue: https://github.com/open-cluster-management/backlog/issues/1583 