### PR TITLE
Revert "temperarily disable bma controller (#394)"

### DIFF
--- a/pkg/foundation/ocm_controller.go
+++ b/pkg/foundation/ocm_controller.go
@@ -56,7 +56,6 @@ func OCMControllerDeployment(m *operatorsv1.MultiClusterHub, overrides map[strin
 						Args: []string{
 							"/controller",
 							"--agent-cafile=/var/run/klusterlet/ca.crt",
-							"--enable-inventory=false",
 						},
 						LivenessProbe: &v1.Probe{
 							Handler: v1.Handler{


### PR DESCRIPTION
This reverts commit 6214ea671d232654ef95fe755c5f1fe98c992413.

The issue https://github.com/open-cluster-management/backlog/issues/5269 has been fixed in the PR https://github.com/open-cluster-management/multicloud-operators-foundation/pull/243 .

so need to revert #394 .