### PR TITLE
MCH status quick view

### DIFF
--- a/deploy/crds/operator.open-cluster-management.io_multiclusterhubs_crd.yaml
+++ b/deploy/crds/operator.open-cluster-management.io_multiclusterhubs_crd.yaml
@@ -3,6 +3,14 @@ kind: CustomResourceDefinition
 metadata:
   name: multiclusterhubs.operator.open-cluster-management.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The overall status of the multiclusterhub
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: operator.open-cluster-management.io
   names:
     kind: MultiClusterHub

--- a/deploy/olm-catalog/multiclusterhub-operator/manifests/operator.open-cluster-management.io_multiclusterhubs_crd.yaml
+++ b/deploy/olm-catalog/multiclusterhub-operator/manifests/operator.open-cluster-management.io_multiclusterhubs_crd.yaml
@@ -3,6 +3,14 @@ kind: CustomResourceDefinition
 metadata:
   name: multiclusterhubs.operator.open-cluster-management.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: The overall status of the multiclusterhub
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: operator.open-cluster-management.io
   names:
     kind: MultiClusterHub

--- a/pkg/apis/operator/v1/multiclusterhub_types.go
+++ b/pkg/apis/operator/v1/multiclusterhub_types.go
@@ -296,6 +296,8 @@ type HubCondition struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=multiclusterhubs,scope=Namespaced,shortName=mch
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="MultiClusterHub"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="The overall status of the multiclusterhub"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type MultiClusterHub struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Adds a printer column to show status of mch on a get via kubectl. Now status can be quickly checked without looking through full yaml output.

```
kubectl get mch                                                                                                                  
NAME              STATUS       AGE
multiclusterhub   Installing   70m
```
In the case where status is not set (which should be never) the column is just empty
```
NAME              STATUS   AGE
multiclusterhub            11s
```