### PR TITLE
Include lastTransitionTime in deployment conditions at all times

### DIFF
--- a/pkg/controller/multiclusterhub/status.go
+++ b/pkg/controller/multiclusterhub/status.go
@@ -226,15 +226,15 @@ func mapDeployment(ds *appsv1.Deployment) operatorsv1.StatusCondition {
 
 	dcs := latestDeployCondition(ds.Status.Conditions)
 	ret := operatorsv1.StatusCondition{
-		Type:           string(dcs.Type),
-		Status:         metav1.ConditionStatus(string(dcs.Status)),
-		LastUpdateTime: dcs.LastUpdateTime,
-		Reason:         dcs.Reason,
-		Message:        dcs.Message,
+		Type:               string(dcs.Type),
+		Status:             metav1.ConditionStatus(string(dcs.Status)),
+		LastUpdateTime:     dcs.LastUpdateTime,
+		LastTransitionTime: dcs.LastTransitionTime,
+		Reason:             dcs.Reason,
+		Message:            dcs.Message,
 	}
 	if successfulDeploy(ds) {
 		ret.Message = ""
-		ret.LastTransitionTime = dcs.LastTransitionTime
 	}
 
 	return ret
@@ -305,35 +305,6 @@ func isErrorType(cr string) bool {
 		cr == string(subrelv1.ReasonReconcileError) ||
 		cr == string(subrelv1.ReasonUninstallError)
 }
-
-// type byTransitionTime []operatorsv1.StatusCondition
-
-// func (a byTransitionTime) Len() int      { return len(a) }
-// func (a byTransitionTime) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-// func (a byTransitionTime) Less(i, j int) bool {
-// 	return a[i].LastTransitionTime.Time.Before(a[j].LastTransitionTime.Time)
-// }
-
-// // Adds the statusCondition to a multiclusterhub
-// func AddCondition(m *operatorsv1.MultiClusterHub, sc operatorsv1.StatusCondition) {
-// 	log.Info("Adding condition", "Condition", sc.Reason)
-// 	for i, x := range m.Status.HubConditions {
-// 		if x.Reason == sc.Reason && x.Status == sc.Status {
-// 			ltt := x.LastTransitionTime
-// 			m.Status.HubConditions[i] = sc
-// 			m.Status.HubConditions[i].LastTransitionTime = ltt
-// 			return
-// 		}
-// 	}
-// 	m.Status.HubConditions = append(m.Status.HubConditions, sc)
-
-// 	// Trim conditions
-// 	sort.Sort(sort.Reverse(byTransitionTime(m.Status.HubConditions)))
-// 	if len(m.Status.HubConditions) > 2 {
-// 		m.Status.HubConditions = m.Status.HubConditions[:1]
-// 	}
-
-// }
 
 // NewHubCondition creates a new hub condition.
 func NewHubCondition(condType operatorsv1.HubConditionType, status v1.ConditionStatus, reason, message string) *operatorsv1.HubCondition {


### PR DESCRIPTION
Removing the lastTransitionTime may cause the the json to marshal it to null, causing parsing issues.