### PR TITLE
 made search crds version as v1alpha1

### DIFF
--- a/crds/search.open-cluster-management.io_searchcustomizations.yaml
+++ b/crds/search.open-cluster-management.io_searchcustomizations.yaml
@@ -69,9 +69,9 @@ spec:
           - storageSize
           type: object
       type: object
-  version: v1
+  version: v1alpha1
   versions:
-  - name: v1
+  - name: v1alpha1
     served: true
     storage: true
 status:

--- a/crds/search.open-cluster-management.io_searchoperators.yaml
+++ b/crds/search.open-cluster-management.io_searchoperators.yaml
@@ -107,9 +107,9 @@ spec:
           - persistence
           type: object
       type: object
-  version: v1
+  version: v1alpha1
   versions:
-  - name: v1
+  - name: v1alpha1
     served: true
     storage: true
 status:


### PR DESCRIPTION
@JakobGray This change has to go along with this PR https://github.com/open-cluster-management/search-operator/pull/37
We are changing the CRD version to v1alpha1