### PR TITLE
increase the mem limit to fix the mch-operator oom in 2k clusters

### DIFF
--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -578,7 +578,7 @@ spec:
                 resources:
                   limits:
                     cpu: 100m
-                    memory: 2Gi
+                    memory: 4Gi
                   requests:
                     cpu: 100m
                     memory: 256Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,7 +60,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 2048Mi
+            memory: 4Gi
           requests:
             memory: 256Mi
             cpu: 100m


### PR DESCRIPTION
fix issue: https://github.com/stolostron/backlog/issues/21711
mimic change https://github.com/stolostron/backplane-operator/pull/224

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>