### PR TITLE
Add template/scripts for generating composite ACM operator bundle

### DIFF
--- a/build-scripts/bundle-gen/acm-csv-template.yaml
+++ b/build-scripts/bundle-gen/acm-csv-template.yaml
@@ -1,0 +1,68 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "*Merge* to String rep of List"
+    capabilities: Basic Install
+    categories: "*Merge* to string containing comma-separated Set"
+    certified: false
+    createdAt: "*Insert* eg: 2020-03-24T17:00:00Z>"
+    description: Advanced provisioning and management of Openshift and Kubernetes clusters
+  name: "*Insert* eg: multicluster-hub-operator.v1.0.0"
+  namespace: placeholder
+spec:
+  displayName: Advanced Cluster Management
+  version: "*Insert* eg: 0.9.0"
+  replaces: "*Insert* eg: multicluster-hub-operator.v0.8.9"
+  provider:
+    name: Red Hat, Inc
+  maintainers:
+  - email: acm-tech@redhat.com
+    name: Red Hat, Inc
+  maturity: alpha
+  description: |
+    This is some placeholder text.
+
+    The Advanced Cluster Management Hub operator installs and maintains an instnace of the ACM hub,
+    a cetneral management console for managing OpenShift and Kubernetes clusters.
+
+    ## Prerequisites
+    - You should really like playing with OpenShift clusters.
+
+    ## How to Install
+    - Install the Advanced Cluster Manaament Hub ooperator by following instructions in top right button `Install`.
+    
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  keywords: "*Merge* to Set"
+  labels:
+    app: acm-hub
+  links:
+  - name: Documentation
+    url: https://redhat-customer-portal.redhat.com/acm/start-here.html
+  selector:
+    matchLabels:
+      app: acm-hub
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  apiservicedefinitions:
+    required: "*Merge* to List"
+    owned: "*Merge* to List"
+  customresourcedefinitions:
+    required: "*Merge* to List"
+    owned: "*Merge* to List"
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions: "*Merge* to list"
+      permissions: "*Merge* to List"
+      deployments: "*Merge* to List"
+

