### PR TITLE
Render GRC chart directly

### DIFF
--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -442,11 +442,9 @@ spec:
         - apiGroups:
           - ""
           - apps
-          - monitoring.coreos.com
           resources:
           - deployments
           - serviceaccounts
-          - servicemonitors
           - services
           verbs:
           - delete
@@ -491,6 +489,17 @@ spec:
           verbs:
           - create
           - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          - servicemonitors
+          verbs:
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -332,11 +332,9 @@ rules:
 - apiGroups:
   - ""
   - apps
-  - monitoring.coreos.com
   resources:
   - deployments
   - serviceaccounts
-  - servicemonitors
   - services
   verbs:
   - delete
@@ -381,6 +379,17 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
   - get
   - list
   - patch

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -105,8 +105,9 @@ var (
 //+kubebuilder:rbac:groups="multicluster.openshift.io",resources=multiclusterengines,verbs=create;get;list;patch;update;delete;watch
 //+kubebuilder:rbac:groups=console.openshift.io;search.open-cluster-management.io,resources=consoleplugins;searches,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups="";"apps";monitoring.coreos.com,resources=servicemonitors;deployments;services;serviceaccounts,verbs=patch;delete;get;deletecollection
+//+kubebuilder:rbac:groups="";"apps",resources=deployments;services;serviceaccounts,verbs=patch;delete;get;deletecollection
 //+kubebuilder:rbac:groups=packages.operators.coreos.com,resources=packagemanifests,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=get;list;watch;update;patch
 
 // AgentServiceConfig webhook delete check
 //+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agentserviceconfigs,verbs=get;list;watch
@@ -410,9 +411,9 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 	if multiClusterHub.Enabled(operatorv1.GRC) {
-		result, err = r.ensureSubscription(multiClusterHub, subscription.GRC(multiClusterHub, r.CacheSpec.ImageOverrides))
+		result, err = r.ensureGRC(ctx, multiClusterHub, r.CacheSpec.ImageOverrides)
 	} else {
-		result, err = r.ensureNoSubscription(multiClusterHub, subscription.GRC(multiClusterHub, r.CacheSpec.ImageOverrides))
+		result, err = r.ensureNoGRC(ctx, multiClusterHub, r.CacheSpec.ImageOverrides)
 	}
 	if result != (ctrl.Result{}) {
 		return result, err
@@ -647,6 +648,52 @@ func (r *MultiClusterHubReconciler) ensureNoInsights(ctx context.Context, m *ope
 
 	// Renders all templates from charts
 	templates, errs := renderer.RenderChart(utils.InsightsChartLocation, m, images)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Info(err.Error())
+		}
+		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
+	}
+
+	// Deletes all templates
+	for _, template := range templates {
+		result, err := r.deleteTemplate(ctx, m, template)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Failed to delete template: %s", template.GetName()))
+			return result, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterHubReconciler) ensureGRC(ctx context.Context, m *operatorv1.MultiClusterHub, images map[string]string) (ctrl.Result, error) {
+
+	log := log.FromContext(ctx)
+
+	templates, errs := renderer.RenderChart(utils.GRCChartLocation, m, images)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Info(err.Error())
+		}
+		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
+	}
+
+	// Applies all templates
+	for _, template := range templates {
+		result, err := r.applyTemplate(ctx, m, template)
+		if err != nil {
+			return result, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterHubReconciler) ensureNoGRC(ctx context.Context, m *operatorv1.MultiClusterHub, images map[string]string) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	// Renders all templates from charts
+	templates, errs := renderer.RenderChart(utils.GRCChartLocation, m, images)
 	if len(errs) > 0 {
 		for _, err := range errs {
 			log.Info(err.Error())

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -950,6 +950,10 @@ func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operat
 	if err != nil {
 		return err
 	}
+	_, err = r.ensureNoGRC(context.TODO(), m, r.CacheSpec.ImageOverrides)
+	if err != nil {
+		return err
+	}
 	_, err = r.ensureNoSearchV2(context.TODO(), m, r.CacheSpec.ImageOverrides)
 	if err != nil {
 		return err

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	resources "github.com/stolostron/multiclusterhub-operator/test/unit-tests"
 	searchv2v1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	ocmapi "open-cluster-management.io/api/addon/v1alpha1"
 	policy "open-cluster-management.io/governance-policy-propagator/api/v1"
 	appsub "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
@@ -334,6 +335,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 		Expect(configv1.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(consolev1.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(olmapi.AddToScheme(clientScheme)).Should(Succeed())
+		Expect(ocmapi.AddToScheme(clientScheme)).Should(Succeed())
 
 		k8sManager, err := ctrl.NewManager(clientConfig, ctrl.Options{
 			Scheme:                 clientScheme,
@@ -565,6 +567,18 @@ var _ = Describe("MultiClusterHub controller", func() {
 			By("Ensuring No CLC")
 
 			result, err = reconciler.ensureNoCLC(ctx, mch, testImages)
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).To(BeNil())
+
+			By("Ensuring GRC")
+
+			result, err = reconciler.ensureGRC(ctx, mch, testImages)
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).To(BeNil())
+
+			By("Ensuring No GRC")
+
+			result, err = reconciler.ensureNoGRC(ctx, mch, testImages)
 			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).To(BeNil())
 		})

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -109,7 +109,11 @@ var (
 				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
 			),
 			newUnstructured(
-				types.NamespacedName{Name: "cluster-backup-chart-sub", Namespace: utils.ClusterSubscriptionNamespace},
+				types.NamespacedName{Name: "cluster-backup-chart-sub", Namespace: m.Namespace},
+				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
+			),
+			newUnstructured(
+				types.NamespacedName{Name: "grc-sub", Namespace: m.Namespace},
 				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
 			),
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/fatih/structs v1.1.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.1.4
@@ -25,6 +24,8 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
 	k8s.io/kube-aggregator v0.24.3
+	open-cluster-management.io/api v0.8.0
+	open-cluster-management.io/governance-policy-propagator v0.8.0
 	open-cluster-management.io/multicloud-operators-subscription v0.8.0
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/yaml v1.3.0
@@ -41,7 +42,6 @@ require (
 	github.com/BurntSushi/toml v1.2.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
-	github.com/avast/retry-go/v3 v3.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -58,7 +58,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
-	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
@@ -87,9 +86,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stolostron/backplane-operator v0.0.0-20220727154840-1f60baf1fb98 // indirect
-	github.com/stolostron/go-log-utils v0.1.0 // indirect
-	github.com/stolostron/go-template-utils/v2 v2.2.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
@@ -115,8 +111,6 @@ require (
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
 	k8s.io/utils v0.0.0-20220725171434-9bab9ef40391 // indirect
-	open-cluster-management.io/api v0.8.0 // indirect
-	open-cluster-management.io/governance-policy-propagator v0.8.0 // indirect
 	open-cluster-management.io/multicloud-operators-channel v0.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/avast/retry-go/v3 v3.1.1 h1:49Scxf4v8PmiQ/nY0aY3p0hDueqSmc7++cBbtiDGu2g=
-github.com/avast/retry-go/v3 v3.1.1/go.mod h1:6cXRK369RpzFL3UQGqIUp9Q7GDrams+KsYWrfNA1/nQ=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
@@ -302,8 +300,6 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
-github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
@@ -350,7 +346,7 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -436,7 +432,6 @@ github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang-migrate/migrate/v4 v4.6.2 h1:LDDOHo/q1W5UDj6PbkxdCv7lv9yunyZHXvxuwDkGo3k=
 github.com/golang-migrate/migrate/v4 v4.6.2/go.mod h1:JYi6reN3+Z734VZ0akNuyOJNcrg45ZL7LDBMW3WGJL0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -907,10 +902,6 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/backplane-operator v0.0.0-20220727154840-1f60baf1fb98 h1:fb77iXzaY4kud+wPqNPT6UgvPITK9q+O1D5FeUJ6qP0=
 github.com/stolostron/backplane-operator v0.0.0-20220727154840-1f60baf1fb98/go.mod h1:IGZxghtPz8rJylGtW8XUAQdlqRai2j7aL4ymOINsP/c=
-github.com/stolostron/go-log-utils v0.1.0 h1:YRi84JogWKHCfrif46m/4rep+ucsc80c9667FzaBbTA=
-github.com/stolostron/go-log-utils v0.1.0/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
-github.com/stolostron/go-template-utils/v2 v2.2.2 h1:wGGfxzexV0xNHcT6XUlXLGj6K44pBDwRixD9wYEyhtc=
-github.com/stolostron/go-template-utils/v2 v2.2.2/go.mod h1:z4d9KZkkW5jAHns3bafVTmab+eq/jVsoFRYWbH37Qu4=
 github.com/stolostron/multicloud-operators-subscription v0.0.0-20220310201446-9989c4301546 h1:/bqhtsFxzVB7gr43HMObkaT4hTmw+cpQcPMwVWgcuyE=
 github.com/stolostron/multicloud-operators-subscription v0.0.0-20220310201446-9989c4301546/go.mod h1:kb5wASyZUizaKxXXf4m1Cdf/IRnYtXjnJyAHEO4YYRU=
 github.com/stolostron/search-v2-operator v0.0.0-20220721051905-143d28ab4f10 h1:USGd9WwtGqAflJ0sY7k41hCO5L5BuYaPElmAsZm/q4M=
@@ -1703,7 +1694,6 @@ k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
-k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/klog/v2 v2.60.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/klog/v2 v2.70.1 h1:7aaoSdahviPmR+XkS7FyxlkkXs6tHISSG03RxleQAVQ=
 k8s.io/klog/v2 v2.70.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=

--- a/main.go
+++ b/main.go
@@ -73,6 +73,10 @@ const (
 )
 
 func init() {
+	if _, exists := os.LookupEnv("OPERATOR_VERSION"); !exists {
+		panic("OPERATOR_VERSION not defined")
+	}
+
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(operatorv1.AddToScheme(scheme))

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -19,6 +19,7 @@ import (
 	v1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/subscription"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
+	"github.com/stolostron/multiclusterhub-operator/pkg/version"
 	"helm.sh/helm/v3/pkg/engine"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,6 +52,7 @@ type HubConfig struct {
 	ReplicaCount int               `json:"replicaCount" structs:"replicaCount"`
 	Tolerations  []Toleration      `json:"tolerations" structs:"tolerations"`
 	OCPVersion   string            `json:"ocpVersion" structs:"ocpVersion"`
+	HubVersion   string            `json:"hubVersion" structs:"hubVersion"`
 }
 
 type Toleration struct {
@@ -307,6 +309,8 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 	values.Org = "open-cluster-management"
 
 	values.HubConfig.OCPVersion = os.Getenv("ACM_HUB_OCP_VERSION")
+
+	values.HubConfig.HubVersion = version.Version
 
 	if utils.ProxyEnvVarsAreSet() {
 		proxyVar := map[string]string{}

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -28,6 +28,7 @@ var chartPaths = []string{
 	utils.InsightsChartLocation,
 	utils.SearchV2ChartLocation,
 	utils.CLCChartLocation,
+	utils.GRCChartLocation,
 }
 
 func TestRender(t *testing.T) {

--- a/pkg/templates/charts/toggle/grc/Chart.yaml
+++ b/pkg/templates/charts/toggle/grc/Chart.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+apiVersion: v1
+appVersion: "1.0.0"
+description:  helm chart for multicloud grc
+name: grc
+version: 2.1.0
+category: "Development"
+verified: "RHACM"
+keywords:
+  - acm
+  - grc

--- a/pkg/templates/charts/toggle/grc/templates/cert-policy-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/cert-policy-clustermanagementaddon.yaml
@@ -1,0 +1,8 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: cert-policy-controller
+spec:
+  addOnMeta:
+    description: Monitors certificate expiration based on distributed policies.
+    displayName: Certificate Policy Addon

--- a/pkg/templates/charts/toggle/grc/templates/config-policy-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/config-policy-clustermanagementaddon.yaml
@@ -1,0 +1,8 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: config-policy-controller
+spec:
+  addOnMeta:
+    description: Audits k8s resources and remediates violation based on configuration policies.
+    displayName: Config Policy Addon

--- a/pkg/templates/charts/toggle/grc/templates/governance-policy-framework-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/governance-policy-framework-clustermanagementaddon.yaml
@@ -1,0 +1,8 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: governance-policy-framework
+spec:
+  addOnMeta:
+    description: Distributes policies and collects policy evaluation results.
+    displayName: Governance Policy Framework Addon

--- a/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
@@ -1,0 +1,152 @@
+# Copyright (c) 2020 Red Hat, Inc.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-grc-clusterrole"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+rules:
+- apiGroups:
+  - tower.ansible.com
+  resources:
+  - ansiblejobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - configmaps
+  - configmaps/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - view.open-cluster-management.io
+  resources:
+  - managedclusterviews
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  - placementdecisions
+  - placements
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - 'authentication.k8s.io'
+  resources:
+  - 'tokenreviews'
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - '*'
+  resources:
+  - '*/finalizers'
+  verbs:
+  - update
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - patch
+  - update
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole-aggregate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-grc-clusterrole-aggregate"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+    rbac.authorization.k8s.io/aggregate-to-ocm-cluster-manager-admin: "true"
+rules:
+- apiGroups: ["tower.ansible.com"]
+  resources: ["ansiblejobs"]
+  verbs: ["create","get", "list", "watch", "update", "delete", "deletecollection", "patch"]
+
+---

--- a/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
@@ -2,18 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.org }}:grc:clusterrole
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-grc-clusterrole"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 rules:
 - apiGroups:
   - tower.ansible.com
@@ -131,18 +128,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole-aggregate
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.org }}:grc:clusterrole-aggregate
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-grc-clusterrole-aggregate"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
     rbac.authorization.k8s.io/aggregate-to-ocm-cluster-manager-admin: "true"
 rules:
 - apiGroups: ["tower.ansible.com"]

--- a/pkg/templates/charts/toggle/grc/templates/grc-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-grc-clusterrolebinding"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: grc-sa
+    namespace: {{ .Release.Namespace }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-clusterrolebinding.yaml
@@ -3,23 +3,20 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrolebinding
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.org }}:grc:clusterrolebinding
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-grc-clusterrolebinding"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  name: {{ .Values.org }}:grc:clusterrole
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: grc-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-cm.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-cm.yaml
@@ -1,0 +1,19 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grc-ca-bundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-grc-sa"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/pkg/templates/charts/toggle/grc/templates/grc-cm.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-cm.yaml
@@ -4,16 +4,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grc-ca-bundle
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-grc-sa"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -1,0 +1,233 @@
+# Copyright (c) 2022 Red Hat, Inc.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:policyaddon-clusterrole
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-addon-ctrl"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+rules:
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - clustermanagementaddons
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - clustermanagementaddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - managedclusteraddons
+  verbs:
+  - delete
+- apiGroups:
+  - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - managedclusteraddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - managedclusteraddons/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  verbs:
+  - approve
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - open-cluster-management:cert-policy-controller-hub
+  - open-cluster-management:config-policy-controller-hub
+  - open-cluster-management:iam-policy-controller-hub
+  - open-cluster-management:policy-framework-hub
+  resources:
+  - clusterroles
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - open-cluster-management:cert-policy-controller-hub
+  - open-cluster-management:config-policy-controller-hub
+  - open-cluster-management:iam-policy-controller-hub
+  - open-cluster-management:policy-framework-hub
+  resources:
+  - rolebindings
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - manifestworks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -3,18 +3,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:policyaddon-clusterrole
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.org }}:grc:policyaddon-clusterrole
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-addon-ctrl"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 rules:
 - apiGroups:
   - addon.open-cluster-management.io

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 Red Hat, Inc.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:policyaddon-clusterrolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-addon-ctrl"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}:{{ .Release.Name }}:policyaddon-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: grc-policy-addon-sa
+    namespace: {{ .Release.Namespace }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrolebinding.yaml
@@ -3,23 +3,20 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:policyaddon-clusterrolebinding
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.org }}:grc:policyaddon-clusterrolebinding
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-addon-ctrl"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:policyaddon-clusterrole
+  name: {{ .Values.org }}:grc:policyaddon-clusterrole
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: grc-policy-addon-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
@@ -1,0 +1,131 @@
+# Copyright (c) 2022 Red Hat, Inc.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-policy-addon-controller
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-addon-ctrl"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "grc.name" . }}
+      component: "ocm-policy-addon-ctrl"
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app: {{ template "grc.name" . }}
+        ocm-antiaffinity-selector: "grcpolicyaddon"
+        component: "ocm-policy-addon-ctrl"
+        name: governance-policy-addon-controller
+        release: {{ .Release.Name }}
+        chart: {{ template "grc.chart" . }}
+        heritage: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ template "grc.name" . }}
+        helm.sh/chart: {{ template "grc.chart" . }}
+    spec:
+      serviceAccountName: grc-policy-addon-sa
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                {{- toYaml .Values.arch | nindent 18}}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - grcpolicyaddon
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - grcpolicyaddon
+      {{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}      
+      containers:
+      - args:
+        - controller
+        command:
+        - governance-policy-addon-controller
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: CERT_POLICY_CONTROLLER_IMAGE
+          value: {{ .Values.global.imageOverrides.cert_policy_controller }}
+        - name: IAM_POLICY_CONTROLLER_IMAGE
+          value: {{ .Values.global.imageOverrides.iam_policy_controller }}
+        - name: CONFIG_POLICY_CONTROLLER_IMAGE
+          value: {{ .Values.global.imageOverrides.config_policy_controller }}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: {{ .Values.global.imageOverrides.kube_rbac_proxy }}
+        - name: GOVERNANCE_POLICY_SPEC_SYNC_IMAGE
+          value: {{ .Values.global.imageOverrides.governance_policy_spec_sync }}
+        - name: GOVERNANCE_POLICY_STATUS_SYNC_IMAGE
+          value: {{ .Values.global.imageOverrides.governance_policy_status_sync }}
+        - name: GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE
+          value: {{ .Values.global.imageOverrides.governance_policy_template_sync }}
+        image: {{ .Values.global.imageOverrides.governance_policy_addon_controller }}
+        imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+        name: manager
+        resources:
+        {{- toYaml .Values.governance.resources | nindent 10 }}
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: "/tmp"
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.pullSecret }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
@@ -3,40 +3,34 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-policy-addon-controller
+  name: grc-policy-addon-controller
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-addon-ctrl"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "grc.name" . }}
+      app: grc
       component: "ocm-policy-addon-ctrl"
-      release: {{ .Release.Name }}
+      release: grc
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        app: {{ template "grc.name" . }}
+        app: grc
         ocm-antiaffinity-selector: "grcpolicyaddon"
         component: "ocm-policy-addon-ctrl"
         name: governance-policy-addon-controller
-        release: {{ .Release.Name }}
-        chart: {{ template "grc.chart" . }}
-        heritage: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ template "grc.name" . }}
-        helm.sh/chart: {{ template "grc.chart" . }}
+        release: grc
+        chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
+        app.kubernetes.io/instance: grc
+        app.kubernetes.io/name: grc
     spec:
       serviceAccountName: grc-policy-addon-sa
       hostNetwork: false
