### PR TITLE
removed deprecated mch specs from MultiClusterHub overview in UI

### DIFF
--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -48,7 +48,7 @@ type MultiClusterHubSpec struct {
 	AvailabilityConfig AvailabilityType `json:"availabilityConfig,omitempty"`
 
 	// (Deprecated) Install cert-manager into its own namespace
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Separate Certificate Management",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Separate Certificate Management",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +optional
 	SeparateCertificateManagement bool `json:"separateCertificateManagement"`
 
@@ -59,7 +59,7 @@ type MultiClusterHubSpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// (Deprecated) Overrides for the default HiveConfig spec
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hive Config",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hive Config",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Hive *HiveConfigSpec `json:"hive,omitempty"`
 
 	// Configuration options for ingress management
@@ -83,11 +83,11 @@ type MultiClusterHubSpec struct {
 	DisableUpdateClusterImageSets bool `json:"disableUpdateClusterImageSets,omitempty"`
 
 	// (Deprecated) Enable cluster proxy addon
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Cluster Proxy Addon",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Cluster Proxy Addon",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	EnableClusterProxyAddon bool `json:"enableClusterProxyAddon,omitempty"`
 
 	// (Deprecated) Enable cluster backup
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Cluster Backup",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Cluster Backup",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +optional
 	EnableClusterBackup bool `json:"enableClusterBackup"`
 }

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -65,19 +65,17 @@ spec:
         displayName: Enable Cluster Backup
         path: enableClusterBackup
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: (Deprecated) Enable cluster proxy addon
         displayName: Enable Cluster Proxy Addon
         path: enableClusterProxyAddon
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: (Deprecated) Overrides for the default HiveConfig spec
         displayName: Hive Config
         path: hive
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Override pull secret for accessing MultiClusterHub operand and
           endpoint images
         displayName: Image Pull Secret
@@ -104,8 +102,7 @@ spec:
         displayName: Separate Certificate Management
         path: separateCertificateManagement
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1
   description: 'The Open Cluster Management Hub operator installs and maintains an
     instance of the OCM hub, a central management console for managing OpenShift and

--- a/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
@@ -52,19 +52,17 @@ spec:
         displayName: Enable Cluster Backup
         path: enableClusterBackup
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: (Deprecated) Enable cluster proxy addon
         displayName: Enable Cluster Proxy Addon
         path: enableClusterProxyAddon
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: (Deprecated) Overrides for the default HiveConfig spec
         displayName: Hive Config
         path: hive
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Override pull secret for accessing MultiClusterHub operand and
           endpoint images
         displayName: Image Pull Secret
@@ -91,8 +89,7 @@ spec:
         displayName: Separate Certificate Management
         path: separateCertificateManagement
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       version: v1
   description: 'The Open Cluster Management Hub operator installs and maintains an
     instance of the OCM hub, a central management console for managing OpenShift and


### PR DESCRIPTION
Signed-off-by: Erin Murphy <erinmurp@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/21839