--- a/build-scripts/bundle-gen/create-bound-bundle.py
+++ b/build-scripts/bundle-gen/create-bound-bundle.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Assumes: Python 3.6+
+
+# Takes an "unbound" CSV bundle abd configures it for a release by:
+#
+# - Updating CSV version and CSV name (to match version)
+# - Setting the "replaces" property.
+# - Overriding image refernces
+# - Setting the createdAt timestamp
+#
+# Note:
+# - We declare our Pyton requirement as 3.6+ to gain use of the inseration-oder preserving
+#   implementation of dict() to have a generated CSV ordering that matches that of the
+#   template CSV.  (Python 3.7+ makes this order preserving a part of the language spec, btw).
+
+from bundle_common import *
+
+import argparse
+import datetime
+import os
+
+
+# --- Main ---
+
+def main():
+
+   # Handle args:
+
+   parser = argparse.ArgumentParser()
+
+   parser.add_argument("--source-bundle-dir", dest="source_bundle_pathn", required=True)
+
+   parser.add_argument("--pkg-dir",  dest="pkg_dir_pathn", required=True)
+   parser.add_argument("--pkg-name", dest="pkg_name", required=True)
+
+   parser.add_argument("--use-bundle-image-format", dest="use_bundle_image_format", action="store_true")
+
+   parser.add_argument("--default-channel",    dest="default_channel", required=True)
+   parser.add_argument("--replaces-channel",   dest="replaces_channel")
+   parser.add_argument("--additional-channel", dest="other_channels", action="append")
+
+   parser.add_argument("--csv-vers",  dest="csv_vers", required=True)
+   parser.add_argument("--prev-vers", dest="prev_vers")
+
+   parser.add_argument("--image-override", dest="image_overrides", action="append", required=True)
+
+   args = parser.parse_args()
+
+   source_bundle_pathn = args.source_bundle_pathn
+
+   operator_name  = args.pkg_name
+   pkg_name       = args.pkg_name
+   pkg_dir_pathn  = args.pkg_dir_pathn
+
+   use_bundle_image_format = args.use_bundle_image_format
+
+   replaces_channel = args.replaces_channel
+   other_channels   = args.other_channels
+   default_channel  = args.default_channel
+
+   csv_vers  = args.csv_vers
+   prev_vers = args.prev_vers
+
+   image_override_list = args.image_overrides
+
+   csv_name = "%s.v%s" % (pkg_name, csv_vers)
+   csv_fn   = "%s.clusterserviceversion.yaml" % (csv_name)
+
+   # The package directory is the directory in which we place a version-named
+   # sub-directory for the new bundle.  Make sure the package directory exists,
+   # and then create (or empty out) a bundle directory under it.
+
+   if not os.path.exists(pkg_dir_pathn):
+      die("Output package directory doesn't exist: %s" % pkg_dir_pathn)
+   elif not os.path.isdir(pkg_dir_pathn):
+      die("Output package path exists but isn't a directory: %s" % pkg_dir_pathn)
+
+   # There seem to be several formats for a bundle directore, depending on how they
+   # are being published: being placed in an operator bundle image, or made available
+   # some other way (eg. via a Quay.io Application Repo).
+   #
+   # When the bundle is in bundle-image format, the bundle directory has a manifests
+   # subdirectory containing all CSV, CRD manifests, and a metadata directory containing
+   # an annotations manifest. When other formats these subdirectories do not exist and
+   # all manifests are in the bundle directory itself.  (The bits of metadata are instead
+   # in a package.yamml in the package directory containing the bundle.)
+
+   if use_bundle_image_format:
+      bundle_pathn = os.path.join(pkg_dir_pathn, csv_vers, "manifests")
+   else:
+      bundle_pathn = os.path.join(pkg_dir_pathn, csv_vers)
+   create_or_empty_directory("outout bundle manifests", bundle_pathn)
+
+
+   # Load or create the (output) package manifest.
+
+   pkg_manifest_pathn = os.path.join(pkg_dir_pathn, "package.yaml")
+   pkg_manifest = load_pkg_manifest(pkg_manifest_pathn, pkg_name)
+   if default_channel:
+      pkg_manifest["defaultChannel"] = default_channel
+   else:
+      # TODO/Idea: Use default channel already in package manifest if any?
+      if use_bundle_image_format:
+         emsg("A default channel is required when using bundle-image format.")
+
+   # See if this CSV is to replace an existing one as determeined by:
+   #
+   # - Previous version speicified by invocation arg, or if none
+   # - Current CSV listed on the replaces channel for the package.
+
+   prev_csv_name = None
+   if prev_vers:
+      prev_csv_name = "%s.v%s" % (pkg_name, prev_vers)
+   else:
+      if replaces_channel:
+         chan = find_channel_entry(pkg_manifest, replaces_channel)
+         if chan is not None:
+            prev_csv_name = chan["currentCSV"]
+
+   print("New CSV name: %s" % csv_name)
+   if prev_csv_name:
+      print("Replaces previous CSV: %s" % prev_csv_name)
+   else:
+      print("NOTE: New CSV does not replace a previous one.")
+
+   channels_to_update = list()
+   if replaces_channel:
+      channels_to_update.append(replaces_channel)
+   if default_channel:
+      channels_to_update.append(default_channel)
+   if other_channels:
+      channels_to_update.extend(other_channels)
+
+   # Load all manifests in the source bundle directory.  For non-CSV manifests,
+   # just copy over to output bundle.  Hold onto the CSV for later manipulation.
+
+   csv = None
+
+   manifests = load_all_manifests(source_bundle_pathn)
+   for manifest_fn, manifest in manifests.items():
+      kind = manifest["kind"]
+      if kind == "ClusterServiceVersion":
+         if csv is None:
+            csv = manifest
+         else:
+            die("More than one CSV manifest found in bundle directory.")
+      else:
+         print("Copying manifest file unchanged: %s" % manifest_fn)
+         copy_file(manifest_fn, source_bundle_pathn, bundle_pathn)
+   #
+
+   # Adjust CSV name and creation timestamp in metadata
+
+   metadata = csv["metadata"]
+   metadata["name"] = csv_name
+
+   created_at = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+   annotations = metadata["annotations"]
+   annotations["createdAt"] = created_at
+
+   # Plug in version and previous CSV ("replaces") if any.
+
+   spec = csv["spec"]
+   spec["version"]  = csv_vers
+   if prev_csv_name is not None:
+      spec["replaces"] = prev_csv_name
+   else:
+      try:
+         del spec["replaces"]
+      except KeyError:
+         pass
+
+   # Adjust image refs in deployment specs according to overrides:
+
+   image_overrides = create_image_override_map(image_override_list)
+
+   install_spec = spec["install"]["spec"]
+   deployments = install_spec["deployments"]
+
+   if image_overrides:
+      print("Updating image references...")
+      for deployment in deployments:
+         update_image_refs_in_deployment(deployment, image_overrides)
+
+   # Write out the updated CSV
+
+   csv_pathn = os.path.join(bundle_pathn, csv_fn)
+
+   print("Writing CSV mainfest: %s" % csv_fn)
+   dump_manifest("bound CSV", csv_pathn, csv)
+
+   # Generate metadata/annotatoins
+
+   if use_bundle_image_format:
+      metadata_pathn = os.path.join(pkg_dir_pathn, csv_vers, "metadata")
+      create_or_empty_directory("outout bundle metadata", metadata_pathn)
+
+      annotations_manifest = dict()
+      annotations_manifest["annotations"] = dict()
+      annot = annotations_manifest["annotations"]
+
+      annot["operators.operatorframework.io.bundle.mediatype.v1"] = "registry+v1"
+      annot["operators.operatorframework.io.bundle.manifests.v1"] = "manifests/"
+      annot["operators.operatorframework.io.bundle.metadata.v1"]  = "metadata/"
+
+      annot["operators.operatorframework.io.bundle.package.v1"] = pkg_name
+
+      channels_list = ','.join(sorted(list(channels_to_update)))
+      annot["operators.operatorframework.io.bundle.channels.v1"] = channels_list
+
+      # Observation: Having a default channel annotation be a property of a bundle
+      # (representing a specific version of a CSV) seems odd, as this is really a
+      # property of the package, not a paritcular CSV.  I wonder what the result is if
+      # multiple CSVs decleare different defaults??
+      annot["operators.operatorframework.io.bundle.channel.default.v1"] = default_channel
+
+      print("Writing bundle metadata.")
+      bundle_annotations_pathn = os.path.join(metadata_pathn, "annotations.yaml")
+      dump_manifest("bundle metadata", bundle_annotations_pathn, annotations_manifest)
+
+   # Update the package manifest to point to the new CSV
+
+   print("Updating package manifest.")
+   update_pkg_manifest(pkg_manifest, channels_to_update, csv_name)
+   dump_manifest("package manifest", pkg_manifest_pathn, pkg_manifest)
+
+   exit(0)
+
+if __name__ == "__main__":
+   main()
+
+#-30-
+