@@ -52,7 +46,10 @@ spec:
               - key: kubernetes.io/arch
                 operator: In
                 values:
-                {{- toYaml .Values.arch | nindent 18}}
+                - amd64
+                - ppc64le
+                - s390x
+                - arm64
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 70
@@ -75,8 +72,14 @@ spec:
                   - grcpolicyaddon
       {{- with .Values.hubconfig.tolerations }}
       tolerations:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}      
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
+      {{- end }}  
       containers:
       - args:
         - controller
@@ -105,7 +108,9 @@ spec:
         imagePullPolicy: "{{ .Values.global.pullPolicy }}"
         name: manager
         resources:
-        {{- toYaml .Values.governance.resources | nindent 10 }}
+          requests:
+            memory: "64Mi"
+            cpu: "25m"
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true
@@ -121,9 +126,9 @@ spec:
       - name: tmp
         emptyDir: {}
       terminationGracePeriodSeconds: 10
-      {{- if .Values.pullSecret }}
+      {{- if .Values.global.pullSecret  }}
       imagePullSecrets:
-      - name: {{ .Values.pullSecret }}
+      - name: {{ .Values.global.pullSecret  }}
       {{- end }}
       {{- with .Values.hubconfig.nodeSelector }}
       nodeSelector:

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-role.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-role.yaml
@@ -3,18 +3,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-grc-policy-addon-role
-  namespace: {{ .Release.Namespace }}
+  name: grc-grc-policy-addon-role
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-addon-ctrl"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 rules:
 - apiGroups:
   - ""

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-role.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-role.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2022 Red Hat, Inc.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-grc-policy-addon-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-addon-ctrl"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-rolebinding.yaml
@@ -3,21 +3,18 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-grc-policy-addon-rolebinding
-  namespace: {{ .Release.Namespace }}
+  name: grc-grc-policy-addon-rolebinding
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-addon-ctrl"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}-grc-policy-addon-role
+  name: grc-grc-policy-addon-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-rolebinding.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2022 Red Hat, Inc.
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-grc-policy-addon-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-addon-ctrl"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-grc-policy-addon-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: grc-policy-addon-sa

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-sa.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-sa.yaml
@@ -4,14 +4,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grc-policy-addon-sa
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-addon-ctrl"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-sa.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-sa.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 Red Hat, Inc.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grc-policy-addon-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-addon-ctrl"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
@@ -2,38 +2,32 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: {{ .Release.Name }}-policy-propagator
+  name: grc-policy-propagator
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-propagator"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "grc.name" . }}
+      app: grc
       component: "ocm-policy-propagator"
