### PR TITLE
Clone imagepullsecret from MCH namspace to MCE

### DIFF
--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -46,7 +46,9 @@ func MultiClusterEngine(m *operatorsv1.MultiClusterHub) *mcev1alpha1.MultiCluste
 		ObjectMeta: metav1.ObjectMeta{
 			Name: MulticlusterengineName,
 		},
-		Spec: mcev1alpha1.MultiClusterEngineSpec{},
+		Spec: mcev1alpha1.MultiClusterEngineSpec{
+			ImagePullSecret: m.Spec.ImagePullSecret,
+		},
 	}
 	return mce
 }

--- a/test/function_tests/multiclusterhub_install_test/multiclusterhub_test.go
+++ b/test/function_tests/multiclusterhub_install_test/multiclusterhub_test.go
@@ -163,6 +163,28 @@ func FullInstallTestSuite() {
 
 	})
 
+	It("Test MCE propagation", func() {
+		By("- When creating the MCH, ensure that fields are applied to the owned MCE")
+
+		utils.CreateMCHNotManaged()
+		err := utils.ValidateMCH()
+		Expect(err).To(BeNil())
+
+		By("- inspecting MCE spec")
+		k8sClient := utils.DynamicKubeClient.Resource(utils.GVRMultiClusterEngine)
+		mce := &unstructured.Unstructured{}
+		mce, err = k8sClient.Get(context.TODO(), "multiclusterengine", metav1.GetOptions{})
+		Expect(err).To(BeNil())
+
+		pullSecret := mce.Object["spec"].(map[string]interface{})["imagePullSecret"]
+		Expect(pullSecret).To(BeEquivalentTo("multiclusterhub-operator-pull-secret"))
+
+		By("- checking imagepullsecret clone created")
+		_, err = utils.KubeClient.CoreV1().Secrets("multicluster-engine").Get(context.TODO(), "multiclusterhub-operator-pull-secret", metav1.GetOptions{})
+		Expect(err).To(BeNil())
+
+	})
+
 	It("Testing Image Overrides Configmap", func() {
 		By("- If configmap is manually overwitten, ensure MCH Operator will overwrite")
 


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/18902

If the MCH sets an imagePullSecret it is copied to the MCE namespace and set in the MCE spec. If the MCH imagePullSecret is then removed, it is also removed from MCE spec and deleted from the MCE namespace.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>