### PR TITLE
[release-2.5] Remove setCustomCA call to avoid type assertion on nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ build/_output/*
 *.swp
 *.swo
 *~
+
+.vscode/*

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -1,8 +1,7 @@
 FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
 
-RUN go get github.com/onsi/ginkgo/ginkgo
-RUN go get github.com/onsi/gomega/...
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN go install github.com/onsi/ginkgo/ginkgo@latest
+RUN go install github.com/mikefarah/yq/v3@latest
 
 USER root
 

--- a/pkg/subscription/cluster_backup.go
+++ b/pkg/subscription/cluster_backup.go
@@ -43,7 +43,6 @@ func OldClusterBackup(m *operatorsv1.MultiClusterHub) *unstructured.Unstructured
 		Name:      "cluster-backup-chart",
 		Namespace: m.Namespace,
 	}
-	setCustomCA(m, sub)
 
 	return newSubscription(m, sub)
 }


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/24780

Calling setCustomCA on a subscription without overrides causes a panic
because the overrides field is nil.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>