### PR TITLE
add correct type for mcePullSecret

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -643,6 +643,7 @@ func (r *MultiClusterHubReconciler) ensurePullSecret(m *operatorv1.MultiClusterH
 			Labels:    pullSecret.Labels,
 		},
 		Data: pullSecret.Data,
+		Type: corev1.SecretTypeDockerConfigJson,
 	}
 	mceSecret.SetName(m.Spec.ImagePullSecret)
 	mceSecret.SetNamespace(newNS)


### PR DESCRIPTION
currently the pull secret replicated to the MCE namespace is of type `Opaque` which is the incorrect type for a pull secret is `kubernetes.io/dockerconfigjson`

corev1 documentation reference https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/core
```
// SecretTypeDockerConfigJSON contains a dockercfg file that follows the same format rules as ~/.docker/config.json
//
// Required fields:
// - Secret.Data[".dockerconfigjson"] - a serialized ~/.docker/config.json file
[SecretType](https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/core#SecretType)DockerConfigJSON SecretType = "kubernetes.io/dockerconfigjson"
```

NOTE: this field is immutable therefore if upgrade is required additional code maybe need to be added. It maybe easier to fix it now where previous ACM does not depend on MCE than in a later release.

currently this is causing failure in deployment of managed-serviceaccount controller due to type validation in 
https://github.com/open-cluster-management-io/managed-serviceaccount/blob/b3c5e6cdd3b7d394924a005fb034170cacc921f6/cmd/manager/main.go#L161-L164

Signed-off-by: Hao Liu <haoli@redhat.com>