-      release: {{ .Release.Name }}
+      release: grc
   template:
     metadata:
       labels:
-        app: {{ template "grc.name" . }}
+        app: grc
         ocm-antiaffinity-selector: "grcpolicypropagator"
         component: "ocm-policy-propagator"
         name: governance-policy-propagator
-        release: {{ .Release.Name }}
-        chart: {{ template "grc.chart" . }}
-        heritage: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ template "grc.name" . }}
-        helm.sh/chart: {{ template "grc.chart" . }}
+        release: grc
+        chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
+        app.kubernetes.io/instance: grc
+        app.kubernetes.io/name: grc
     spec:
       serviceAccountName: grc-sa
       hostNetwork: false
@@ -49,7 +43,10 @@ spec:
               - key: kubernetes.io/arch
                 operator: In
                 values:
-                {{- toYaml .Values.arch | nindent 18}}
+                - amd64
+                - ppc64le
+                - s390x
+                - arm64
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 70
@@ -72,7 +69,13 @@ spec:
                   - grcpolicypropagator
       {{- with .Values.hubconfig.tolerations }}
       tolerations:
-      {{- toYaml . | nindent 8 }}
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
       {{- end }}
       containers:
       - name: kube-rbac-proxy
@@ -98,7 +101,9 @@ spec:
         image: {{ .Values.global.imageOverrides.governance_policy_propagator}}
         imagePullPolicy: "{{ .Values.global.pullPolicy }}"
         resources:
-        {{- toYaml .Values.governance.resources | nindent 10 }}
+          requests:
+            memory: "64Mi"
+            cpu: "25m"
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true
@@ -137,10 +142,10 @@ spec:
         emptyDir: {}
       - name: metrics-cert
         secret:
-          secretName: {{ .Release.Name }}-grc-metrics-cert
-      {{- if .Values.pullSecret }}
+          secretName: grc-grc-metrics-cert
+      {{- if .Values.global.pullSecret  }}
       imagePullSecrets:
