### PR TITLE
Update ensureSubscriptionOperatorIsRunning

### DIFF
--- a/pkg/controller/multiclusterhub/common.go
+++ b/pkg/controller/multiclusterhub/common.go
@@ -591,8 +591,8 @@ func (r *ReconcileMultiClusterHub) ensureSubscriptionOperatorIsRunning(mch *oper
 
 	selfDeployment, exists := getDeploymentByName(allDeps, utils.MCHOperatorName)
 	if !exists {
-		err := fmt.Errorf("MCH operator deployment not found")
-		return &reconcile.Result{}, err
+		// Deployment doesn't exist so this is either being run locally or with unit tests
+		return nil, nil
 	}
 
 	// skip check if not deployed by OLM

--- a/pkg/controller/multiclusterhub/common_test.go
+++ b/pkg/controller/multiclusterhub/common_test.go
@@ -920,11 +920,11 @@ func TestReconcileMultiClusterHub_ensureSubscriptionOperatorIsRunning(t *testing
 			wantErr:    nil,
 		},
 		{
-			name:       "MCH operator is missing",
+			name:       "Not running MCH operator in deployment",
 			mch:        full_mch,
 			allDeps:    []*appsv1.Deployment{subOperatorOld},
-			wantResult: &reconcile.Result{RequeueAfter: time.Second * 10},
-			wantErr:    fmt.Errorf("MCH operator deployment not found"),
+			wantResult: nil,
+			wantErr:    nil,
 		},
 		{
 			name:       "Subscription operator is missing",


### PR DESCRIPTION
The reconciler wasn't succeeding in unit tests because the `ensureSubscriptionOperatorIsRunning` function checks for the multiclusterhub-operator deployment, which wouldn't exist. Updated so it skips the check when the deployment doesn't exist, which would be the case in unit testing and if running the operator locally.