--- a/build-scripts/bundle-gen/create-unbound-acm-bundle.py
+++ b/build-scripts/bundle-gen/create-unbound-acm-bundle.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+# Assumes: Python 3.6+
+
+# Creates the composite ACM bundle by merging CSVs and other manifests from one or more
+# ssource bundles into an output bundle.  Boilerplate info for the output CSV is obtained
+# from a template.
+#
+# Note:
+#
+# - The main inputs to this script are already-formed OLM/operator bundles, so there is no
+#   depedency on eg. repo structures, whether operator-sdk is being used or not, etc.
+#
+# - Except for a few arg defaults, hopefully this script is not really ACM specific.
+#
+# - We declare our Pyton requirement as 3.6+ to gain use of the inseration-oder preserving
+#   implementation of dict() to have a generated CSV ordering that matches that of the
+#   template CSV.  (Python 3.7+ makes this order preserving a part of the language spec, btw).
+
+from bundle_common import *
+
+import argparse
+import datetime
+import os
+import sys
+import yaml
+
+
+# --- Main ---
+
+def main():
+
+   default_pkg_name  = "advanced-cluster-management"
+   default_csv_template_pathn ="./acm-csv-template.yaml"
+
+   # Handle args:
+
+   parser = argparse.ArgumentParser()
+
+   parser.add_argument("--pkg-dir",  dest="pkg_dir_pathn", required=True)
+   parser.add_argument("--pkg-name", dest="pkg_name",      default=default_pkg_name)
+   parser.add_argument("--channel",  dest="for_channels",  required=True, action="append")
+
+   parser.add_argument("--csv-vers",  dest="csv_vers", default="x.y.z")
+   parser.add_argument("--prev-vers", dest="prev_vers")
+
+   parser.add_argument("--source-bundle-dir", dest="source_bundle_pathns", required=True, action="append")
+
+   parser.add_argument("--csv-template", dest="csv_template_pathn", default=default_csv_template_pathn)
+
+   args = parser.parse_args()
+
+   csv_template_pathn = args.csv_template_pathn
+
+   operator_name = args.pkg_name
+   pkg_name      = args.pkg_name
+   pkg_dir_pathn = args.pkg_dir_pathn
+   for_channels  = args.for_channels
+
+   csv_vers  = args.csv_vers
+   prev_vers = args.prev_vers
+
+   source_bundle_pathns = args.source_bundle_pathns
+
+
+   # And now on to the show...
+
+   csv_name  = "%s.v%s" % (operator_name, csv_vers)
+   csv_fn    = "%s.clusterserviceversion.yaml" % (csv_name)
+
+   # The package directory is the directory in which we place a version-named
+   # sub-directory for the new bundle.  Make sure the package directory exists,
+   # and then create (or empty out) a bundle directory under it.
+
+   if not os.path.exists(pkg_dir_pathn):
+      die("Output package directory doesn't exist: %s" % pkg_dir_pathn)
+   elif not os.path.isdir(pkg_dir_pathn):
+      die("Output package path exists but isn't a directory: %s" % pkg_dir_pathn)
+
+   bundle_pathn = os.path.join(pkg_dir_pathn, csv_vers)
+   create_or_empty_directory("output bundle", bundle_pathn)
+
+   csv_pathn = "%s/%s" % (bundle_pathn, csv_fn)
+
+
+   # Load or create the package manifest.
+
+   pkg_manifest_pathn = os.path.join(pkg_dir_pathn, "package.yaml")
+   pkg_manifest = load_pkg_manifest(pkg_manifest_pathn, pkg_name)
+
+
+   # Load/parse the base template for the CSV we're generating.  This template provides various
+   # boilerplate we're going to use as-is in the output CSV we're generating.
+
+   o_csv = load_manifest("CSV template", csv_template_pathn)
+
+   # Check that the specified bundle directories exist.
+   for s_bundle_pathn in source_bundle_pathns:
+      if not os.path.isdir(s_bundle_pathn):
+         die("Source bundle directory doesn't exist or isn't a directory: %s" % s_bundle_pathn)
+   #
+
+   o_spec = o_csv["spec"]
+
+   # Holds info that is accumulated over the set of source bundles:
+   m_categories        = set()
+   m_keywords          = set()
+   m_alm_examples      = dict()
+   m_owned_crds        = dict()
+   m_required_crds     = dict()
+   m_owned_api_svcs    = dict()
+   m_required_api_svcs = dict()
+   m_deployments       = dict()
+   m_cluster_perms     = dict()
+   m_ns_perms          = dict()
+
+   bundle_fns = set() # Used to ensure no dups/overlays iin file names added to buundle
+
+   # Process each of the source bundles:
+
+   first_bundle = True
+   for s_bundle_pathn in source_bundle_pathns:
+
+      if not first_bundle:
+         print("\n------------\n")
+      first_bundle = False
+
+      print("Processing bundle: %s...\n" % s_bundle_pathn)
+
+      s_owned_crds_map = dict()
+
+      # Load all bundle manifests
+
+      s_csv_fn = None
+      s_csv    = None
+      s_other_manifests = dict()
+
+      manifests = load_all_manifests(s_bundle_pathn)
+      for fn, manifest in manifests.items():
+         kind = manifest["kind"]
+         if kind == "ClusterServiceVersion":
+            if s_csv is None:
+               s_csv = manifest
+               s_csv_fn = fn
+            else:
+               die("Too many CSV manifests found in %s." % s_bundle_pathn)
+         else:
+            s_other_manifests[fn] = manifest
+
+      #--- Consume the bundle's CSV ---
+
+      # Make sure we have only one CSV.
+
+      if s_csv is None:
+         die("No CSV manifest found in %s." % s_bundle_pathn)
+
+      print("Found source CSV manifest: %s" % s_csv_fn)
+
+      s_spec = get_map(s_csv, "spec")
+      if not s_spec:
+         die("Source CSV doesn't have a (non-empty) spec.")
+
+      s_metadata = get_map(s_csv, "metadata")
+      if not s_metadata:
+         die("Source CSV doesn't have any metadata.")
+
+      s_annotations = get_map(s_metadata, "annotations")
+      if not s_annotations:
+         print("   WARN: Source CSV doesn't have any annotations.")
+
+      # Accumulate categories into the output set.
+      s_cat_str = get_scalar(s_annotations, "categories")
+      if s_cat_str is None:
+         print("   WARN: Source CSV has no categories.")
+      else:
+         # Categories are specified as a common-separated string.  Spint and accumulate.
+         accumulate_set("category", "categories", s_cat_str.split(","), m_categories)
+
+      # Accumulate CR examples (ALM-Examples) into the output set.
+      s_alm_examples_str = get_scalar(s_annotations, "alm-examples")
+      if s_alm_examples_str is None:
+         print("   WARN: Source CSV has no ALM examples.")
+      else:
+         # ALM examples contains a string representation of a YML sequence of mappings.
+         s_alm_examples = yaml.load(s_alm_examples_str, Loader=yaml_loader)
+         accumulate_keyed("ALM example", s_alm_examples, m_alm_examples, get_avk)
+
+      # Accumulate keywords into the output set.
+      s_keywords = get_seq(s_spec, "keywords")
+      accumulate_set("keyword", "keywords", s_keywords, m_keywords)
+
+      # Add owned CRds from this CSV into the list we're accumulating.  Keep track
+      # of them by GVK so we can reconsile against required CRDs later.
+      try:
+         s_crds = s_spec["customresourcedefinitions"]
+         s_owned_crds_list = s_crds["owned"]
+         accumulate_keyed("owned CRD", s_owned_crds_list, m_owned_crds, get_gvk, another_thing_map=s_owned_crds_map)
+      except KeyError:
+         print("   WARN: Source CSV specs no owned CRDs. (???)")
+         s_owned_crds = []
+
+      # Nowc collect up the required CRDs.
+      try:
+         s_crds = s_spec["customresourcedefinitions"]
+         s_required_crds = s_crds["required"]
+         accumulate_keyed("required CRD", s_required_crds, m_required_crds, get_gvk, dups_ok=True)
+      except KeyError:
+         # No warn msg as its perfectly fine for a CSV to not defined any required CRDs.
+         s_required_crds = []
+
+      # Collect up spec.install stanzas...
+
+      s_install = s_spec["install"]
+      s_install_strategy = s_install["strategy"]
+      if s_install_strategy != "deployment":
+         die("Source CSV specs unsupported install stragegy (%s)." % s_install_strategy)
+
+      s_install_spec = s_install["spec"]
+
+      # Cluster and namespace Permissions (Service Accounts):
+      try:
+         s_cluster_perms = s_install_spec["clusterPermissions"]
+         accumulate_keyed("cluster permission", s_cluster_perms, m_cluster_perms, lambda e: e["serviceAccountName"])
+      except KeyError:
+         s_cluster_perms = []
+
+      try:
+         s_ns_perms = s_install_spec["permissions"]
+         accumulate_keyed("namespace permission", s_perms, m_ns_perms, lambda e: e["serviceAccountName"])
+      except KeyError:
+         s_ns_perms = []
+
+      if not (s_cluster_perms or s_ns_perms):
+         print("   WARN: Source CSV defines neither cluster nor namespace permissions/service accounts.")
+
+      # Deployments:
+      try:
+         s_deployments = s_install_spec["deployments"]
+         accumulate_keyed("install deployment", s_deployments, m_deployments, lambda e: e["name"])
+      except KeyError:
+         print("   WARN: Source CSV specs no install deployments. (???)")
+         s_deployments = []
+
+      #--- Copy the source budnle's non-CSV manifests to the output bundle ---
+
+      print("\nHandling non-CSV manifests in the budnle")
+
+      expected_crds = set(s_owned_crds_map.keys())
+
+      for fn, manifest in s_other_manifests.items():
+
+         kind = manifest["kind"]
+         if kind == "CustomResourceDefinition":
+            crd_gvk = get_gvk_for_crd(manifest)
+
+            # Check that the CRD is expected (listed as owned in CSV) and if so, take
+            # it out of the list of expected ones not seen yet.
+            crd_is_expected = crd_gvk in expected_crds
+            if crd_is_expected:
+               expected_crds.remove(crd_gvk)
+
+            k = "CRD" if crd_is_expected else "*Unlisted* CRD"
+            print("   Copying manifest file (%s): %s" % (k, fn))
+
+         else:
+            # We have a manifest file for something other than a CRD???
+            print("***TBD???: %s in %s" % (kind, fn))
+
+         if fn not in bundle_fns:
+            copy_file(fn, s_bundle_pathn, bundle_pathn)
+            bundle_fns.add(fn)
+         else:
+            die("Duplicate mainfest filename: %s." % t_manifest_fn)
+      #
+
+      # Check that we found manifests for all CRDs owned by this source bundle
+      if expected_crds:
+         for crd_gvk in expected_crds:
+            die("No manifest found for expected CRD: %s" % crd_gvk)
+      else:
+         print("   Note: Manfests were copied for all expected CRDs.")
+
+      #
+   # End for each source-bundle
+
+   print("\n============\n")
+   print("Creating merged CSV...")
+
+
+   # --- Reconsile and generate output CSV properties ---
+
+   # Plug in simple metadata
+
+   o_metadata    = o_csv["metadata"]
+   o_annotations = o_metadata["annotations"]
+
+   created_at = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+   o_metadata["name"] = csv_name
+   o_annotations["createdAt"] = created_at
+
+   # Convert categories into a common-separated string and plug into annotations
+   o_annotations["categories"] = ','.join(sorted(list(m_categories)))
+
+   # Convert ALM examples into a sting representation and plug into annotations.
+   o_alm_examples = list(m_alm_examples.values())
+   o_alm_examples_str = yaml.dump(o_alm_examples, width=100, default_flow_style=False, sort_keys=False)
+   o_annotations["alm-examples"] = o_alm_examples_str
+
+   o_spec["version"]  = csv_vers
+
+   if prev_vers:
+      prev_csv_name = "%s.v%s" % (pkg_name, prev_vers)
+      o_spec["replaces"] = prev_csv_name
+   else:
+      try:
+         del o_spec["replaces"]
+      except KeyError:
+         pass
+
+   # Plug in the merged keyword list (no dups)
+   o_spec["keywords"] = list(sorted(m_keywords))
+
+   # Plug in reconsiled/merged CRD info...
+
+   o_crds = o_spec["customresourcedefinitions"]
+   reconsile_and_plug_in_things("CRD", o_crds, m_owned_crds, m_required_crds)
+
+   # Tidy up: If no CRD info at all, remove the spec stanza.
+   if not o_crds:
+      del o_spec["customresourcedefinitions"]
+
+
+   #-Plug in reconsiled/merged API service info...
+   o_api_svcs = o_spec["apiservicedefinitions"]
+   reconsile_and_plug_in_things("API service", o_api_svcs, m_owned_api_svcs, m_required_api_svcs)
+
+   # Tidy up: If no API service definitions info at all, remove the spec stanza.
+   if not o_api_svcs:
+      del o_spec["apiservicedefinitions"]
+
+   # Now plug in merged/editedspec.install contents...
+
+   o_install = o_spec["install"]
+   o_install["strategy"] = "deployment"  # The only strategy we currently support.
+   o_install_spec  = o_install["spec"]
+
+   print("Plugging in install permissions...")
+   plug_in_things("cluster permission",   o_install_spec, "clusterPermissions", m_cluster_perms)
+   plug_in_things("naemspace permission", o_install_spec, "permissions",        m_ns_perms)
+
+   print("Plugging in install deployments...")
+   plug_in_things("deployment",           o_install_spec, "deployments",        m_deployments, True)
+
+   # --- Write out the resutling merged CSV ---
+
+   if csv_fn not in bundle_fns:
+      print("\nWriting merged CSV mainfest: %s" % csv_fn)
+      dump_manifest("merged CSV", csv_pathn, o_csv)
+      bundle_fns.add(csv_fn)
+   else:
+      die("Duplicate manifest filename (for the CSV): %s." % csv_fn)
+
+   # --- Update the package manifest to point to the new CSV ---
+
+   print("Updating package manifest.")
+   update_pkg_manifest(pkg_manifest, for_channels, csv_name)
+   dump_manifest("package manifest", pkg_manifest_pathn, pkg_manifest)
+
+   return
+
+if __name__ == "__main__":
+   main()
+
+#-30-
+

