### PR TITLE
Specify resource requests and limits in deployment file

### DIFF
--- a/build/_output/olm/multiclusterhub-operator/1.0.0/multiclusterhub-operator.v1.0.0.clusterserviceversion.yaml
+++ b/build/_output/olm/multiclusterhub-operator/1.0.0/multiclusterhub-operator.v1.0.0.clusterserviceversion.yaml
@@ -249,11 +249,11 @@ spec:
                 imagePullPolicy: Always
                 name: multiclusterhub-operator
                 resources:
-                  requests:
-                    memory: 256Mi
-                    cpu: 100m
                   limits:
-                    memory: 2048Mi
+                    memory: 2Gi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
               imagePullSecrets:
               - name: multiclusterhub-operator-pull-secret
               serviceAccountName: multiclusterhub-operator

--- a/build/_output/olm/multiclusterhub.csv.yaml
+++ b/build/_output/olm/multiclusterhub.csv.yaml
@@ -248,11 +248,11 @@
                   imagePullPolicy: Always
                   name: multiclusterhub-operator
                   resources:
-                    requests:
-                      memory: 256Mi
-                      cpu: 100m
                     limits:
-                      memory: 2048Mi
+                      memory: 2Gi
+                    requests:
+                      cpu: 100m
+                      memory: 256Mi
                 imagePullSecrets:
                 - name: multiclusterhub-operator-pull-secret
                 serviceAccountName: multiclusterhub-operator

--- a/build/_output/olm/multiclusterhub.resources.yaml
+++ b/build/_output/olm/multiclusterhub.resources.yaml
@@ -584,11 +584,11 @@ data:
                       imagePullPolicy: Always
                       name: multiclusterhub-operator
                       resources:
-                        requests:
-                          memory: 256Mi
-                          cpu: 100m
                         limits:
-                          memory: 2048Mi
+                          memory: 2Gi
+                        requests:
+                          cpu: 100m
+                          memory: 256Mi
                     imagePullSecrets:
                     - name: multiclusterhub-operator-pull-secret
                     serviceAccountName: multiclusterhub-operator

--- a/build/_output/olm/operator.yaml
+++ b/build/_output/olm/operator.yaml
@@ -21,6 +21,12 @@ spec:
           imagePullPolicy: Always
           command:
           - multiclusterhub-operator
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 2048Mi
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/common/scripts/olm_catalog.sh
+++ b/common/scripts/olm_catalog.sh
@@ -102,16 +102,8 @@ if [ "$(uname)" = "Darwin" ]; then
   sed -i -e "/email:/a\\
   \ \ \ \ name: install\\
   " "${CSVFILE}"
-
-  sed -i -e "/deployments:/,/maintainers/ s/resources: {}/resources:\\
-                  requests:\\
-                    memory: 256Mi\\
-                    cpu: 100m\\
-                  limits:\\
-                    memory: 2048Mi/" "${CSVFILE}"
 else
   sed -i -e "/email:/a\\    name: install\\" "${CSVFILE}"
-  sed -i -e "/deployments:/,/maintainers/ s/resources: {}/resources:\n                  requests:\n                    memory: 256Mi\n                    cpu: 100m\n                  limits:\n                    memory: 2048Mi/" "${CSVFILE}"
 fi
 sed -i -e "/keywords/{n;s/.*/    - operator/;}" "${CSVFILE}" 
 sed -i -e "s/mediatype:/  mediatype:/" "${CSVFILE}"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,6 +21,12 @@ spec:
           imagePullPolicy: Always
           command:
           - multiclusterhub-operator
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 2048Mi
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
Currently we set resource requirements by generating files and then patching those generated files with `sed` commands. This places the requests and limits in the deployment file so we don't need to edit the generated files after the fact. 