### PR TITLE
Add MCH param. to disableUpdateClusterImageSets

### DIFF
--- a/deploy/crds/operator.open-cluster-management.io_multiclusterhubs_crd.yaml
+++ b/deploy/crds/operator.open-cluster-management.io_multiclusterhubs_crd.yaml
@@ -54,6 +54,9 @@ spec:
               description: Disable automatic import of the hub cluster as a managed
                 cluster
               type: boolean
+            disableUpdateClusterImageSets:
+              description: Disable automatic update of ClusterImageSets
+              type: boolean
             hive:
               description: Overrides for the default HiveConfig spec
               properties:

--- a/deploy/olm-catalog/multiclusterhub-operator/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/multiclusterhub-operator/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -54,6 +54,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:booleanSwitch
+      - description: Disable automatic update of ClusterImageSets
+        displayName: Disable Update ClusterImageSets
+        path: disableUpdateClusterImageSets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:booleanSwitch
       - description: Overrides for the default HiveConfig spec
         displayName: Hive Config
         path: hive

--- a/docs/functional-tests-explained.md
+++ b/docs/functional-tests-explained.md
@@ -49,7 +49,10 @@ make ft-downstream-install
 
 Running the uninstall composite functional test will first attempt to remove the MCH CR. After the CR has been validated as removed, the subscriptions will and related resources will be removed.
 
-```
+```bash
+# If you want all install tests, export full_test_suite
+export full_test_suite=true
+
 make ft-downstream-uninstall
 ```
 

--- a/pkg/apis/operator/v1/multiclusterhub_types.go
+++ b/pkg/apis/operator/v1/multiclusterhub_types.go
@@ -82,6 +82,13 @@ type MultiClusterHubSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Disable Hub Self Management"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:io.kubernetes:booleanSwitch"
 	DisableHubSelfManagement bool `json:"disableHubSelfManagement,omitempty"`
+
+	// Disable automatic update of ClusterImageSets
+	// +optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Disable Update ClusterImageSets"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:io.kubernetes:booleanSwitch"
+	DisableUpdateClusterImageSets bool `json:"disableUpdateClusterImageSets,omitempty"`
 }
 
 // Overrides provides developer overrides for MCH installation

--- a/pkg/subscription/console.go
+++ b/pkg/subscription/console.go
@@ -27,6 +27,9 @@ func Console(m *operatorsv1.MultiClusterHub, overrides map[string]string, ingres
 				"imageOverrides": overrides,
 				"pullPolicy":     utils.GetImagePullPolicy(m),
 			},
+			"clusterImageSets": map[string]interface{}{
+				"subscriptionPause": utils.GetDisableClusterImageSets(m),
+			},
 		},
 	}
 	setCustomCA(m, sub)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -215,3 +215,11 @@ func TrackedNamespaces(m *operatorsv1.MultiClusterHub) []string {
 	}
 	return trackedNamespaces
 }
+
+// GetDisableClusterImageSets returns true or false for whether auto update for clusterImageSets should be disabled
+func GetDisableClusterImageSets(m *operatorsv1.MultiClusterHub) string {
+	if m.Spec.DisableUpdateClusterImageSets {
+		return "true"
+	}
+	return "false"
+}

--- a/test/multiclusterhub_install_test/multiclusterhub_test.go
+++ b/test/multiclusterhub_install_test/multiclusterhub_test.go
@@ -193,6 +193,39 @@ func FullInstallTestSuite() {
 
 	})
 
+	It("- If `spec.disableUpdateClusterImageSets` controls the automatic updates of clusterImageSets", func() {
+		By("- Verfiying default ")
+		utils.CreateDefaultMCH()
+		err := utils.ValidateMCH()
+		Expect(err).To(BeNil())
+
+		// Test initial case with no setting, is equivalent to disableUpdateClusterImageSets: false
+		err = utils.ValidateClusterImageSetsSubscriptionPause("false")
+		Expect(err).To(BeNil())
+
+		// Set the disableUpdateCluterImageSets: true
+		By("- Setting `spec.disableUpdateClusterImageSets` to true to disable automatic updates of clusterImageSets")
+		utils.ToggleDisableUpdateClusterImageSets(true)
+
+		Eventually(func() error {
+			if err := utils.ValidateClusterImageSetsSubscriptionPause("true"); err != nil {
+				return fmt.Errorf("resources still exist")
+			}
+			return nil
+		}, utils.GetWaitInMinutes()*60, 1).Should(BeNil())
+
+		// Set the disableUpdateCluterImageSets: false
+		By("- Setting `spec.disableUpdateClusterImageSets` to false to enable automatic updates of clusterImageSets")
+		utils.ToggleDisableUpdateClusterImageSets(false)
+
+		Eventually(func() error {
+			if err := utils.ValidateClusterImageSetsSubscriptionPause("false"); err != nil {
+				return fmt.Errorf("resources still exist")
+			}
+			return nil
+		}, utils.GetWaitInMinutes()*60, 1).Should(BeNil())
+	})
+
 	It("- Delete ManagedCluster before it is joined/available", func() {
 		By("- Verifying default install has local-cluster resources")
 		utils.CreateDefaultMCH()


### PR DESCRIPTION
This is to allow the subscription that auto-populates ClusterImageSets to be disabled.

User_Story: https://github.com/open-cluster-management/backlog/issues/6971