--- a/build-scripts/bundle-gen/find-bundle-dir.py
+++ b/build-scripts/bundle-gen/find-bundle-dir.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# Given a package directory (eg. as is found in the community-operators repo),
+# find the bundle directory for the current CSV in a specified channel of a package.
+
+import os
+import yaml
+import sys
+
+yaml_loader = yaml.SafeLoader
+
+def eprint(*args, **kwargs):
+   print(*args, file=sys.stderr, **kwargs)
+
+def emsg(msg, *args):
+   eprint("Error: " + msg, *args)
+
+# --- Main ---
+
+def main():
+
+   if len(sys.argv) != 3:
+      eprint("Syntax: %s <channel_name> <package_dir>" % sys.argv[0])
+      exit(1)
+
+   selected_channel = sys.argv[1]
+   pkg_pathn        = sys.argv[2]
+
+   # The package directory should have a single yaml file
+
+   pkg_yamls = []
+   bundle_dirs = []
+   try:
+      pkg_fns = os.listdir(pkg_pathn)
+   except FileNotFoundError:
+      emsg("Package directory not found: %s." % pkg_pathn)
+      exit(1)
+   except NotADirectoryError:
+      emsg("Not a directory: %s." % pkg_pathn)
+      exit(1)
+
+   for fn in pkg_fns:
+      pathn = os.path.join(pkg_pathn, fn)
+      if os.path.isdir(pathn):
+         bundle_dirs.append(pathn)
+      elif pathn.endswith(".yaml"):
+         pkg_yamls.append(pathn)
+   #
+
+   if len(pkg_yamls) == 0:
+      emsg("Package manifest (.yaml) not found in %s." % pkg_pathn)
+      exit(1)
+   elif len(pkg_yamls) > 1:
+      emsg("More than one .yaml file found in %s." % pkg_pathn)
+      exit(1)
+
+   # Determine the current CSV for the selected channel.
+
+   with open(pkg_yamls[0], "r") as f:
+      pkg = yaml.load(f, yaml_loader)
+
+   pkg_channels = pkg["channels"]
+   cur_csv = None
+   for c in pkg_channels:
+      if c["name"] == selected_channel:
+         cur_csv = c["currentCSV"]
+         break
+   #
+   if cur_csv is None:
+      emsg("Channel %s not found in package." % selected_channel)
+      exit(1)
+
+   # Look through all of the bundle directories to find the one containing the CSV.
+   # We do so by looking at the contents of the manifests so we avoid any depnedency
+   # on directory/manifest file naming patterns.
+
+   the_bundle_dir = None
+   for bundle_pathn in bundle_dirs:
+      bundle_files = os.listdir(bundle_pathn)
+
+      found_csv = False
+      for fn in bundle_files:
+         if not fn.endswith(".yaml"):
+            continue
+         file_pathn = os.path.join(bundle_pathn, fn)
+         with open(file_pathn, "r") as f:
+            manifest = yaml.load(f, yaml_loader)
+         #
+         kind = manifest["kind"]
+         if kind == "ClusterServiceVersion":
+            found_csv = True
+            break
+      if not found_csv:
+         emsg("CSV manifest not found in bundle %s." % bundle_pathn)
+         exit(1)
+
+      csv_name = manifest["metadata"]["name"]
+      if csv_name == cur_csv:
+         the_bundle_dir = bundle_pathn
+         break
+   # end-for
+
+   if the_bundle_dir is None:
+      emsg("Bundle containing CSV %s not found." % cur_csv)
+      exit(1)
+
+   print(the_bundle_dir)
+   exit(0)
+
+if __name__ == "__main__":
+   main()
+
+#-30-
+

