### PR TITLE
Render cluster-lifecycle chart directly

### DIFF
--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -535,6 +535,18 @@ var _ = Describe("MultiClusterHub controller", func() {
 			result, err = reconciler.ensureNoSearchV2(ctx, mch, testImages)
 			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).To(BeNil())
+
+			By("Ensuring CLC")
+
+			result, err = reconciler.ensureCLC(ctx, mch, testImages)
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).To(BeNil())
+
+			By("Ensuring No CLC")
+
+			result, err = reconciler.ensureNoCLC(ctx, mch, testImages)
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).To(BeNil())
 		})
 	})
 

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -92,7 +92,6 @@ var (
 
 	uninstallRenderList = func(m *operatorsv1.MultiClusterHub) []*unstructured.Unstructured {
 		removals := []*unstructured.Unstructured{
-
 			newUnstructured(
 				types.NamespacedName{Name: "policyreport-sub", Namespace: m.Namespace},
 				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
@@ -103,6 +102,10 @@ var (
 			),
 			newUnstructured(
 				types.NamespacedName{Name: "search-prod-sub", Namespace: m.Namespace},
+				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
+			),
+			newUnstructured(
+				types.NamespacedName{Name: "cluster-lifecycle-sub", Namespace: m.Namespace},
 				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
 			),
 		}

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -31,10 +31,11 @@ type Values struct {
 }
 
 type Global struct {
-	ImageOverrides map[string]string `json:"imageOverrides" structs:"imageOverrides"`
-	PullPolicy     string            `json:"pullPolicy" structs:"pullPolicy"`
-	PullSecret     string            `json:"pullSecret" structs:"pullSecret"`
-	Namespace      string            `json:"namespace" structs:"namespace"`
+	ImageOverrides  map[string]string `json:"imageOverrides" structs:"imageOverrides"`
+	PullPolicy      string            `json:"pullPolicy" structs:"pullPolicy"`
+	PullSecret      string            `json:"pullSecret" structs:"pullSecret"`
+	Namespace       string            `json:"namespace" structs:"namespace"`
+	ImageRepository string            `json:"imageRepository" structs:"namespace"`
 }
 
 type HubConfig struct {
@@ -285,6 +286,8 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 	values.Global.Namespace = mch.Namespace
 
 	values.Global.PullSecret = mch.Spec.ImagePullSecret
+
+	values.Global.ImageRepository = utils.GetImageRepository(mch)
 
 	values.HubConfig.ReplicaCount = utils.DefaultReplicaCount(mch)
 

--- a/pkg/templates/charts/toggle/cluster-lifecycle/Chart.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/Chart.yaml
@@ -1,0 +1,25 @@
+# Copyright Contributors to the Open Cluster Management project
+
+###############################################################################
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2020 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+###############################################################################
+# Copyright (c) 2020 Red Hat, Inc
+
+apiVersion: v1
+description: A helm chart for deploying the cluster lifecycle
+name: cluster-lifecycle
+appVersion: "2.5"
+version: 2.5.0
+kubeVersion: ">=1.11.0-0"
+keywords:
+  - IcpClusterResource
+  - Commercial
+  - ICP
+  - IKS
+  - ICPRHOCP
+  - Operations
+  - amd64
+  - ppc64le
+  - s390x

--- a/pkg/templates/charts/toggle/cluster-lifecycle/Chart.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/Chart.yaml
@@ -1,25 +1,8 @@
 # Copyright Contributors to the Open Cluster Management project
 
-###############################################################################
-# Licensed Materials - Property of IBM
-# (C) Copyright IBM Corporation 2020 All Rights Reserved
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
-###############################################################################
-# Copyright (c) 2020 Red Hat, Inc
-
 apiVersion: v1
 description: A helm chart for deploying the cluster lifecycle
 name: cluster-lifecycle
 appVersion: "2.5"
 version: 2.5.0
 kubeVersion: ">=1.11.0-0"
-keywords:
-  - IcpClusterResource
-  - Commercial
-  - ICP
-  - IKS
-  - ICPRHOCP
-  - Operations
-  - amd64
-  - ppc64le
-  - s390x

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/clustermanagementaddon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/clustermanagementaddon-clusterrole.yaml
@@ -1,0 +1,10 @@
+# Copyright Contributors to the Open Cluster Management project
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: open-cluster-management:clustermanagementaddons-readonly-v2
+rules:
+- apiGroups: ["addon.open-cluster-management.io"]
+  resources: ["clustermanagementaddons"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/clustermanagementaddon-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/clustermanagementaddon-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: open-cluster-management:clustermanagementaddons-readonly-v2
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: open-cluster-management:clustermanagementaddons-readonly-v2
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
@@ -1,4 +1,3 @@
-# Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
 apiVersion: apps/v1

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
@@ -1,0 +1,122 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: klusterlet-addon-controller-v2
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: klusterlet-addon-controller-v2
+    component: klusterlet-addon-controller
+    app.kubernetes.io/name: klusterlet-addon-controller
+spec:
+  minReadySeconds: 0
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      app: klusterlet-addon-controller-v2
+      component: klusterlet-addon-controller
+  template:
+    metadata:
+      labels:
+        app: klusterlet-addon-controller-v2
+        ocm-antiaffinity-selector: "klusterletaddon"
+        component: klusterlet-addon-controller
+        app.kubernetes.io/name: klusterlet-addon-controller
+    spec:
+      {{- if .Values.global.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.pullSecret }}
+      {{- end }}
+      serviceAccountName: klusterlet-addon-controller-v2
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+                - arm64
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - klusterletaddon
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - klusterletaddon
+      {{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
+      {{- end }}
+      containers:
+      - name: klusterlet-addon-controller
+        image: "{{ .Values.global.imageOverrides.klusterlet_addon_controller }}"
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        resources:
+          requests:
+            memory: "96Mi"
+            cpu: "50m"
+          limits:
+            memory: "2Gi"
+            cpu: "500m"
+        env:
+          - name: WATCH_NAMESPACE
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OPERATOR_NAME
+            value: klusterlet-addon-controller
+          - name: USE_SHA_MANIFEST
+            value: "true"
+          - name: DEFAULT_IMAGE_PULL_SECRET
+            value: {{ .Values.global.pullSecret }}
+          - name: DEFAULT_IMAGE_REGISTRY
+            value: {{ .Values.global.imageRepository }}
+          - name: ADDON_CLUSTERROLE_PREFIX
+            value: "open-cluster-management:addons:"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role.yaml
@@ -1,3 +1,5 @@
+# Copyright Contributors to the Open Cluster Management project
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role.yaml
@@ -1,0 +1,122 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:klusterlet-addon-controller-v2
+  labels:
+    app: klusterlet-addon-controller-v2
+    component: klusterlet-addon-controller
+    app.kubernetes.io/name: klusterlet-addon-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - secrets
+  - configmaps
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agent.open-cluster-management.io
+  resources:
+  - klusterletaddonconfigs
+  - klusterletaddonconfigs/finalizers
+  - klusterletaddonconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  - managedclusters/finalizers
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - manifestworks
+  - manifestworks/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+# appmgr
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - delete
+- apiGroups: 
+  - addon.open-cluster-management.io
+  resources: 
+  - managedclusteraddons
+  - managedclusteraddons/status
+  - clustermanagementaddons
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+    - imageregistry.open-cluster-management.io
+  resources:
+    - managedclusterimageregistries
+    - managedclusterimageregistries/status
+  verbs:
+    - get
+    - list
+    - watch

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role_binding.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role_binding.yaml
@@ -1,4 +1,3 @@
-# Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
 kind: ClusterRoleBinding

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role_binding.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-role_binding.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: open-cluster-management:klusterlet-addon-controller-v2
+  labels:
+    app: klusterlet-addon-controller-v2
+    component: klusterlet-addon-controller
+    app.kubernetes.io/name: klusterlet-addon-controller
+subjects:
+- kind: ServiceAccount
+  name: klusterlet-addon-controller-v2
+  namespace: '{{ .Values.global.namespace }}'
+roleRef:
+  kind: ClusterRole
+  name: open-cluster-management:klusterlet-addon-controller-v2
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-service_account.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-service_account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: klusterlet-addon-controller-v2
+  labels:
+    app: klusterlet-addon-controller-v2
+    component: klusterlet-addon-controller
+    app.kubernetes.io/name: klusterlet-addon-controller

--- a/pkg/templates/charts/toggle/cluster-lifecycle/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/values.yaml
@@ -1,0 +1,12 @@
+global:
+  imageOverrides:
+    klusterlet_addon_controller: ''
+  namespace: default
+  pullSecret: null
+  imageRepository: "" # utils.GetImageRepository(m)
+hubconfig:
+  nodeSelector: null
+  proxyConfigs: {}
+  replicaCount: 1
+  tolerations: []
+org: open-cluster-management

--- a/pkg/templates/crds/cluster-lifecycle/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
+++ b/pkg/templates/crds/cluster-lifecycle/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
@@ -1,0 +1,215 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+# Copyright Contributors to the Open Cluster Management project
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: klusterletaddonconfigs.agent.open-cluster-management.io
+spec:
+  group: agent.open-cluster-management.io
+  names:
+    kind: KlusterletAddonConfig
+    listKind: KlusterletAddonConfigList
+    plural: klusterletaddonconfigs
+    singular: klusterletaddonconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KlusterletAddonConfig is the Schema for the klusterletaddonconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KlusterletAddonConfigSpec defines the desired state of KlusterletAddonConfig
+            properties:
+              applicationManager:
+                description: ApplicationManagerConfig defines the configurations of ApplicationManager addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              certPolicyController:
+                description: CertPolicyControllerConfig defines the configurations of CertPolicyController addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              clusterLabels:
+                additionalProperties:
+                  type: string
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                type: object
+              clusterName:
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                minLength: 1
+                type: string
+              clusterNamespace:
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                minLength: 1
+                type: string
+              iamPolicyController:
+                description: IAMPolicyControllerConfig defines the configurations of IamPolicyController addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              policyController:
+                description: PolicyController defines the configurations of PolicyController addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              proxyConfig:
+                description: ProxyConfig defines the cluster-wide proxy configuration of the OCP managed cluster.
+                properties:
+                  httpProxy:
+                    description: HTTPProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  httpsProxy:
+                    description: HTTPSProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  noProxy:
+                    description: NoProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Empty means unset and will not result in an env var. The API Server of Hub cluster should be added here. And If you scale up workers that are not included in the network defined by the networking.machineNetwork[].cidr field from the installation configuration, you must add them to this list to prevent connection issues.
+                    type: string
+                type: object
+              searchCollector:
+                description: SearchCollectorConfig defines the configurations of SearchCollector addon agent.
+                properties:
+                  enabled:
+                    description: Enabled is the flag to enable/disable the addon. default is false.
+                    type: boolean
+                  proxyPolicy:
+                    description: ProxyPolicy defines the policy to set proxy for each addon agent. default is Disabled. Disabled means that the addon agent pods do not configure the proxy env variables. OCPGlobalProxy means that the addon agent pods use the cluster-wide proxy config of OCP cluster provisioned by ACM. CustomProxy means that the addon agent pods use the ProxyConfig specified in KlusterletAddonConfig.
+                    enum:
+                    - Disabled
+                    - OCPGlobalProxy
+                    - CustomProxy
+                    type: string
+                type: object
+              version:
+                description: DEPRECATED in release 2.4 and will be removed in the future since not used anymore.
+                type: string
+            required:
+            - applicationManager
+            - certPolicyController
+            - iamPolicyController
+            - policyController
+            - searchCollector
+            type: object
+          status:
+            description: KlusterletAddonConfigStatus defines the observed state of KlusterletAddonConfig
+            properties:
+              conditions:
+                description: Conditions contains condition information for the klusterletAddonConfig
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ocpGlobalProxy:
+                description: OCPGlobalProxy is the cluster-wide proxy config of the OCP cluster provisioned by ACM
+                properties:
+                  httpProxy:
+                    description: HTTPProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  httpsProxy:
+                    description: HTTPSProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
+                    type: string
+                  noProxy:
+                    description: NoProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Empty means unset and will not result in an env var. The API Server of Hub cluster should be added here. And If you scale up workers that are not included in the network defined by the networking.machineNetwork[].cidr field from the installation configuration, you must add them to this list to prevent connection issues.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -51,6 +51,7 @@ const (
 	MCEManagedByLabel     = "multiclusterhubs.operator.open-cluster-management.io/managed-by"
 	InsightsChartLocation = "/charts/toggle/insights"
 	SearchV2ChartLocation = "/charts/toggle/search-v2-operator"
+	CLCChartLocation      = "/charts/toggle/cluster-lifecycle"
 )
 
 var (
@@ -277,7 +278,7 @@ func GetTestImages() []string {
 		"SEARCH_AGGREGATOR", "SEARCH_API", "SEARCH_COLLECTOR", "SEARCH_E2E", "SEARCH_INDEXER", "SEARCH_OPERATOR",
 		"SEARCH_V2_API", "SUBMARINER_ADDON", "THANOS", "VOLSYNC", "VOLSYNC_ADDON_CONTROLLER", "VOLSYNC_MOVER_RCLONE",
 		"VOLSYNC_MOVER_RESTIC", "VOLSYNC_MOVER_RSYNC", "kube_rbac_proxy", "insights_metrics", "insights_client",
-		"search_collector", "search_indexer", "search_v2_api", "postgresql_13", "search_v2_operator"}
+		"search_collector", "search_indexer", "search_v2_api", "postgresql_13", "search_v2_operator", "klusterlet_addon_controller"}
 
 }
 
@@ -349,7 +350,6 @@ func GetAppsubs(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 		{Name: "console-chart-sub", Namespace: m.Namespace},
 		{Name: "grc-sub", Namespace: m.Namespace},
 		{Name: "management-ingress-sub", Namespace: m.Namespace},
-		{Name: "cluster-lifecycle-sub", Namespace: m.Namespace},
 		{Name: "volsync-addon-controller-sub", Namespace: m.Namespace},
 	}
 	if m.Enabled(operatorsv1.ClusterBackup) {
@@ -382,6 +382,9 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedN
 		nn = append(nn, types.NamespacedName{Name: "search-indexer", Namespace: m.Namespace})
 		nn = append(nn, types.NamespacedName{Name: "search-postgres", Namespace: m.Namespace})
 	}
+	if m.Enabled(operatorsv1.ClusterLifecycle) {
+		nn = append(nn, types.NamespacedName{Name: "klusterlet-addon-controller-v2", Namespace: m.Namespace})
+	}
 	return nn
 }
 
@@ -395,9 +398,6 @@ func GetAppsubsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedName 
 	}
 	if m.Enabled(operatorsv1.ManagementIngress) {
 		nn = append(nn, types.NamespacedName{Name: "management-ingress-sub", Namespace: m.Namespace})
-	}
-	if m.Enabled(operatorsv1.ClusterLifecycle) {
-		nn = append(nn, types.NamespacedName{Name: "cluster-lifecycle-sub", Namespace: m.Namespace})
 	}
 	if m.Enabled(operatorsv1.ClusterBackup) {
 		nn = append(nn, types.NamespacedName{Name: "cluster-backup-chart-sub", Namespace: ClusterSubscriptionNamespace})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -170,7 +170,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
 			appsubs := GetAppsubs(&mch)
-			Expect(len(appsubs)).To(Equal(6))
+			Expect(len(appsubs)).To(Equal(5))
 		})
 		It("gets deployments in Community Mode", func() {
 			os.Setenv("OPERATOR_PACKAGE", "stolostron")
@@ -185,7 +185,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
 			appsubs := GetAppsubs(&mch)
-			Expect(len(appsubs)).To(Equal(6))
+			Expect(len(appsubs)).To(Equal(5))
 
 		})
 		It("gets custom resources", func() {
@@ -210,6 +210,12 @@ var _ = Describe("utility functions", func() {
 			d := GetDeploymentsForStatus(&mch)
 			Expect(len(d)).To(Equal(2))
 		})
+		It("gets deployments for status with cluster-lifecycle enabled", func() {
+			mch := resources.EmptyMCH()
+			mch.Enable(operatorsv1.ClusterLifecycle)
+			d := GetDeploymentsForStatus(&mch)
+			Expect(len(d)).To(Equal(1))
+		})
 		It("gets appsubs for status", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
@@ -221,7 +227,7 @@ var _ = Describe("utility functions", func() {
 			mch.Enable(operatorsv1.Search)
 			mch.Enable(operatorsv1.Volsync)
 			appsubs := GetAppsubsForStatus(&mch)
-			Expect(len(appsubs)).To(Equal(6))
+			Expect(len(appsubs)).To(Equal(5))
 		})
 		It("Sets Default Component values", func() {
 			mch := resources.EmptyMCH()


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/25587

Moves source-of-truth for MCH cluster lifecycle templates from https://github.com/stolostron/multiclusterhub-repo/tree/main/multiclusterhub/charts/cluster-lifecycle/templates and CRDs from https://github.com/stolostron/hub-crds/tree/main/crds/cluster-lifecycle-chart to this repo.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>