### PR TITLE
Revert "Disable applicationmanager (#395)"

### DIFF
--- a/pkg/controller/multiclusterhub/managedcluster.go
+++ b/pkg/controller/multiclusterhub/managedcluster.go
@@ -74,7 +74,7 @@ func getKlusterletAddonConfig() *unstructured.Unstructured {
 				"clusterName":      KlusterletAddonConfigName,
 				"clusterNamespace": ManagedClusterName,
 				"applicationManager": map[string]interface{}{
-					"enabled": false,
+					"enabled": true,
 				},
 				"clusterLabels": map[string]interface{}{
 					"cloud":  "auto-detect",


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/4789
In this issue, application-manager will be able to work on hub, so we will re-enable it.

This reverts commit 069242e1f2dc0ebe88534d838cacc1824f000c95.