--- a/build-scripts/bundle-gen/gen-bound-acm-bundle.sh
+++ b/build-scripts/bundle-gen/gen-bound-acm-bundle.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#
+# Assumptions:
+#
+# - We assume this directory is located two subdirs below the top of the repo.
+#
+# Cautions:
+#
+# - Tested on Linux, not Mac.
+
+my_dir=$(dirname $(readlink -f $0))
+top_of_repo=$(readlink -f $my_dir/../..)
+
+github="git@joegpro.github.com"
+
+#--- SCAFFOLDING ---
+# TODO: Make these input args or derive from state in some way?
+new_csv_vers="1.0.0"
+prev_csv_ver="1.0.0"
+default_channel="stable-1.0"
+additional_channels="stable-v1"
+#--- END SCAFFODLING ---
+
+tmp_root="/tmp/gen-acm-bundle"
+mkdir -p "$tmp_root"
+
+tmp_dir="$tmp_root/work"
+rm -rf "$tmp_dir"
+mkdir -p "$tmp_dir"
+
+
+#--- SCAFFOLDING ---
+# TEMP: For now this is a temp spot.  Maybe it should be a place in a repo cloe that
+# we then commit the resulting bundles to for posterity?
+unbound_acm_pkg_dir="$tmp_root/operator-bundles/unbound"
+bound_acm_pkg_dir="$tmp_root/operator-bundles/bound"
+mkdir -p "$bound_acm_pkg_dir"
+#--- END SCAFFODLING ---
+
+# Ensure the specified input and output directories for the budnles exist.
+
+if [[ ! -d $unbound_acm_pkg_dir ]]; then
+   >&2 echo "Error: Input package directory $unbound_acm_pkg_dir doesn't exist."
+   >&2 echo "Aborting."
+   exit 2
+fi
+
+if [[ ! -d $bound_acm_pkg_dir ]]; then
+   >&2 echo "Error: Output package directory $bound_acm_pkg_dir doesn't exist."
+   >&2 echo "Aborting."
+   exit 2
+fi
+
+unbound_acm_bundle=$($my_dir/find-bundle-dir.py "latest" $unbound_acm_pkg_dir)
+if [[ $? -ne 0 ]]; then
+   >&2 echo "Error: Could not find source bundle directory for unbound ACM bundle."
+   >&2 echo "Aborting."
+   exit 2
+fi
+
+if [[ -n "$prev_csv_vers" ]]; then
+   prev_option="--prev-csv $prev_csv_vers"
+fi
+
+addl_channel_optons=""
+for c in $additional_channels; do
+   addl_channel_options="$additional_channel_options --additional-channel $c"
+done
+
+$my_dir/create-bound-bundle.py \
+   --pkg-name "advanced-cluster-management" --pkg-dir $bound_acm_pkg_dir \
+   --source-bundle-dir $unbound_acm_bundle \
+   --csv-vers "$new_csv_vers" $prev_option \
+   --default-channel $default_channel $addl_channel_options \
+   --image-override quay.io/hive/hive@sha256:1111 \
+   --image-override quay.io/open-cluster-management/multicluster-operators-placementrule@sha256:2222 \
+   --image-override quay.io/open-cluster-management/multicluster-operators-subscription@sha256:3333 \
+   --image-override quay.io/open-cluster-management/multicluster-operators-deployable@sha256:4444 \
+   --image-override quay.io/open-cluster-management/multicluster-operators-channel@sha256:5555 \
+   --image-override quay.io/open-cluster-management/multicluster-operators-application@sha256:6666 \
+   --image-override quay.io/open-cluster-management/multiclusterhub-operator@sha256:7878
+
+