-      - name: {{ .Values.pullSecret }}
+      - name: {{ .Values.global.pullSecret  }}
       {{- end }}
       {{- with .Values.hubconfig.nodeSelector }}
       nodeSelector:

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
@@ -1,0 +1,148 @@
+# Copyright (c) 2020 Red Hat, Inc.
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .Release.Name }}-policy-propagator
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "grc.name" . }}
+      component: "ocm-policy-propagator"
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "grc.name" . }}
+        ocm-antiaffinity-selector: "grcpolicypropagator"
+        component: "ocm-policy-propagator"
+        name: governance-policy-propagator
+        release: {{ .Release.Name }}
+        chart: {{ template "grc.chart" . }}
+        heritage: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ template "grc.name" . }}
+        helm.sh/chart: {{ template "grc.chart" . }}
+    spec:
+      serviceAccountName: grc-sa
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                {{- toYaml .Values.arch | nindent 18}}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - grcpolicypropagator
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - grcpolicypropagator
+      {{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: kube-rbac-proxy
+        image: {{ .Values.global.imageOverrides.kube_rbac_proxy}}
+        imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+        args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8383/
+        - --logtostderr=true
+        - --v=6
+        - "--tls-cert-file=/var/run/policy-metrics-cert/tls.crt"
+        - "--tls-private-key-file=/var/run/policy-metrics-cert/tls.key"
+        - "--tls-min-version=VersionTLS13"
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        volumeMounts:
+        - mountPath: "/var/run/policy-metrics-cert"
+          name: metrics-cert
+          readOnly: true
+      - name: governance-policy-propagator
+        image: {{ .Values.global.imageOverrides.governance_policy_propagator}}
+        imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+        resources:
+        {{- toYaml .Values.governance.resources | nindent 10 }}
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+        command: ["governance-policy-propagator"]
+        env:
+          - name: WATCH_NAMESPACE
+            value: ""
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OPERATOR_NAME
+            value: "governance-policy-propagator"
+        livenessProbe:
+          exec:
+            command:
+            - ls
+          initialDelaySeconds: 15
+          periodSeconds: 15
+        readinessProbe:
+          exec:
+            command:
+            - ls
+          initialDelaySeconds: 15
+          periodSeconds: 15
+        volumeMounts:
+        - name: tmp
+          mountPath: "/tmp"
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: metrics-cert
+        secret:
+          secretName: {{ .Release.Name }}-grc-metrics-cert
+      {{- if .Values.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.pullSecret }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
@@ -3,18 +3,15 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: ocm-{{ .Release.Name }}-policy-propagator-metrics
+  name: ocm-grc-policy-propagator-metrics
   namespace: openshift-monitoring
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-propagator"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 spec:
   groups:
   - name: policy_governance_info.rules

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
@@ -1,0 +1,29 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ocm-{{ .Release.Name }}-policy-propagator-metrics
+  namespace: openshift-monitoring
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+spec:
+  groups:
+  - name: policy_governance_info.rules
+    rules:
+    - record: cluster:policy_governance_info:propagated_count
+      expr: count by (cluster_namespace) (policy_governance_info{type="propagated"})
+    - record: cluster:policy_governance_info:propagated_noncompliant_count
+      expr: count by (cluster_namespace) (policy_governance_info{type="propagated"}==1)
+    - record: policy:policy_governance_info:propagated_count
+      expr: count by (policy) (policy_governance_info{type="propagated"})
+    - record: policy:policy_governance_info:propagated_noncompliant_count
+      expr: count by (policy) (policy_governance_info{type="propagated"}==1)

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-service.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-service.yaml
@@ -3,19 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-policy-propagator-metrics
+  name: grc-policy-propagator-metrics
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-propagator"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{ .Release.Name }}-grc-metrics-cert
+    service.beta.openshift.io/serving-cert-secret-name: grc-grc-metrics-cert
 spec:
   ports:
   - name: https
@@ -23,8 +20,8 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: {{ template "grc.name" . }}
+    app: grc
     component: "ocm-policy-propagator"
-    release: {{ .Release.Name }}
+    release: grc
   sessionAffinity: None
   type: ClusterIP

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-service.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-service.yaml
@@ -1,0 +1,30 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-policy-propagator-metrics
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ .Release.Name }}-grc-metrics-cert
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: {{ template "grc.name" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
@@ -1,0 +1,36 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ocm-{{ .Release.Name }}-policy-propagator-metrics
+  namespace: openshift-monitoring
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-policy-propagator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    interval: 60s
+    scrapeTimeout: 10s
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: ocm-grc-policy-propagator
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "grc.name" . }}
+      component: "ocm-policy-propagator"
+      release: {{ .Release.Name }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
@@ -3,18 +3,15 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: ocm-{{ .Release.Name }}-policy-propagator-metrics
+  name: ocm-grc-policy-propagator-metrics
   namespace: openshift-monitoring
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-policy-propagator"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -28,9 +25,9 @@ spec:
   jobLabel: ocm-grc-policy-propagator
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ .Values.global.namespace }}
   selector:
     matchLabels:
-      app: {{ template "grc.name" . }}
+      app: grc
       component: "ocm-policy-propagator"
-      release: {{ .Release.Name }}
+      release: grc

--- a/pkg/templates/charts/toggle/grc/templates/grc-role.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-role.yaml
@@ -2,18 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-grc-role
-  namespace: {{ .Release.Namespace }}
+  name: grc-grc-role
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-grc-role"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 rules:
 - apiGroups:
   - ""
@@ -71,7 +68,7 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
-  - {{ .Release.Name }}-policy-propagator
+  - grc-policy-propagator
   resources:
   - deployments/finalizers
   verbs:

--- a/pkg/templates/charts/toggle/grc/templates/grc-role.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-role.yaml
@@ -1,0 +1,129 @@
+# Copyright (c) 2020 Red Hat, Inc.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-grc-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-grc-role"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - '*'
+  verbs:
+  - update
+- apiGroups:
+  - operator.open-cluster-management.io
+  resources:
+  - multiclusterhubs
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resourceNames:
+  - {{ .Release.Name }}-policy-propagator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policysets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policysets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policysets/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/pkg/templates/charts/toggle/grc/templates/grc-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-rolebinding.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Red Hat, Inc.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-grc-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-grc-rolebinding"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-grc-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: grc-sa
+    

--- a/pkg/templates/charts/toggle/grc/templates/grc-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-rolebinding.yaml
@@ -2,21 +2,18 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-grc-rolebinding
-  namespace: {{ .Release.Namespace }}
+  name: grc-grc-rolebinding
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-grc-rolebinding"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}-grc-role
+  name: grc-grc-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/pkg/templates/charts/toggle/grc/templates/grc-sa.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-sa.yaml
@@ -4,14 +4,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grc-sa
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.global.namespace }}
   labels:
-    app: {{ template "grc.name" . }}
-    chart: {{ template "grc.chart" . }}
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
     component: "ocm-grc-sa"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "grc.name" . }}
-    helm.sh/chart: {{ template "grc.chart" . }}
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc

--- a/pkg/templates/charts/toggle/grc/templates/grc-sa.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-sa.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grc-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "grc.name" . }}
+    chart: {{ template "grc.chart" . }}
+    component: "ocm-grc-sa"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "grc.name" . }}
+    helm.sh/chart: {{ template "grc.chart" . }}

--- a/pkg/templates/charts/toggle/grc/templates/iam-policy-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/iam-policy-clustermanagementaddon.yaml
@@ -1,0 +1,8 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: iam-policy-controller
+spec:
+  addOnMeta:
+    description: Monitors identity controls based on distributed policies.
+    displayName: IAM Policy Addon

--- a/pkg/templates/charts/toggle/grc/values.yaml
+++ b/pkg/templates/charts/toggle/grc/values.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+org: open-cluster-management
+
+global:
+  imageOverrides:
+    governance_policy_propagator: ""
+    governance_policy_addon_controller: ""
+    cert_policy_controller: ""
+    iam_policy_controller: ""
+    config_policy_controller: ""
+    governance_policy_spec_sync: ""
+    governance_policy_status_sync: ""
+    governance_policy_template_sync: ""
+    kube_rbac_proxy: ""
+  pullPolicy: IfNotPresent
+
+arch:
+  - amd64
+  - ppc64le
+  - s390x
+  - arm64
+pullSecret: null
+
+governance:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "25m"
+
+hubconfig:
+  nodeSelector: null
+  replicaCount: 1
+  proxyConfigs: {}
+  tolerations:
+    - key: dedicated
+      operator: Exists
+      effect: NoSchedule
+    - effect: NoSchedule 
+      key: node-role.kubernetes.io/infra 
+      operator: Exists

--- a/pkg/templates/charts/toggle/grc/values.yaml
+++ b/pkg/templates/charts/toggle/grc/values.yaml
@@ -1,7 +1,5 @@
 # Copyright (c) 2020 Red Hat, Inc.
 
-org: open-cluster-management
-
 global:
   imageOverrides:
     governance_policy_propagator: ""
@@ -12,30 +10,12 @@ global:
     governance_policy_spec_sync: ""
     governance_policy_status_sync: ""
     governance_policy_template_sync: ""
