### PR TITLE
Don't push a change to the bundle image into the pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,10 +92,6 @@ jobs:
           make 
           make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
           rm -rf pipeline
-          echo "Waiting 60s before publishing bundle image..." && sleep 60
-          COMPONENT_NAME=multiclusterhub-operator-bundle
-          make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}
-          rm -rf pipeline
-          echo "Waiting 60s before publishing bundle image..." && sleep 60
+          echo "Waiting 60s before publishing test image..." && sleep 60
           COMPONENT_NAME=multiclusterhub-operator-tests
           make pipeline-manifest/update PIPELINE_MANIFEST_COMPONENT_SHA256=${TRAVIS_COMMIT} PIPELINE_MANIFEST_COMPONENT_REPO=${TRAVIS_REPO_SLUG} PIPELINE_MANIFEST_BRANCH=${TRAVIS_BRANCH}


### PR DESCRIPTION
We have removed `multiclusterhub-operator-bundle` from the manifest - please don't push it back in.