--- a/build-scripts/bundle-gen/gen-bound-ocm-hub-bundle.sh
+++ b/build-scripts/bundle-gen/gen-bound-ocm-hub-bundle.sh
@@ -26,9 +26,8 @@ top_of_repo=$(readlink  -f $my_dir/../..)
 
 image_rgy_ns_and_repo="quay.io/open-cluster-management/multiclusterhub-operator"
 
-deploy_dir=$top_of_repo/deploy
-pkg_dir=$top_of_repo/operator-bundles/bound/open-cluster-management-hub
-csv_template=$my_dir/ocm-hub-csv-template.yaml
+unbound_pkg_dir=$top_of_repo/operator-bundles/unbound/open-cluster-management-hub
+bound_pkg_dir=$top_of_repo/operator-bundles/bound/open-cluster-management-hub
 
 csv_release="$1"
 image_tag_or_digest="$2"
@@ -38,6 +37,8 @@ if [[ -z $image_tag_or_digest ]]; then
    >&2 echo "Syntax: <csv_version> <image_tag_or_digest> [<snapshot_id>]"
    exit 1
 fi
+
+source_bundle_dir=$($my_dir/find-bundle-dir.py "latest" $unbound_pkg_dir)
 
 # CSV release identifier is assumed to be in x.y.z format.
 