-    kube_rbac_proxy: ""
-  pullPolicy: IfNotPresent
-
-arch:
-  - amd64
-  - ppc64le
-  - s390x
-  - arm64
-pullSecret: null
-
-governance:
-  resources:
-    requests:
-      memory: "64Mi"
-      cpu: "25m"
-
+    kube_rbac_proxy: ""  namespace: default
+  pullSecret: null
+  pullPolicy: Always
 hubconfig:
   nodeSelector: null
-  replicaCount: 1
   proxyConfigs: {}
-  tolerations:
-    - key: dedicated
-      operator: Exists
-      effect: NoSchedule
-    - effect: NoSchedule 
-      key: node-role.kubernetes.io/infra 
-      operator: Exists
+  replicaCount: 1
+  tolerations: []
+org: open-cluster-management

--- a/pkg/templates/charts/toggle/grc/values.yaml
+++ b/pkg/templates/charts/toggle/grc/values.yaml
@@ -10,7 +10,8 @@ global:
     governance_policy_spec_sync: ""
     governance_policy_status_sync: ""
     governance_policy_template_sync: ""
-    kube_rbac_proxy: ""  namespace: default
+    kube_rbac_proxy: ""
+  namespace: default
   pullSecret: null
   pullPolicy: Always
 hubconfig:

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
@@ -1,0 +1,102 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: placementbindings.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: PlacementBinding
+    listKind: PlacementBindingList
+    plural: placementbindings
+    shortNames:
+    - pb
+    singular: placementbinding
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PlacementBinding is the Schema for the placementbindings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          placementRef:
+            description: PlacementSubject reference
+            properties:
+              apiGroup:
+                enum:
+                - apps.open-cluster-management.io
+                - cluster.open-cluster-management.io
+                minLength: 1
+                type: string
+              kind:
+                enum:
+                - PlacementRule
+                - Placement
+                minLength: 1
+                type: string
+              name:
+                minLength: 1
+                type: string
+            required:
+            - apiGroup
+            - kind
+            - name
+            type: object
+          status:
+            description: PlacementBindingStatus defines the observed state of PlacementBinding
+            type: object
+          subjects:
+            items:
+              description: Subject reference
+              properties:
+                apiGroup:
+                  enum:
+                  - policy.open-cluster-management.io
+                  minLength: 1
+                  type: string
+                kind:
+                  enum:
+                  - Policy
+                  - PolicySet
+                  minLength: 1
+                  type: string
+                name:
+                  minLength: 1
+                  type: string
+              required:
+              - apiGroup
+              - kind
+              - name
+              type: object
+            minItems: 1
+            type: array
+        required:
+        - placementRef
+        - subjects
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policies.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policies.yaml
@@ -1,0 +1,164 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: policies.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: Policy
+    listKind: PolicyList
+    plural: policies
+    shortNames:
+    - plc
+    singular: policy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.remediationAction
+      name: Remediation action
+      type: string
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Policy is the Schema for the policies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicySpec defines the desired state of Policy
+            properties:
+              disabled:
+                type: boolean
+              policy-templates:
+                items:
+                  description: PolicyTemplate template for custom security policy
+                  properties:
+                    objectDefinition:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - objectDefinition
+                  type: object
+                type: array
+              remediationAction:
+                description: RemediationAction describes weather to enforce or inform
+                enum:
+                - Inform
+                - inform
+                - Enforce
+                - enforce
+                type: string
+            required:
+            - disabled
+            - policy-templates
+            type: object
+          status:
+            description: PolicyStatus defines the observed state of Policy
+            properties:
+              compliant:
+                description: ComplianceState shows the state of enforcement
+                enum:
+                - Compliant
+                - NonCompliant
+                type: string
+              details:
+                items:
+                  description: DetailsPerTemplate defines compliance details and history
+                  properties:
+                    compliant:
+                      description: ComplianceState shows the state of enforcement
+                      type: string
+                    history:
+                      items:
+                        description: ComplianceHistory defines compliance details
+                          history
+                        properties:
+                          eventName:
+                            type: string
+                          lastTimestamp:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                        type: object
+                      type: array
+                    templateMeta:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              placement:
+                items:
+                  description: Placement defines the placement results
+                  properties:
+                    decisions:
+                      items:
+                        description: PlacementDecision defines the decision made by
+                          controller
+                        properties:
+                          clusterName:
+                            type: string
+                          clusterNamespace:
+                            type: string
+                        type: object
+                      type: array
+                    placement:
+                      type: string
+                    placementBinding:
+                      type: string
+                    placementRule:
+                      type: string
+                    policySet:
+                      type: string
+                  type: object
+                type: array
+              status:
+                items:
+                  description: CompliancePerClusterStatus defines compliance per cluster
+                    status
+                  properties:
+                    clustername:
+                      type: string
+                    clusternamespace:
+                      type: string
+                    compliant:
+                      description: ComplianceState shows the state of enforcement
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
@@ -1,0 +1,122 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: policyautomations.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: PolicyAutomation
+    listKind: PolicyAutomationList
+    plural: policyautomations
+    shortNames:
+    - plca
+    singular: policyautomation
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: PolicyAutomation is the Schema for the policyautomations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyAutomationSpec defines the desired state of PolicyAutomation
+            properties:
+              automationDef:
+                description: AutomationDef defines the automation to invoke
+                properties:
+                  extra_vars:
+                    description: ExtraVars is passed to the Ansible job at execution
+                      time and is a known Ansible entity.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  name:
+                    description: Name of the Ansible Template to run in Tower as a
+                      job
+                    minLength: 1
+                    type: string
+                  secret:
+                    minLength: 1
+                    type: string
+                  type:
+                    description: Type of the automation to invoke
+                    type: string
+                required:
+                - name
+                - secret
+                type: object
+              delayAfterRunSeconds:
+                minimum: 0
+                type: integer
+              eventHook:
+                description: EventHook decides when automation is going to be triggered
+                enum:
+                - noncompliant
+                type: string
+              mode:
+                description: Mode decides how automation is going to be triggered
+                enum:
+                - once
+                - everyEvent
+                - disabled
+                type: string
+              policyRef:
+                description: PolicyRef is the name of the policy automation is going
+                  to binding with.
+                type: string
+              rescanAfter:
+                type: string
+            required:
+            - automationDef
+            - mode
+            - policyRef
+            type: object
+          status:
+            description: PolicyAutomationStatus defines the observed state of PolicyAutomation
+            properties:
+              clustersWithEvent:
+                additionalProperties:
+                  description: PolicyAutomation events on each target cluster
+                  properties:
+                    automationStartTime:
+                      description: Policy automation start time for everyEvent mode
+                      type: string
+                    eventTime:
+                      description: The last policy compliance transition event time
+                      type: string
+                  required:
+                  - automationStartTime
+                  - eventTime
+                  type: object
+                description: Cluster name as the key of ClustersWithEvent
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policysets.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policysets.yaml
@@ -1,0 +1,91 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: policysets.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: PolicySet
+    listKind: PolicySetList
+    plural: policysets
+    shortNames:
+    - plcset
+    singular: policyset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: PolicySet is the Schema for the policysets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicySetSpec defines the desired state of PolicySet
+            properties:
+              description:
+                type: string
+              policies:
+                items:
+                  minLength: 1
+                  type: string
+                type: array
+            required:
+            - policies
+            type: object
+          status:
+            description: PolicySetStatus defines the observed state of PolicySet
+            properties:
+              compliant:
+                type: string
+              placement:
+                items:
+                  description: PolicySetStatusPlacement defines a placement object
+                    for the status
+                  properties:
+                    placement:
+                      type: string
+                    placementBinding:
+                      type: string
+                    placementRule:
+                      type: string
+                  type: object
+                type: array
+              statusMessage:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -53,6 +53,7 @@ const (
 	SearchV2ChartLocation      = "/charts/toggle/search-v2-operator"
 	CLCChartLocation           = "/charts/toggle/cluster-lifecycle"
 	ClusterBackupChartLocation = "/charts/toggle/cluster-backup"
+	GRCChartLocation           = "/charts/toggle/grc"
 )
 
 var (
@@ -276,9 +277,7 @@ func IsUnitTest() bool {
 
 func GetTestImages() []string {
 	return []string{"LIFECYCLE_BACKEND_E2E", "BAILER", "CERT_POLICY_CONTROLLER", "CLUSTER_BACKUP_CONTROLLER",
-		"CLUSTER_LIFECYCLE_E2E", "CLUSTER_PROXY", "CLUSTER_PROXY_ADDON", "CONFIG_POLICY_CONTROLLER", "CONSOLE",
-		"ENDPOINT_MONITORING_OPERATOR", "GOVERNANCE_POLICY_ADDON_CONTROLLER", "GOVERNANCE_POLICY_PROPAGATOR",
-		"GOVERNANCE_POLICY_SPEC_SYNC", "GOVERNANCE_POLICY_STATUS_SYNC", "GOVERNANCE_POLICY_TEMPLATE_SYNC",
+		"CLUSTER_LIFECYCLE_E2E", "CLUSTER_PROXY", "CLUSTER_PROXY_ADDON", "CONSOLE", "ENDPOINT_MONITORING_OPERATOR",
 		"GRAFANA", "GRAFANA_DASHBOARD_LOADER", "GRC_POLICY_FRAMEWORK_TESTS", "HELLOPROW_GO", "HELLOWORLD",
 		"HYPERSHIFT_DEPLOYMENT_CONTROLLER", "IAM_POLICY_CONTROLLER", "INSIGHTS_CLIENT", "INSIGHTS_METRICS",
 		"KLUSTERLET_ADDON_CONTROLLER", "KLUSTERLET_ADDON_OPERATOR", "KUBE_RBAC_PROXY", "KUBE_STATE_METRICS",
@@ -291,7 +290,10 @@ func GetTestImages() []string {
 		"SEARCH_AGGREGATOR", "SEARCH_API", "SEARCH_COLLECTOR", "SEARCH_E2E", "SEARCH_INDEXER", "SEARCH_OPERATOR",
 		"SEARCH_V2_API", "SUBMARINER_ADDON", "THANOS", "VOLSYNC", "VOLSYNC_ADDON_CONTROLLER", "VOLSYNC_MOVER_RCLONE",
 		"VOLSYNC_MOVER_RESTIC", "VOLSYNC_MOVER_RSYNC", "kube_rbac_proxy", "insights_metrics", "insights_client",
-		"search_collector", "search_indexer", "search_v2_api", "postgresql_13", "search_v2_operator", "klusterlet_addon_controller", "cluster_backup_controller"}
+		"search_collector", "search_indexer", "search_v2_api", "postgresql_13", "search_v2_operator", "klusterlet_addon_controller",
+		"governance_policy_propagator", "governance_policy_addon_controller", "cert_policy_controller", "iam_policy_controller",
+		"config_policy_controller", "governance_policy_spec_sync", "governance_policy_status_sync", "governance_policy_template_sync",
+		"cluster_backup_controller"}
 
 }
 
@@ -365,7 +367,6 @@ func GetDeployments(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 func GetAppsubs(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 	appsubs := []types.NamespacedName{
 		{Name: "console-chart-sub", Namespace: m.Namespace},
-		{Name: "grc-sub", Namespace: m.Namespace},
 		{Name: "management-ingress-sub", Namespace: m.Namespace},
 		{Name: "volsync-addon-controller-sub", Namespace: m.Namespace},
 	}
@@ -403,6 +404,10 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedN
 		nn = append(nn, types.NamespacedName{Name: "cluster-backup-chart-clusterbackup", Namespace: ClusterSubscriptionNamespace})
 		nn = append(nn, types.NamespacedName{Name: "openshift-adp-controller-manager", Namespace: ClusterSubscriptionNamespace})
 	}
+	if m.Enabled(operatorsv1.GRC) {
+		nn = append(nn, types.NamespacedName{Name: "grc-policy-addon-controller", Namespace: m.Namespace})
+		nn = append(nn, types.NamespacedName{Name: "grc-policy-propagator", Namespace: m.Namespace})
+	}
 	return nn
 }
 
@@ -410,9 +415,6 @@ func GetAppsubsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedName 
 	nn := []types.NamespacedName{}
 	if m.Enabled(operatorsv1.Console) {
 		nn = append(nn, types.NamespacedName{Name: "console-chart-sub", Namespace: m.Namespace})
-	}
-	if m.Enabled(operatorsv1.GRC) {
-		nn = append(nn, types.NamespacedName{Name: "grc-sub", Namespace: m.Namespace})
 	}
 	if m.Enabled(operatorsv1.ManagementIngress) {
 		nn = append(nn, types.NamespacedName{Name: "management-ingress-sub", Namespace: m.Namespace})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -220,6 +220,10 @@ var _ = Describe("utility functions", func() {
 		It("gets deployments for status with cluster-backkup enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
+		})
+		It("gets deployments for status with grc enabled", func() {
+			mch := resources.EmptyMCH()
+			mch.Enable(operatorsv1.GRC)
 			d := GetDeploymentsForStatus(&mch)
 			Expect(len(d)).To(Equal(2))
 		})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -171,7 +171,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
 			appsubs := GetAppsubs(&mch)
-			Expect(len(appsubs)).To(Equal(4))
+			Expect(len(appsubs)).To(Equal(3))
 		})
 		It("gets deployments in Community Mode", func() {
 			os.Setenv("OPERATOR_PACKAGE", "stolostron")
@@ -186,7 +186,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
 			appsubs := GetAppsubs(&mch)
-			Expect(len(appsubs)).To(Equal(4))
+			Expect(len(appsubs)).To(Equal(3))
 
 		})
 		It("gets custom resources", func() {
@@ -238,7 +238,7 @@ var _ = Describe("utility functions", func() {
 			mch.Enable(operatorsv1.Search)
 			mch.Enable(operatorsv1.Volsync)
 			appsubs := GetAppsubsForStatus(&mch)
-			Expect(len(appsubs)).To(Equal(4))
+			Expect(len(appsubs)).To(Equal(3))
 		})
 		It("Sets Default Component values", func() {
 			mch := resources.EmptyMCH()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,13 +4,14 @@ package version
 
 import "os"
 
+// Version is the semver version the operator is reconciling towards
 var Version string
 
 func init() {
 	if value, exists := os.LookupEnv("OPERATOR_VERSION"); exists {
 		Version = value
 	} else {
-		panic("OPERATOR_VERSION not defined")
+		Version = "9.9.9"
 	}
 }
 

--- a/test/unit-tests/crds/cluster_management_addons.yaml
+++ b/test/unit-tests/crds/cluster_management_addons.yaml
@@ -1,0 +1,105 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clustermanagementaddons.addon.open-cluster-management.io
+spec:
+  group: addon.open-cluster-management.io
+  names:
+    kind: ClusterManagementAddOn
+    listKind: ClusterManagementAddOnList
+    plural: clustermanagementaddons
+    singular: clustermanagementaddon
+  scope: Cluster
+  preserveUnknownFields: false
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.addOnMeta.displayName
+          name: DISPLAY NAME
+          type: string
+        - jsonPath: .spec.addOnConfiguration.crdName
+          name: CRD NAME
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterManagementAddOn represents the registration of an add-on to the cluster manager. This resource allows the user to discover which add-on is available for the cluster manager and also provides metadata information about the add-on. This resource also provides a linkage to ManagedClusterAddOn, the name of the ClusterManagementAddOn resource will be used for the namespace-scoped ManagedClusterAddOn resource. ClusterManagementAddOn is a cluster-scoped resource.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec represents a desired configuration for the agent on the cluster management add-on.
+              type: object
+              properties:
+                addOnConfiguration:
+                  description: 'Deprecated: Use supportedConfigs filed instead addOnConfiguration is a reference to configuration information for the add-on. In scenario where a multiple add-ons share the same add-on CRD, multiple ClusterManagementAddOn resources need to be created and reference the same AddOnConfiguration.'
+                  type: object
+                  properties:
+                    crName:
+                      description: crName is the name of the CR used to configure instances of the managed add-on. This field should be configured if add-on CR have a consistent name across the all of the ManagedCluster instaces.
+                      type: string
+                    crdName:
+                      description: crdName is the name of the CRD used to configure instances of the managed add-on. This field should be configured if the add-on have a CRD that controls the configuration of the add-on.
+                      type: string
+                    lastObservedGeneration:
+                      description: lastObservedGeneration is the observed generation of the custom resource for the configuration of the addon.
+                      type: integer
+                      format: int64
+                addOnMeta:
+                  description: addOnMeta is a reference to the metadata information for the add-on.
+                  type: object
+                  properties:
+                    description:
+                      description: description represents the detailed description of the add-on.
+                      type: string
+                    displayName:
+                      description: displayName represents the name of add-on that will be displayed.
+                      type: string
+                supportedConfigs:
+                  description: supportedConfigs is a list of configuration types supported by add-on. An empty list means the add-on does not require configurations. The default is an empty list
+                  type: array
+                  items:
+                    description: ConfigMeta represents a collection of metadata information for add-on configuration.
+                    type: object
+                    required:
+                      - resource
+                    properties:
+                      defaultConfig:
+                        description: defaultConfig represents the namespace and name of the default add-on configuration. In scenario where all add-ons have a same configuration.
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: name of the add-on configuration.
+                            type: string
+                            minLength: 1
+                          namespace:
+                            description: namespace of the add-on configuration. If this field is not set, the configuration is in the cluster scope.
+                            type: string
+                      group:
+                        description: group of the add-on configuration.
+                        type: string
+                      resource:
+                        description: resource of the add-on configuration.
+                        type: string
+                        minLength: 1
+            status:
+              description: status represents the current status of cluster management add-on.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/unit-tests/crds/prometheusrules.yaml
+++ b/test/unit-tests/crds/prometheusrules.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: prometheusrules.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+    - prometheus-operator
+    kind: PrometheusRule
+    listKind: PrometheusRuleList
+    plural: prometheusrules
+    shortNames:
+    - promrule
+    singular: prometheusrule
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PrometheusRule defines recording and alerting rules for a Prometheus
+          instance
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of desired alerting rule definitions for Prometheus.
+            properties:
+              groups:
+                description: Content of Prometheus rule file
+                items:
+                  description: 'RuleGroup is a list of sequentially evaluated recording
+                    and alerting rules. Note: PartialResponseStrategy is only used
+                    by ThanosRuler and will be ignored by Prometheus instances.  Valid
+                    values for this field are ''warn'' or ''abort''.  More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response'
+                  properties:
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    partial_response_strategy:
+                      type: string
+                    rules:
+                      items:
+                        description: 'Rule describes an alerting or recording rule
+                          See Prometheus documentation: [alerting](https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+                          or [recording](https://www.prometheus.io/docs/prometheus/latest/configuration/recording_rules/#recording-rules)
+                          rule'
+                        properties:
+                          alert:
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          expr:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          for:
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          record:
+                            type: string
+                        required:
+                        - expr
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - rules
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/test/unit-tests/crds/service_monitor.yaml
+++ b/test/unit-tests/crds/service_monitor.yaml
@@ -1,10 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
 spec:
-  conversion:
-    strategy: None
   group: monitoring.coreos.com
   names:
     categories:
@@ -12,6 +13,8 @@ spec:
     kind: ServiceMonitor
     listKind: ServiceMonitorList
     plural: servicemonitors
+    shortNames:
+    - smon
     singular: servicemonitor
   scope: Namespaced
   versions:
@@ -21,187 +24,283 @@ spec:
         description: ServiceMonitor defines monitoring for a set of services.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specification of desired Service selection for target discovery by Prometheus.
+            description: Specification of desired Service selection for target discovery
+              by Prometheus.
             properties:
               endpoints:
                 description: A list of endpoints allowed as part of this ServiceMonitor.
                 items:
-                  description: Endpoint defines a scrapeable endpoint serving Prometheus metrics.
+                  description: Endpoint defines a scrapeable endpoint serving Prometheus
+                    metrics.
                   properties:
                     authorization:
                       description: Authorization section for this endpoint
                       properties:
                         credentials:
-                          description: The secret's key that contains the credentials of the request
+                          description: The secret's key that contains the credentials
+                            of the request
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         type:
-                          description: Set the authentication type. Defaults to Bearer, Basic will cause an error
+                          description: Set the authentication type. Defaults to Bearer,
+                            Basic will cause an error
                           type: string
                       type: object
                     basicAuth:
-                      description: 'BasicAuth allow an endpoint to authenticate over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                      description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
                       properties:
                         password:
-                          description: The secret in the service monitor namespace that contains the password for authentication.
+                          description: The secret in the service monitor namespace
+                            that contains the password for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace that contains the username for authentication.
+                          description: The secret in the service monitor namespace
+                            that contains the username for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenFile:
                       description: File to read bearer token for scraping targets.
                       type: string
                     bearerTokenSecret:
-                      description: Secret to mount to read bearer token for scraping targets. The secret needs to be in the same namespace as the service monitor and accessible by the Prometheus Operator.
+                      description: Secret to mount to read bearer token for scraping
+                        targets. The secret needs to be in the same namespace as the
+                        service monitor and accessible by the Prometheus Operator.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must be a valid secret key.
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must be defined
+                          description: Specify whether the Secret or its key must
+                            be defined
                           type: boolean
                       required:
                       - key
                       type: object
+                      x-kubernetes-map-type: atomic
+                    enableHttp2:
+                      description: Whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description: FollowRedirects configures whether scrape requests
+                        follow HTTP 3xx redirects.
+                      type: boolean
                     honorLabels:
-                      description: HonorLabels chooses the metric's labels on collisions with target labels.
+                      description: HonorLabels chooses the metric's labels on collisions
+                        with target labels.
                       type: boolean
                     honorTimestamps:
-                      description: HonorTimestamps controls whether Prometheus respects the timestamps present in scraped data.
+                      description: HonorTimestamps controls whether Prometheus respects
+                        the timestamps present in scraped data.
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped
+                      description: Interval at which metrics should be scraped If
+                        not specified Prometheus' global scrape interval is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
-                      description: MetricRelabelConfigs to apply to samples before ingestion.
+                      description: MetricRelabelConfigs to apply to samples before
+                        ingestion.
                       items:
-                        description: 'RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                        description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
-                            description: Action to perform based on regex matching. Default is 'replace'
+                            default: replace
+                            description: Action to perform based on regex matching.
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
-                            description: Modulus to take of the hash of the source label values.
+                            description: Modulus to take of the hash of the source
+                              label values.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted value is matched. Default is '(.*)'
+                            description: Regular expression against which the extracted
+                              value is matched. Default is '(.*)'
                             type: string
                           replacement:
-                            description: Replacement value against which a regex replace is performed if the regular expression matches. Regex capture groups are available. Default is '$1'
+                            description: Replacement value against which a regex replace
+                              is performed if the regular expression matches. Regex
+                              capture groups are available. Default is '$1'
                             type: string
                           separator:
-                            description: Separator placed between concatenated source label values. default is ';'.
+                            description: Separator placed between concatenated source
+                              label values. default is ';'.
                             type: string
                           sourceLabels:
-                            description: The source labels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.
+                            description: The source labels select values from existing
+                              labels. Their content is concatenated using the configured
+                              separator and matched against the configured regular
+                              expression for the replace, keep, and drop actions.
                             items:
+                              description: LabelName is a valid Prometheus label name
+                                which may only contain ASCII letters, numbers, as
+                                well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             type: array
                           targetLabel:
-                            description: Label to which the resulting value is written in a replace action. It is mandatory for replace actions. Regex capture groups are available.
+                            description: Label to which the resulting value is written
+                              in a replace action. It is mandatory for replace actions.
+                              Regex capture groups are available.
                             type: string
                         type: object
                       type: array
                     oauth2:
-                      description: OAuth2 for the URL. Only valid in Prometheus versions 2.27.0 and newer.
+                      description: OAuth2 for the URL. Only valid in Prometheus versions
+                        2.27.0 and newer.
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2 client id
+                          description: The secret or configmap containing the OAuth2
+                            client id
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the targets.
+                              description: ConfigMap containing data to use for the
+                                targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its key must be defined
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             secret:
                               description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key must be defined
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
                           description: The secret containing the OAuth2 client secret
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         endpointParams:
                           additionalProperties:
                             type: string
@@ -229,42 +328,88 @@ spec:
                       description: Optional HTTP URL parameters
                       type: object
                     path:
-                      description: HTTP path to scrape for metrics.
+                      description: HTTP path to scrape for metrics. If empty, Prometheus
+                        uses the default value (e.g. `/metrics`).
                       type: string
                     port:
-                      description: Name of the service port this endpoint refers to. Mutually exclusive with targetPort.
+                      description: Name of the service port this endpoint refers to.
+                        Mutually exclusive with targetPort.
                       type: string
                     proxyUrl:
-                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.
+                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                        to proxy through this endpoint.
                       type: string
                     relabelings:
-                      description: 'RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few standard Kubernetes fields and replaces original scrape job name with __tmp_prometheus_job_name. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      description: 'RelabelConfigs to apply to samples before scraping.
+                        Prometheus Operator automatically adds relabelings for a few
+                        standard Kubernetes fields. The original scrape job''s name
+                        is available via the `__tmp_prometheus_job_name` label. More
+                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
                       items:
-                        description: 'RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                        description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
-                            description: Action to perform based on regex matching. Default is 'replace'
+                            default: replace
+                            description: Action to perform based on regex matching.
+                              Default is 'replace'. uppercase and lowercase actions
+                              require Prometheus >= 2.36.
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
                             type: string
                           modulus:
-                            description: Modulus to take of the hash of the source label values.
+                            description: Modulus to take of the hash of the source
+                              label values.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted value is matched. Default is '(.*)'
+                            description: Regular expression against which the extracted
+                              value is matched. Default is '(.*)'
                             type: string
                           replacement:
-                            description: Replacement value against which a regex replace is performed if the regular expression matches. Regex capture groups are available. Default is '$1'
+                            description: Replacement value against which a regex replace
+                              is performed if the regular expression matches. Regex
+                              capture groups are available. Default is '$1'
                             type: string
                           separator:
-                            description: Separator placed between concatenated source label values. default is ';'.
+                            description: Separator placed between concatenated source
+                              label values. default is ';'.
                             type: string
                           sourceLabels:
-                            description: The source labels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.
+                            description: The source labels select values from existing
+                              labels. Their content is concatenated using the configured
+                              separator and matched against the configured regular
+                              expression for the replace, keep, and drop actions.
                             items:
+                              description: LabelName is a valid Prometheus label name
+                                which may only contain ASCII letters, numbers, as
+                                well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             type: array
                           targetLabel:
-                            description: Label to which the resulting value is written in a replace action. It is mandatory for replace actions. Regex capture groups are available.
+                            description: Label to which the resulting value is written
+                              in a replace action. It is mandatory for replace actions.
+                              Regex capture groups are available.
                             type: string
                         type: object
                       type: array
@@ -272,112 +417,147 @@ spec:
                       description: HTTP scheme to use for scraping.
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended
+                      description: Timeout after which the scrape is ended If not
+                        specified, the Prometheus global scrape timeout is used unless
+                        it is less than `Interval` in which the latter is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the target port of the Pod behind the Service, the port must be specified with container port property. Mutually exclusive with port.
+                      description: Name or number of the target port of the Pod behind
+                        the Service, the port must be specified with container port
+                        property. Mutually exclusive with port.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
                       description: TLS configuration to use when scraping the endpoint
                       properties:
                         ca:
-                          description: Struct containing the CA cert to use for the targets.
+                          description: Struct containing the CA cert to use for the
+                            targets.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the targets.
+                              description: ConfigMap containing data to use for the
+                                targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its key must be defined
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             secret:
                               description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key must be defined
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         caFile:
-                          description: Path to the CA cert in the Prometheus container to use for the targets.
+                          description: Path to the CA cert in the Prometheus container
+                            to use for the targets.
                           type: string
                         cert:
-                          description: Struct containing the client cert file for the targets.
+                          description: Struct containing the client cert file for
+                            the targets.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the targets.
+                              description: ConfigMap containing data to use for the
+                                targets.
                               properties:
                                 key:
                                   description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its key must be defined
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                             secret:
                               description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key must be defined
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         certFile:
-                          description: Path to the client cert file in the Prometheus container for the targets.
+                          description: Path to the client cert file in the Prometheus
+                            container for the targets.
                           type: string
                         insecureSkipVerify:
                           description: Disable target certificate validation.
                           type: boolean
                         keyFile:
-                          description: Path to the client key file in the Prometheus container for the targets.
+                          description: Path to the client key file in the Prometheus
+                            container for the targets.
                           type: string
                         keySecret:
-                          description: Secret containing the client key file for the targets.
+                          description: Secret containing the client key file for the
+                            targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
+                          x-kubernetes-map-type: atomic
                         serverName:
                           description: Used to verify the hostname for the targets.
                           type: string
@@ -385,57 +565,82 @@ spec:
                   type: object
                 type: array
               jobLabel:
-                description: "Chooses the label of the Kubernetes `Endpoints`. Its value will be used for the `job`-label's value of the created metrics. \n Default & fallback value: the name of the respective Kubernetes `Endpoint`."
+                description: "JobLabel selects the label from the associated Kubernetes
+                  service which will be used as the `job` label for all metrics. \n
+                  For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo:
+                  bar`, then the `job=\"bar\"` label is added to all metrics. \n If
+                  the value of this field is empty or if the label doesn't exist for
+                  the given Service, the `job` label of the metrics defaults to the
+                  name of the Kubernetes Service."
                 type: string
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: Per-scrape limit on number of labels that will be accepted
+                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: Per-scrape limit on length of labels name that will be
+                  accepted for a sample. Only valid in Prometheus versions 2.27.0
+                  and newer.
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will be accepted for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: Per-scrape limit on length of labels value that will
+                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
+                  and newer.
                 format: int64
                 type: integer
               namespaceSelector:
-                description: Selector to select which namespaces the Kubernetes Endpoints objects are discovered from.
+                description: Selector to select which namespaces the Kubernetes Endpoints
+                  objects are discovered from.
                 properties:
                   any:
-                    description: Boolean describing whether all namespaces are selected in contrast to a list restricting them.
+                    description: Boolean describing whether all namespaces are selected
+                      in contrast to a list restricting them.
                     type: boolean
                   matchNames:
-                    description: List of namespace names.
+                    description: List of namespace names to select from.
                     items:
                       type: string
                     type: array
                 type: object
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes `Pod` onto the created metrics.
+                description: PodTargetLabels transfers labels on the Kubernetes `Pod`
+                  onto the created metrics.
                 items:
                   type: string
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
+                description: SampleLimit defines per-scrape limit on number of scraped
+                  samples that will be accepted.
                 format: int64
                 type: integer
               selector:
                 description: Selector to select Endpoints objects.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -447,16 +652,23 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               targetLabels:
-                description: TargetLabels transfers labels from the Kubernetes `Service` onto the created metrics. All labels set in `selector.matchLabels` are automatically transferred.
+                description: TargetLabels transfers labels from the Kubernetes `Service`
+                  onto the created metrics.
                 items:
                   type: string
                 type: array
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped targets that will be accepted.
+                description: TargetLimit defines a limit on the number of scraped
+                  targets that will be accepted.
                 format: int64
                 type: integer
             required:


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/25585

Moves source-of-truth for MCH GRC templates from https://github.com/stolostron/multiclusterhub-repo/tree/main/multiclusterhub/charts/grc and CRDs from https://github.com/stolostron/hub-crds/tree/main/crds/grc-chart to this repo.

Templates changelog:
```
REMOVE _helpers.tpl
{{ .Release.Name }} -> grc (was grc-93feb)
{{ .Release.Namespace }} -> {{ .Values.global.namespace }}
{{ template "grc.name" . }} -> grc (was grc)
{{ template "grc.chart" . }} -> grc-chart-x.y.z (was grc-2.7.0)
REMOVE `heritage: {{ .Release.Service }}` (was Helm)
REMOVE `app.kubernetes.io/managed-by: {{ .Release.Service }}` (was Helm)
REMOVE `helm.sh/chart: {{ template "grc.chart" . }}`
REPLACE `{{- toYaml .Values.arch | nindent 18}}` with actual values
REPLACE `{{- with .Values.hubconfig.tolerations }}` with new tolerations template format
REPLACE `{{- toYaml .Values.governance.resources | nindent 10 }}` with actual values
{{- if .Values.pullSecret }} -> {{- if .Values.global.pullSecret }} 
```