@@ -121,10 +122,11 @@ channels="$channels --other-channel $snapshot_channel"
 channels="$channels --default-channel $default_channel"
 
 if [[ ! -d $pkg_dir ]]; then
-   mkdir -p $pkg_dir
+   mkdir -p $bound_pkg_dir
 fi
 
-$my_dir/create-ocm-hub-bundle.py \
-   --deploy-dir $deploy_dir --pkg-dir $pkg_dir --csv-template $csv_template \
+$my_dir/create-bound-bundle.py \
+   --pkg-name "open-cluster-management-hub" \
+   --source-bundle-dir $source_bundle_dir --pkg-dir $bound_pkg_dir \
    --csv-vers $csv_vers $bundle_format $channels $operator_image_override
 

--- a/build-scripts/bundle-gen/gen-unbound-acm-bundle.sh
+++ b/build-scripts/bundle-gen/gen-unbound-acm-bundle.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+#
+# Assumptions:
+#
+# - We assume this directory is located two subdirs below the top of the repo.
+#
+# Cautions:
+#
+# - Tested on Linux, not Mac.
+
+my_dir=$(dirname $(readlink -f $0))
+top_of_repo=$(readlink -f $my_dir/../..)
+
+github="git@joegpro.github.com"
+
+#--- SCAFFOLDING ---
+# TODO: Make these input args or derive in some way???
+new_csv_vers="1.0.0"
+#prev_csv_ver="1.0.0"
+#--- END SCAFFODLING ---
+
+tmp_root="/tmp/gen-acm-bundle"
+mkdir -p "$tmp_root"
+
+tmp_dir="$tmp_root/work"
+rm -rf "$tmp_dir"
+mkdir -p "$tmp_dir"
+
+source_bundles="$tmp_dir/source-bundles"
+mkdir -p "$source_bundles"
+
+
+#--- SCAFFOLDING ---
+# TEMP: For now this is a temp spot.  Maybe it should be a place in a repo clone
+# and then committed to preserve the generated bundles to for posterity?
+unbound_acm_pkg_dir="$tmp_root/operator-bundles/unbound"
+rm -rf $unbound_acm_pkg_dir
+mkdir -p $unbound_acm_pkg_dir
+#--- END SCAFFODLING ---
+
+
+# To generate the composite ACM bundle, we need some source bundles as input.
+#
+# For Hive, we generate the source bundle using the Hive operator repo and
+# a generation script found there.
+#
+# For the OCM hub, we use a source bundle found within the operator repo.
+#
+# For the application subscription operator, for the moment we grab the source bundle
+# from what is posted as a comomunity operato.  But in order to syncronize the
+# bundle with the code snapshot being used for downstream build, we should change this
+# to either (a) generate usng a repo-provided script, or (b) pick up an already
+# generated bundle from within the repo.
+
+clone_spot="$tmp_dir/repo-clones"
+
+# App Sub:
+
+community_repo_spot="$clone_spot/community-operators"
+git clone "$github:operator-framework/community-operators.git" "$community_repo_spot"
+app_sub_pkg="$community_repo_spot/community-operators/multicluster-operators-subscription"
+app_sub_channel="alpha"
+
+app_sub_bundle=$($my_dir/find-bundle-dir.py $app_sub_channel $app_sub_pkg)
+if [[ $? -ne 0 ]]; then
+   >&2 echo "Error: Could not find source bundle directory for Multicluster Subscription."
+   >&2 echo "Aborting."
+   exit 2
+fi
+app_sub_bundle_spot="$source_bundles/app-sub"
+ln -s "$app_sub_bundle" $app_sub_bundle_spot
+
+# Hive:
+
+hive_repo_spot="$clone_spot/hive"
+hive_stable_release_branch="ocm-4.4.0"
+git clone -b "$hive_stable_release_branch" "$github:openshift/hive.git" $hive_repo_spot
+
+hive_bundle_work=$tmp_dir/hive-bundle
+mkdir -p "$hive_bundle_work"
+
+echo "Generating Hive source bundle."
+
+# Seems the generation script assumes CWD is top of repo.
+
+save_cwd=$PWD
+cd $hive_repo_spot
+hive_image_placeholder="quay.io/openshift-hive/hive:dont-care"
+python2.7 ./hack/generate-operator-bundle.py $hive_bundle_work dont-care 0 "-none" "$hive_image_placeholder"
+if [[ $? -ne 0 ]]; then
+   >&2 echo "Error: Could not generate Hive source bundle."
+   >&2 echo "Aborting."
+   exit 2
+fi
+cd $save_cwd
+
+hive_bundle_spot="$source_bundles/hive"
+ln -s "$hive_bundle_work/0.1.0-sha-none" $hive_bundle_spot
+
+# OCM Hub:
+
+hub_repo_spot=$top_of_repo
+hub_pkg="$hub_repo_spot/operator-bundles/unbound/open-cluster-management-hub"
+hub_channel="latest"
+
+hub_bundle=$($my_dir/find-bundle-dir.py $hub_channel $hub_pkg)
+if [[ $? -ne 0 ]]; then
+   >&2 echo "Error: Could not find source bundle directory for OCM Hub."
+   >&2 echo "Aborting."
+   exit 2
+fi
+
+hub_bundle_spot="$source_bundles/ocm-hub"
+ln -s "$hub_bundle" "$hub_bundle_spot"
+
+
+# Generate the unbound composite bundle, which will be the source for producing
+# the bound one.
+
+$my_dir/create-unbound-acm-bundle.py \
+   --pkg-name "advanced-cluster-management" --pkg-dir $unbound_acm_pkg_dir \
+   --csv-vers "x.y.z" --channel "latest" \
+   --csv-template $my_dir/acm-csv-template.yaml \
+   --source-bundle-dir $hub_bundle_spot \
+   --source-bundle-dir $hive_bundle_spot \
+   --source-bundle-dir $app_sub_bundle_spot
+

--- a/build-scripts/bundle-gen/gen-unbound-ocm-hub-bundle.sh
+++ b/build-scripts/bundle-gen/gen-unbound-ocm-hub-bundle.sh
@@ -38,23 +38,20 @@ deploy_dir=$top_of_repo/deploy
 pkg_dir=$top_of_repo/operator-bundles/unbound/open-cluster-management-hub
 csv_template=$my_dir/ocm-hub-csv-template.yaml
 
-csv_release="$1"
+csv_vers="$1"
 
-if [[ -z $csv_release ]]; then
+if [[ -z $csv_vers ]]; then
    >&2 echo "Syntax: <csv_version>"
    exit 1
 fi
 
-csv_vers="$csv_release"
-operator_image_override=""
-bundle_format=""
-channels="--default-channel latest"
+channel="latest"
 
 if [[ ! -d $pkg_dir ]]; then
    mkdir -p $pkg_dir
 fi
 
-$my_dir/create-ocm-hub-bundle.py \
+$my_dir/create-unbound-ocm-hub-bundle.py \
    --deploy-dir $deploy_dir --pkg-dir $pkg_dir --csv-template $csv_template \
-   --csv-vers $csv_vers $bundle_format $channels $operator_image_override
+   --csv-vers $csv_vers --channel $channel
 


### PR DESCRIPTION
This PR adds Python scripts to generate the composite ACM "product" operator bundle as a merging of the individual "project/community" operator bundles for the OCM Hub, Hive, and App Sub operators.

The driving Bash scripts for doing this are still draft/somewhat scaffolding since details about manifests and such are still being worked out.