### PR TITLE
Render console chart directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ vet: ## Run go vet against code.
 test-prep: update-crds manifests generate fmt vet envtest ## prepare to run tests.
 	echo "Ready to run unit tests"
 
-test: envtest ## Run tests.
+test: update-crds manifests generate fmt vet envtest ## Run tests.
 	OPERATOR_VERSION=9.9.9 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 	  go test $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ vet: ## Run go vet against code.
 test-prep: update-crds manifests generate fmt vet envtest ## prepare to run tests.
 	echo "Ready to run unit tests"
 
-test: update-crds manifests generate fmt vet envtest ## Run tests.
+test: envtest ## Run tests.
 	OPERATOR_VERSION=9.9.9 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 	  go test $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
 

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -484,6 +484,7 @@ spec:
           - console.openshift.io
           - search.open-cluster-management.io
           resources:
+          - consolelinks
           - consoleplugins
           - searches
           verbs:
@@ -511,6 +512,18 @@ spec:
           - multicluster.openshift.io
           resources:
           - multiclusterengines
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -374,6 +374,7 @@ rules:
   - console.openshift.io
   - search.open-cluster-management.io
   resources:
+  - consolelinks
   - consoleplugins
   - searches
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -411,6 +411,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - operator.openshift.io
   resources:
   - consoles

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -389,10 +389,8 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 	if multiClusterHub.Enabled(operatorv1.Console) {
-		// result, err = r.ensureSubscription(multiClusterHub, subscription.Console(multiClusterHub, r.CacheSpec.ImageOverrides, r.CacheSpec.IngressDomain))
 		result, err = r.ensureConsole(ctx, multiClusterHub, r.CacheSpec.ImageOverrides)
 	} else {
-		// result, err = r.ensureNoSubscription(multiClusterHub, subscription.Console(multiClusterHub, r.CacheSpec.ImageOverrides, r.CacheSpec.IngressDomain))
 		result, err = r.ensureNoConsole(ctx, multiClusterHub, r.CacheSpec.ImageOverrides)
 	}
 	if result != (ctrl.Result{}) {

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -109,6 +109,8 @@ var (
 //+kubebuilder:rbac:groups=packages.operators.coreos.com,resources=packagemanifests,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=create;delete;get;list;watch;update;patch
 
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=create;delete;get;list;watch;update;patch
+
 // AgentServiceConfig webhook delete check
 //+kubebuilder:rbac:groups=agent-install.openshift.io,resources=agentserviceconfigs,verbs=get;list;watch
 

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -1009,6 +1009,10 @@ func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operat
 	if err != nil {
 		return err
 	}
+	_, err = r.ensureNoConsole(context.TODO(), m, r.CacheSpec.ImageOverrides)
+	if err != nil {
+		return err
+	}
 	_, err = r.ensureNoSearchV2(context.TODO(), m, r.CacheSpec.ImageOverrides)
 	if err != nil {
 		return err

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -37,6 +37,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -338,6 +339,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 		Expect(consolev1.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(olmapi.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(ocmapi.AddToScheme(clientScheme)).Should(Succeed())
+		Expect(networking.AddToScheme(clientScheme)).Should(Succeed())
 
 		k8sManager, err := ctrl.NewManager(clientConfig, ctrl.Options{
 			Scheme:                 clientScheme,

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -25,6 +25,7 @@ import (
 	searchv2v1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 	ocmapi "open-cluster-management.io/api/addon/v1alpha1"
 	policy "open-cluster-management.io/governance-policy-propagator/api/v1"
+	channel "open-cluster-management.io/multicloud-operators-channel/pkg/apis"
 	appsub "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 
@@ -326,6 +327,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 		Expect(promv1.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(mchov1.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(appsub.AddToScheme(clientScheme)).Should(Succeed())
+		Expect(channel.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(apiregistrationv1.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(apixv1.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(netv1.AddToScheme(clientScheme)).Should(Succeed())

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -581,6 +581,18 @@ var _ = Describe("MultiClusterHub controller", func() {
 			result, err = reconciler.ensureNoGRC(ctx, mch, testImages)
 			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).To(BeNil())
+
+			By("Ensuring Console")
+
+			result, err = reconciler.ensureConsole(ctx, mch, testImages)
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).To(BeNil())
+
+			By("Ensuring No Console")
+
+			result, err = reconciler.ensureNoConsole(ctx, mch, testImages)
+			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(err).To(BeNil())
 		})
 	})
 

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -116,6 +116,10 @@ var (
 				types.NamespacedName{Name: "grc-sub", Namespace: m.Namespace},
 				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
 			),
+			newUnstructured(
+				types.NamespacedName{Name: "console-chart-sub", Namespace: m.Namespace},
+				schema.GroupVersionKind{Group: "apps.open-cluster-management.io", Kind: "Subscription", Version: "v1"},
+			),
 		}
 		return removals
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
 	k8s.io/kube-aggregator v0.24.3
+	open-cluster-management.io/api v0.8.0
 	open-cluster-management.io/governance-policy-propagator v0.8.0
 	open-cluster-management.io/multicloud-operators-channel v0.8.0
 	open-cluster-management.io/multicloud-operators-subscription v0.8.0
@@ -111,7 +112,6 @@ require (
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
 	k8s.io/utils v0.0.0-20220725171434-9bab9ef40391 // indirect
-	open-cluster-management.io/api v0.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
 	k8s.io/kube-aggregator v0.24.3
-	open-cluster-management.io/api v0.8.0
 	open-cluster-management.io/governance-policy-propagator v0.8.0
+	open-cluster-management.io/multicloud-operators-channel v0.8.0
 	open-cluster-management.io/multicloud-operators-subscription v0.8.0
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/yaml v1.3.0
@@ -111,12 +111,9 @@ require (
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
 	k8s.io/utils v0.0.0-20220725171434-9bab9ef40391 // indirect
-	open-cluster-management.io/multicloud-operators-channel v0.8.0 // indirect
+	open-cluster-management.io/api v0.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 
-replace (
-	k8s.io/client-go => k8s.io/client-go v0.24.1
-	open-cluster-management.io/multicloud-operators-subscription => github.com/stolostron/multicloud-operators-subscription v0.0.0-20220310201446-9989c4301546
-)
+replace k8s.io/client-go => k8s.io/client-go v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,6 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/backplane-operator v0.0.0-20220727154840-1f60baf1fb98 h1:fb77iXzaY4kud+wPqNPT6UgvPITK9q+O1D5FeUJ6qP0=
 github.com/stolostron/backplane-operator v0.0.0-20220727154840-1f60baf1fb98/go.mod h1:IGZxghtPz8rJylGtW8XUAQdlqRai2j7aL4ymOINsP/c=
-github.com/stolostron/multicloud-operators-subscription v0.0.0-20220310201446-9989c4301546 h1:/bqhtsFxzVB7gr43HMObkaT4hTmw+cpQcPMwVWgcuyE=
-github.com/stolostron/multicloud-operators-subscription v0.0.0-20220310201446-9989c4301546/go.mod h1:kb5wASyZUizaKxXXf4m1Cdf/IRnYtXjnJyAHEO4YYRU=
 github.com/stolostron/search-v2-operator v0.0.0-20220721051905-143d28ab4f10 h1:USGd9WwtGqAflJ0sY7k41hCO5L5BuYaPElmAsZm/q4M=
 github.com/stolostron/search-v2-operator v0.0.0-20220721051905-143d28ab4f10/go.mod h1:o73lDVENck8rRBnjt+PmbDer0MyMq2LQ7g8FsqQbQuw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1718,6 +1716,8 @@ open-cluster-management.io/governance-policy-propagator v0.8.0 h1:rWDHz4JglAq3/5
 open-cluster-management.io/governance-policy-propagator v0.8.0/go.mod h1:cHcn2tv8bUUFDIY0KcZmx5MskEFn2RoAm90oQAIPFMA=
 open-cluster-management.io/multicloud-operators-channel v0.8.0 h1:2Cr7AiIWc4maVnhBI2MagNc1YF3UU/VHHCrlSpG3Yr8=
 open-cluster-management.io/multicloud-operators-channel v0.8.0/go.mod h1:E2Y3/mDp+U6glXp+LMn27ViRJ4BsHwJ6QzDLeENEJmc=
+open-cluster-management.io/multicloud-operators-subscription v0.8.0 h1:0YRrUErVU6K6xwExGNaCMF//FOfJT6XyeHAvSbZNEiY=
+open-cluster-management.io/multicloud-operators-subscription v0.8.0/go.mod h1:R83lMSoaMfs3T1Z3ApRjfioA9AgPMzam+CS6XbO5FjU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/letsencrypt v0.0.3 h1:H7xDfhkaFFSYEJlKeq38RwX2jYcnTeHuDQyT+mMNMwM=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	policy "open-cluster-management.io/governance-policy-propagator/api/v1"
+	channel "open-cluster-management.io/multicloud-operators-channel/pkg/apis"
 	appsubv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -86,6 +87,8 @@ func init() {
 	utilruntime.Must(policy.AddToScheme(scheme))
 
 	utilruntime.Must(appsubv1.AddToScheme(scheme))
+
+	utilruntime.Must(channel.AddToScheme(scheme))
 
 	utilruntime.Must(apiregistrationv1.AddToScheme(scheme))
 

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/stolostron/multiclusterhub-operator/controllers"
 	"github.com/stolostron/multiclusterhub-operator/pkg/webhook"
 	searchv2v1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
+	networking "k8s.io/api/networking/v1"
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -109,6 +110,8 @@ func init() {
 	utilruntime.Must(consolev1.AddToScheme(scheme))
 
 	utilruntime.Must(olmapi.AddToScheme(scheme))
+
+	utilruntime.Must(networking.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -47,12 +47,14 @@ type Global struct {
 }
 
 type HubConfig struct {
-	NodeSelector map[string]string `json:"nodeSelector" structs:"nodeSelector"`
-	ProxyConfigs map[string]string `json:"proxyConfigs" structs:"proxyConfigs"`
-	ReplicaCount int               `json:"replicaCount" structs:"replicaCount"`
-	Tolerations  []Toleration      `json:"tolerations" structs:"tolerations"`
-	OCPVersion   string            `json:"ocpVersion" structs:"ocpVersion"`
-	HubVersion   string            `json:"hubVersion" structs:"hubVersion"`
+	NodeSelector      map[string]string `json:"nodeSelector" structs:"nodeSelector"`
+	ProxyConfigs      map[string]string `json:"proxyConfigs" structs:"proxyConfigs"`
+	ReplicaCount      int               `json:"replicaCount" structs:"replicaCount"`
+	Tolerations       []Toleration      `json:"tolerations" structs:"tolerations"`
+	OCPVersion        string            `json:"ocpVersion" structs:"ocpVersion"`
+	HubVersion        string            `json:"hubVersion" structs:"hubVersion"`
+	OCPIngress        string            `json:"ocpIngress" structs:"ocpIngress"`
+	SubscriptionPause string            `json:"subscriptionPause" structs:"subscriptionPause"`
 }
 
 type Toleration struct {
@@ -306,11 +308,15 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 
 	values.HubConfig.Tolerations = convertTolerations(utils.GetTolerations(mch))
 
+	values.HubConfig.OCPVersion = os.Getenv("ACM_HUB_OCP_VERSION")
+
 	values.HubConfig.HubVersion = version.Version
 
-	values.Org = "open-cluster-management"
+	values.HubConfig.OCPIngress = os.Getenv("INGRESS_DOMAIN")
 
-	values.HubConfig.OCPVersion = os.Getenv("ACM_HUB_OCP_VERSION")
+	values.HubConfig.SubscriptionPause = utils.GetDisableClusterImageSets(mch)
+
+	values.Org = "open-cluster-management"
 
 	values.HubConfig.HubVersion = version.Version
 

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -318,8 +318,6 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 
 	values.Org = "open-cluster-management"
 
-	values.HubConfig.HubVersion = version.Version
-
 	if utils.ProxyEnvVarsAreSet() {
 		proxyVar := map[string]string{}
 		proxyVar["HTTP_PROXY"] = os.Getenv("HTTP_PROXY")

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -306,6 +306,8 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 
 	values.HubConfig.Tolerations = convertTolerations(utils.GetTolerations(mch))
 
+	values.HubConfig.HubVersion = version.Version
+
 	values.Org = "open-cluster-management"
 
 	values.HubConfig.OCPVersion = os.Getenv("ACM_HUB_OCP_VERSION")

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -278,7 +278,7 @@ func renderTemplates(chartPath string, mch *v1.MultiClusterHub, images map[strin
 
 		// Add namespace to namespaced resources
 		switch unstructured.GetKind() {
-		case "Deployment", "ServiceAccount", "Role", "RoleBinding", "Service", "ConfigMap":
+		case "Deployment", "ServiceAccount", "Role", "RoleBinding", "Service", "ConfigMap", "Ingress", "Channel", "Subscription":
 			if unstructured.GetNamespace() == "" {
 				unstructured.SetNamespace(mch.Namespace)
 			}

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -29,6 +29,7 @@ var chartPaths = []string{
 	utils.SearchV2ChartLocation,
 	utils.CLCChartLocation,
 	utils.GRCChartLocation,
+	utils.ConsoleChartLocation,
 }
 
 func TestRender(t *testing.T) {

--- a/pkg/templates/charts/toggle/console/Chart.yaml
+++ b/pkg/templates/charts/toggle/console/Chart.yaml
@@ -1,0 +1,13 @@
+# Licensed Materials - Property of IBM
+# (C) Copyright IBM Corporation 2016, 2019 All Rights Reserved
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: v1
+appVersion: "2.0.0"
+description: Helm chart for Open Cluster Management Console
+name: console-chart
+version: 2.4.0
+category: "Development"
+kubeVersion: ">=1.10.0-0"
+keywords:
+  - ui

--- a/pkg/templates/charts/toggle/console/templates/channel.yaml
+++ b/pkg/templates/charts/toggle/console/templates/channel.yaml
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Open Cluster Management project
+
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: acm-hive-openshift-releases-chn-0
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: low
+spec:
+  type: Git
+  pathname: {{ .Values.clusterImageSets.acmHiveOpenshiftReleaseUrl }}
+  # Disable when using a Public repository
+  #secretRef:
+  #  name: my-github-secret

--- a/pkg/templates/charts/toggle/console/templates/channel.yaml
+++ b/pkg/templates/charts/toggle/console/templates/channel.yaml
@@ -9,7 +9,7 @@ metadata:
     apps.open-cluster-management.io/reconcile-rate: low
 spec:
   type: Git
-  pathname: {{ .Values.clusterImageSets.acmHiveOpenshiftReleaseUrl }}
+  pathname: https://github.com/stolostron/acm-hive-openshift-releases.git
   # Disable when using a Public repository
   #secretRef:
   #  name: my-github-secret

--- a/pkg/templates/charts/toggle/console/templates/channel.yaml
+++ b/pkg/templates/charts/toggle/console/templates/channel.yaml
@@ -1,6 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
 
----
 apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
@@ -11,5 +10,5 @@ spec:
   type: Git
   pathname: https://github.com/stolostron/acm-hive-openshift-releases.git
   # Disable when using a Public repository
-  #secretRef:
+  # secretRef:
   #  name: my-github-secret

--- a/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrole.yaml
@@ -1,10 +1,9 @@
-# Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:aggregate-clusterimagesets-readonly
+  name: open-cluster-management:console:aggregate-clusterimagesets-readonly
   labels:
     # Add these permissions to the "view" default role.
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrole.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:aggregate-clusterimagesets-readonly
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["hive.openshift.io"]
+  resources: ["clusterimagesets"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrole.yaml
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
----
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
----
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:readonly-clusterimagesets
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}:{{ .Release.Name }}:aggregate-clusterimagesets-readonly
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/console/templates/clusterimageset-clusterrolebinding.yaml
@@ -1,15 +1,14 @@
-# Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:readonly-clusterimagesets
+  name: open-cluster-management:console:readonly-clusterimagesets
 subjects:
 - kind: Group
   name: system:authenticated
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:aggregate-clusterimagesets-readonly
+  name: open-cluster-management:console:aggregate-clusterimagesets-readonly
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
----
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
@@ -1,19 +1,15 @@
-# Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  name: open-cluster-management:console:clusterrole
   labels:
-    app: {{ template "console.name" . }}
-    chart: {{ template "console.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "console.name" . }}
-    helm.sh/chart: {{ template "console.chart" . }}
+    app: console-chart
+    chart: console-chart-{{ .Values.hubconfig.hubVersion }}
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
     component: clusterrole
 
 rules:

--- a/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
@@ -1,0 +1,256 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  labels:
+    app: {{ template "console.name" . }}
+    chart: {{ template "console.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "console.name" . }}
+    helm.sh/chart: {{ template "console.chart" . }}
+    component: clusterrole
+
+rules:
+
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - operator.open-cluster-management.io
+  resources:
+  - multiclusterhubs
+  verbs:
+  - get
+  - list
+  - watch
+
+- verbs:
+  - list
+  - get
+  - watch
+  apiGroups:
+  - config.openshift.io
+  - console.openshift.io
+  - project.openshift.io
+  - tower.ansible.com
+  resources:
+  - infrastructures
+  - consolelinks
+  - projects
+  - featuregates
+  - ansiblejobs
+
+- verbs:
+  - list
+  apiGroups:
+  - ''
+  resources:
+  - services
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - ''
+  resources:
+  - configmaps
+  - jobs
+  - namespaces
+  - pods
+  - secrets
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - inventory.open-cluster-management.io
+  resources:
+  - baremetalassets
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterclaims
+  - clusterdeployments
+  - clusterpools
+  - clusterimagesets
+  - clusterprovisions
+  - clusterdeprovisions
+  - machinepools
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - clustermanagementaddons
+  - managedclusteraddons
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  - managedclustersets
+  - managedclustersetbindings
+  - clustercurators
+  - placements
+  - placementdecisions
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - internal.open-cluster-management.io
+  resources:
+  - managedclusterinfos
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - discovery.open-cluster-management.io
+  resources:
+  - discoveryconfigs
+  - discoveredclusters
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - wgpolicyk8s.io
+  resources:
+  - policyreports
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - submarineraddon.open-cluster-management.io
+  resources:
+  - submarinerconfigs
+  
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  - infraenvs
+  - nmstateconfigs
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  - provisionings
+
+- apiGroups:
+  - policy.open-cluster-management.io
+  - app.k8s.io
+  - apps.open-cluster-management.io
+  - argoproj.io
+  resources:
+  - applications
+  - applicationsets
+  - appprojects
+  - argocds
+  - channels
+  - gitopsclusters
+  - helmreleases
+  - placementrules
+  - placementbindings
+  - policies
+  - policyautomations
+  - policysets
+  - subscriptions
+  - subscriptionreports
+  verbs:
+  - list
+  - watch
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - console.open-cluster-management.io
+  resources:
+  - userpreferences
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  - nodepools
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - capi-provider.agent-install.openshift.io
+  resources:
+  - agentmachines
+
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  
+- apiGroups:
+  - multicluster.openshift.io
+  verbs:
+  - list
+  - watch
+  resources:
+  - multiclusterengines

--- a/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
@@ -15,8 +15,8 @@ metadata:
     component: clusterrolebinding
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.fullname }}
-  namespace: {{ .Release.Namespace }}
+  name: console-chart
+  namespace: {{ .Values.global.namespace }}
 roleRef:
   kind: ClusterRole
   name: open-cluster-management:console:clusterrole

--- a/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
@@ -5,22 +5,19 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrolebinding
+  name: open-cluster-management:console:clusterrolebinding
   labels:
-    app: {{ template "console.name" . }}
-    chart: {{ template "console.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "console.name" . }}
-    helm.sh/chart: {{ template "console.chart" . }}
+    app: console-chart
+    chart: console-chart-{{ .Values.hubconfig.hubVersion }}
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
     component: clusterrolebinding
 subjects:
 - kind: ServiceAccount
-  name: {{ template "console.fullname" . }}
+  name: {{ .Values.fullname }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  name: open-cluster-management:console:clusterrole
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrolebinding.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrolebinding
+  labels:
+    app: {{ template "console.name" . }}
+    chart: {{ template "console.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "console.name" . }}
+    helm.sh/chart: {{ template "console.chart" . }}
+    component: clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: {{ template "console.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/templates/charts/toggle/console/templates/console-configmap.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-configmap.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: console-config
+  labels:
+    app: console
+    component: "console"
+    chart: {{ template "console.chart" . }}
+    release: {{ template "console.fullname" . }}
+    heritage: {{ .Release.Service }}
+data:
+  LOG_LEVEL: info
+  ansibleIntegration: disabled
+  singleNodeOpenshift: disabled
+  

--- a/pkg/templates/charts/toggle/console/templates/console-configmap.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     app: console
     component: "console"
     chart: console-chart-{{ .Values.hubconfig.hubVersion }}
-    release: {{ .Values.fullname }}
+    release: console-chart
 data:
   LOG_LEVEL: info
   ansibleIntegration: disabled

--- a/pkg/templates/charts/toggle/console/templates/console-configmap.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-configmap.yaml
@@ -8,9 +8,8 @@ metadata:
   labels:
     app: console
     component: "console"
-    chart: {{ template "console.chart" . }}
-    release: {{ template "console.fullname" . }}
-    heritage: {{ .Release.Service }}
+    chart: console-chart-{{ .Values.hubconfig.hubVersion }}
+    release: {{ .Values.fullname }}
 data:
   LOG_LEVEL: info
   ansibleIntegration: disabled

--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -97,7 +97,9 @@ spec:
         image: {{ .Values.global.imageOverrides.console }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
-        {{- toYaml .Values.console.resources | nindent 10 }}
+        requests:
+          memory: "40Mi"
+          cpu: "3m"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.fullname }}-console-v2
+  name: console-chart-console-v2
   labels:
     app: console-chart-v2
     chart: console-chart-{{ .Values.hubconfig.hubVersion }}
@@ -33,7 +33,7 @@ spec:
       hostNetwork: false
       hostPID: false
       hostIPC: false
-      serviceAccountName: {{ .Values.fullname }}
+      serviceAccountName: console-chart
       securityContext:
         runAsNonRoot: true
       affinity:
@@ -44,9 +44,10 @@ spec:
               - key: kubernetes.io/arch
                 operator: In
                 values:
-                {{- range .Values.arch }}
-                - {{ . }}
-                {{- end }}
+                - amd64
+                - ppc64le
+                - s390x
+                - arm64
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 70
@@ -77,29 +78,35 @@ spec:
                   - console
       {{- with .Values.hubconfig.tolerations }}
       tolerations:
-      {{- toYaml . | nindent 8 }}
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
       {{- end }}
       volumes:
-      - name: {{ .Values.fullname }}-console-certs
+      - name: console-chart-console-certs
         secret:
           defaultMode: 420
-          secretName: {{ .Values.fullname }}-console-certs
-      - name: {{ .Values.fullname }}-console-config
+          secretName: console-chart-console-certs
+      - name: console-chart-console-config
         configMap:
           name: console-config
       containers:
       - name: console
         volumeMounts:
         - mountPath: /app/certs
-          name: {{ .Values.fullname }}-console-certs
+          name: console-chart-console-certs
         - mountPath: /app/config
-          name: {{ .Values.fullname }}-console-config
+          name: console-chart-console-config
         image: {{ .Values.global.imageOverrides.console }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
-        requests:
-          memory: "40Mi"
-          cpu: "3m"
+          requests:
+            memory: "40Mi"
+            cpu: "3m"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -111,9 +118,9 @@ spec:
         - name: PORT
           value: "3000"
         - name: FRONTEND_URL
-          value: "https://multicloud-console.{{ .Values.ocpingress }}/multicloud"
+          value: "https://multicloud-console.{{ .Values.hubconfig.ocpIngress }}/multicloud"
         - name: BACKEND_URL
-          value: "https://multicloud-console.{{ .Values.ocpingress }}/multicloud"
+          value: "https://multicloud-console.{{ .Values.hubconfig.ocpIngress }}/multicloud"
         - name: CLUSTER_API_URL
           value: https://kubernetes.default.svc:443
         {{- if .Values.hubconfig.proxyConfigs }}

--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -1,0 +1,154 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "console.fullname" . }}-console-v2
+  labels:
+    app: {{ template "console.name" . }}-v2
+    chart: {{ template "console.chart" . }}
+    component: "console"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "console.name" . }}
+    helm.sh/chart: {{ template "console.chart" . }}
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "console.name" . }}-v2
+      component: "console"
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "console.name" . }}-v2
+        ocm-antiaffinity-selector: "console"
+        component: "console"
+        release: {{ .Release.Name }}
+        chart: {{ template "console.chart" . }}
+        heritage: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ template "console.name" . }}
+        helm.sh/chart: {{ template "console.chart" . }}
+    spec:
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      serviceAccountName: {{ template "console.fullname" . }}
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                {{- range .Values.arch }}
+                - {{ . }}
+                {{- end }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - console
+                - key: component
+                  operator: In
+                  values:
+                  - console
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - console
+                - key: component
+                  operator: In
+                  values:
+                  - console
+      {{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: {{ template "console.fullname" . }}-console-certs
+        secret:
+          defaultMode: 420
+          secretName: {{ template "console.fullname" . }}-console-certs
+      - name: {{ template "console.fullname" . }}-console-config
+        configMap:
+          name: console-config
+      containers:
+      - name: console
+        volumeMounts:
+        - mountPath: /app/certs
+          name: {{ template "console.fullname" . }}-console-certs
+        - mountPath: /app/config
+          name: {{ template "console.fullname" . }}-console-config
+        image: {{ .Values.global.imageOverrides.console }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        resources:
+        {{- toYaml .Values.console.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        env:
+        - name: PORT
+          value: "3000"
+        - name: FRONTEND_URL
+          value: "https://multicloud-console.{{ .Values.ocpingress }}/multicloud"
+        - name: BACKEND_URL
+          value: "https://multicloud-console.{{ .Values.ocpingress }}/multicloud"
+        - name: CLUSTER_API_URL
+          value: https://kubernetes.default.svc:443
+        {{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readinessProbe
+            port: 3000
+            scheme: HTTPS
+          failureThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /livenessProbe
+            port: 3000
+            scheme: HTTPS
+          failureThreshold: 1
+          initialDelaySeconds: 10
+      {{- if .Values.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.pullSecret }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -4,42 +4,36 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "console.fullname" . }}-console-v2
+  name: {{ .Values.fullname }}-console-v2
   labels:
-    app: {{ template "console.name" . }}-v2
-    chart: {{ template "console.chart" . }}
+    app: console-chart-v2
+    chart: console-chart-{{ .Values.hubconfig.hubVersion }}
     component: "console"
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "console.name" . }}
-    helm.sh/chart: {{ template "console.chart" . }}
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
 spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "console.name" . }}-v2
+      app: console-chart-v2
       component: "console"
-      release: {{ .Release.Name }}
+      release: console
   template:
     metadata:
       labels:
-        app: {{ template "console.name" . }}-v2
+        app: console-chart-v2
         ocm-antiaffinity-selector: "console"
         component: "console"
-        release: {{ .Release.Name }}
-        chart: {{ template "console.chart" . }}
-        heritage: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/name: {{ template "console.name" . }}
-        helm.sh/chart: {{ template "console.chart" . }}
+        release: console
+        chart: console-chart-{{ .Values.hubconfig.hubVersion }}
+        app.kubernetes.io/instance: console
+        app.kubernetes.io/name: console-chart
     spec:
       hostNetwork: false
       hostPID: false
       hostIPC: false
-      serviceAccountName: {{ template "console.fullname" . }}
+      serviceAccountName: {{ .Values.fullname }}
       securityContext:
         runAsNonRoot: true
       affinity:
@@ -86,20 +80,20 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ template "console.fullname" . }}-console-certs
+      - name: {{ .Values.fullname }}-console-certs
         secret:
           defaultMode: 420
-          secretName: {{ template "console.fullname" . }}-console-certs
-      - name: {{ template "console.fullname" . }}-console-config
+          secretName: {{ .Values.fullname }}-console-certs
+      - name: {{ .Values.fullname }}-console-config
         configMap:
           name: console-config
       containers:
       - name: console
         volumeMounts:
         - mountPath: /app/certs
-          name: {{ template "console.fullname" . }}-console-certs
+          name: {{ .Values.fullname }}-console-certs
         - mountPath: /app/config
-          name: {{ template "console.fullname" . }}-console-config
+          name: {{ .Values.fullname }}-console-config
         image: {{ .Values.global.imageOverrides.console }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
@@ -144,9 +138,9 @@ spec:
             scheme: HTTPS
           failureThreshold: 1
           initialDelaySeconds: 10
-      {{- if .Values.pullSecret }}
+      {{- if .Values.global.pullSecret }}
       imagePullSecrets:
-      - name: {{ .Values.pullSecret }}
+      - name: {{ .Values.global.pullSecret }}
       {{- end }}
       {{- with .Values.hubconfig.nodeSelector }}
       nodeSelector:

--- a/pkg/templates/charts/toggle/console/templates/console-ingress.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-ingress.yaml
@@ -8,30 +8,27 @@ metadata:
     ingress.open-cluster-management.io/auth-type: access-token
     ingress.open-cluster-management.io/secure-backends: "true"
     kubernetes.io/ingress.class: ingress-open-cluster-management
-  name: {{ template "console.fullname" . }}-console-v2
+  name: {{ .Values.fullname }}-console-v2
   labels:
-    app: {{ template "console.name" . }}-v2
-    chart: {{ template "console.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "console.name" . }}
-    helm.sh/chart: {{ template "console.chart" . }}
+    app: console-chart-v2
+    chart: console-chart-{{ .Values.hubconfig.hubVersion }}
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
 spec:
   rules:
   - http:
       paths:
       - backend:
           service:
-            name: {{ template "console.fullname" . }}-console-v2
+            name: {{ .Values.fullname }}-console-v2
             port:
               number: 3000
         path: /multicloud
         pathType: ImplementationSpecific
       - backend:
           service:
-            name: {{ template "console.fullname" . }}-console-v2
+            name: {{ .Values.fullname }}-console-v2
             port:
               number: 3000
         path: /

--- a/pkg/templates/charts/toggle/console/templates/console-ingress.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-ingress.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.open-cluster-management.io/auth-type: access-token
+    ingress.open-cluster-management.io/secure-backends: "true"
+    kubernetes.io/ingress.class: ingress-open-cluster-management
+  name: {{ template "console.fullname" . }}-console-v2
+  labels:
+    app: {{ template "console.name" . }}-v2
+    chart: {{ template "console.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "console.name" . }}
+    helm.sh/chart: {{ template "console.chart" . }}
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: {{ template "console.fullname" . }}-console-v2
+            port:
+              number: 3000
+        path: /multicloud
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: {{ template "console.fullname" . }}-console-v2
+            port:
+              number: 3000
+        path: /
+        pathType: ImplementationSpecific

--- a/pkg/templates/charts/toggle/console/templates/console-ingress.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     ingress.open-cluster-management.io/auth-type: access-token
     ingress.open-cluster-management.io/secure-backends: "true"
     kubernetes.io/ingress.class: ingress-open-cluster-management
-  name: {{ .Values.fullname }}-console-v2
+  name: console-chart-console-v2
   labels:
     app: console-chart-v2
     chart: console-chart-{{ .Values.hubconfig.hubVersion }}
@@ -21,14 +21,14 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ .Values.fullname }}-console-v2
+            name: console-chart-console-v2
             port:
               number: 3000
         path: /multicloud
         pathType: ImplementationSpecific
       - backend:
           service:
-            name: {{ .Values.fullname }}-console-v2
+            name: console-chart-console-v2
             port:
               number: 3000
         path: /

--- a/pkg/templates/charts/toggle/console/templates/console-link.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-link.yaml
@@ -5,9 +5,9 @@ kind: ConsoleLink
 metadata:
   name: acm-console-link
 spec:
-  href: https://multicloud-console.{{ .Values.ocpingress }}
+  href: https://multicloud-console.{{ .Values.hubconfig.ocpIngress }}
   location: ApplicationMenu
   text: Red Hat Advanced Cluster Management for Kubernetes
   applicationMenu:
     section: Red Hat applications
-    imageURL: https://multicloud-console.{{ .Values.ocpingress }}/multicloud/favicon.svg
+    imageURL: https://multicloud-console.{{ .Values.hubconfig.ocpIngress }}/multicloud/favicon.svg

--- a/pkg/templates/charts/toggle/console/templates/console-link.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-link.yaml
@@ -1,0 +1,13 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: acm-console-link
+spec:
+  href: https://multicloud-console.{{ .Values.ocpingress }}
+  location: ApplicationMenu
+  text: Red Hat Advanced Cluster Management for Kubernetes
+  applicationMenu:
+    section: Red Hat applications
+    imageURL: https://multicloud-console.{{ .Values.ocpingress }}/multicloud/favicon.svg

--- a/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
@@ -1,4 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
+
 apiVersion: console.openshift.io/v1alpha1
 kind: ConsolePlugin
 metadata:

--- a/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
@@ -1,5 +1,4 @@
 # Copyright Contributors to the Open Cluster Management project
-{{- if include "dynamicPlugins.supported" . }}
 apiVersion: console.openshift.io/v1alpha1
 kind: ConsolePlugin
 metadata:
@@ -12,13 +11,13 @@ spec:
     - type: Service
       alias: console
       service:
-        name: {{ .Values.fullname }}-console-v2
-        namespace: {{ .Release.Namespace }}
+        name: console-chart-console-v2
+        namespace: {{ .Values.global.namespace }}
         port: 3000
       authorize: true
   service:
     basePath: /plugin/
-    name: {{ .Values.fullname }}-console-v2
-    namespace: {{ .Release.Namespace }}
+    name: console-chart-console-v2
+    namespace: {{ .Values.global.namespace }}
     port: 3000
-{{ end }}
+  

--- a/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
@@ -12,13 +12,13 @@ spec:
     - type: Service
       alias: console
       service:
-        name: {{ template "console.fullname" . }}-console-v2
+        name: {{ .Values.fullname }}-console-v2
         namespace: {{ .Release.Namespace }}
         port: 3000
       authorize: true
   service:
     basePath: /plugin/
-    name: {{ template "console.fullname" . }}-console-v2
+    name: {{ .Values.fullname }}-console-v2
     namespace: {{ .Release.Namespace }}
     port: 3000
 {{ end }}

--- a/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
@@ -1,0 +1,24 @@
+# Copyright Contributors to the Open Cluster Management project
+{{- if include "dynamicPlugins.supported" . }}
+apiVersion: console.openshift.io/v1alpha1
+kind: ConsolePlugin
+metadata:
+  name: acm
+  annotations:
+    console.openshift.io/use-i18n: "true"
+spec:
+  displayName: Red Hat Advanced Cluster Management
+  proxy:
+    - type: Service
+      alias: console
+      service:
+        name: {{ template "console.fullname" . }}-console-v2
+        namespace: {{ .Release.Namespace }}
+        port: 3000
+      authorize: true
+  service:
+    basePath: /plugin/
+    name: {{ template "console.fullname" . }}-console-v2
+    namespace: {{ .Release.Namespace }}
+    port: 3000
+{{ end }}

--- a/pkg/templates/charts/toggle/console/templates/console-service.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-service.yaml
@@ -5,8 +5,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{ .Values.fullname }}-console-certs
-  name: {{ .Values.fullname }}-console-v2
+    service.beta.openshift.io/serving-cert-secret-name: console-chart-console-certs
+  name: console-chart-console-v2
   labels:
     app: console-chart-v2
     component: "console"

--- a/pkg/templates/charts/toggle/console/templates/console-service.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-service.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ template "console.fullname" . }}-console-certs
+  name: {{ template "console.fullname" . }}-console-v2
+  labels:
+    app: {{ template "console.name" . }}-v2
+    component: "console"
+    chart: {{ template "console.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "console.name" . }}
+    helm.sh/chart: {{ template "console.chart" . }}
+spec:
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "console.name" . }}-v2
+    component: "console"
+    release: {{ .Release.Name }}

--- a/pkg/templates/charts/toggle/console/templates/console-service.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-service.yaml
@@ -5,18 +5,15 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{ template "console.fullname" . }}-console-certs
-  name: {{ template "console.fullname" . }}-console-v2
+    service.beta.openshift.io/serving-cert-secret-name: {{ .Values.fullname }}-console-certs
+  name: {{ .Values.fullname }}-console-v2
   labels:
-    app: {{ template "console.name" . }}-v2
+    app: console-chart-v2
     component: "console"
-    chart: {{ template "console.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "console.name" . }}
-    helm.sh/chart: {{ template "console.chart" . }}
+    chart: console-chart-{{ .Values.hubconfig.hubVersion }}
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
 spec:
   ports:
     - port: 3000
@@ -24,6 +21,6 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ template "console.name" . }}-v2
+    app: console-chart-v2
     component: "console"
-    release: {{ .Release.Name }}
+    release: console

--- a/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.fullname }}
+  name: console-chart
   labels:
     app: console-chart
     chart: console-chart-{{ .Values.hubconfig.hubVersion }}

--- a/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "console.fullname" . }}
+  labels:
+    app: {{ template "console.name" . }}
+    chart: {{ template "console.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "console.name" . }}
+    helm.sh/chart: {{ template "console.chart" . }}
+    component: serviceaccount

--- a/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
@@ -5,14 +5,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "console.fullname" . }}
+  name: {{ .Values.fullname }}
   labels:
-    app: {{ template "console.name" . }}
-    chart: {{ template "console.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ template "console.name" . }}
-    helm.sh/chart: {{ template "console.chart" . }}
+    app: console-chart
+    chart: console-chart-{{ .Values.hubconfig.hubVersion }}
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
     component: serviceaccount

--- a/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-serviceaccount.yaml
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
+++ b/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
@@ -1,6 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
 
----
 apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:

--- a/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
+++ b/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
@@ -12,6 +12,6 @@ metadata:
     subscription-pause: {{ .Values.clusterImageSets.subscriptionPause | quote }}
   name: hive-clusterimagesets-subscription-fast-0
 spec:
-  channel: {{ .Values.hubconfig.namespace }}/acm-hive-openshift-releases-chn-0
+  channel: {{ .Values.global.namespace }}/acm-hive-openshift-releases-chn-0
   placement:
     local: true

--- a/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
+++ b/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
@@ -9,7 +9,7 @@ metadata:
     apps.open-cluster-management.io/git-path: clusterImageSets/fast
   labels:
     app: hive-clusterimagesets
-    # subscription-pause: {{ .Values.clusterImageSets.subscriptionPause | quote }}
+    subscription-pause: {{ .Values.hubconfig.subscriptionPause | quote }}
   name: hive-clusterimagesets-subscription-fast-0
 spec:
   channel: {{ .Values.global.namespace }}/acm-hive-openshift-releases-chn-0

--- a/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
+++ b/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
@@ -1,0 +1,17 @@
+# Copyright Contributors to the Open Cluster Management project
+
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/git-branch: release-2.6
+    apps.open-cluster-management.io/git-path: clusterImageSets/fast
+  labels:
+    app: hive-clusterimagesets
+    subscription-pause: {{ .Values.clusterImageSets.subscriptionPause | quote }}
+  name: hive-clusterimagesets-subscription-fast-0
+spec:
+  channel: {{ .Values.hubconfig.namespace }}/acm-hive-openshift-releases-chn-0
+  placement:
+    local: true

--- a/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
+++ b/pkg/templates/charts/toggle/console/templates/subscription-fast.yaml
@@ -9,7 +9,7 @@ metadata:
     apps.open-cluster-management.io/git-path: clusterImageSets/fast
   labels:
     app: hive-clusterimagesets
-    subscription-pause: {{ .Values.clusterImageSets.subscriptionPause | quote }}
+    # subscription-pause: {{ .Values.clusterImageSets.subscriptionPause | quote }}
   name: hive-clusterimagesets-subscription-fast-0
 spec:
   channel: {{ .Values.global.namespace }}/acm-hive-openshift-releases-chn-0

--- a/pkg/templates/charts/toggle/console/values.yaml
+++ b/pkg/templates/charts/toggle/console/values.yaml
@@ -3,7 +3,6 @@
 # Declare variables to be passed into your templates.
 
 org: open-cluster-management
-fullname: console-chart
 
 global:
   imageOverrides:
@@ -17,16 +16,9 @@ hubconfig:
   replicaCount: 1
   tolerations: []
   hubVersion: ""
-
-arch:
-- amd64
-- ppc64le
-- s390x
-- arm64
-
-ocpingress: ""
-
-
-clusterImageSets:
+  ocpIngress: ""
   subscriptionPause: "false"
-  acmHiveOpenshiftReleaseUrl: "https://github.com/stolostron/acm-hive-openshift-releases.git"
+
+# clusterImageSets:
+#   subscriptionPause: "false"
+#   acmHiveOpenshiftReleaseUrl: "https://github.com/stolostron/acm-hive-openshift-releases.git"

--- a/pkg/templates/charts/toggle/console/values.yaml
+++ b/pkg/templates/charts/toggle/console/values.yaml
@@ -3,28 +3,21 @@
 # Declare variables to be passed into your templates.
 
 org: open-cluster-management
+fullname: console-chart
 
 global:
   imageOverrides:
     console: ""
   namespace: default
   pullSecret: null
-  imageRepository: "" # utils.GetImageRepository(m)
+  pullPolicy: Always
 hubconfig:
   nodeSelector: null
   proxyConfigs: {}
   replicaCount: 1
   tolerations: []
+  hubVersion: ""
 
-
-
-
-global:
-  imageOverrides:
-    console: ""
-    pullPolicy: Always
-
-pullSecret: null
 arch:
 - amd64
 - ppc64le
@@ -32,18 +25,6 @@ arch:
 - arm64
 
 ocpingress: ""
-
-hubconfig:
-  nodeSelector: null
-  replicaCount: 1
-  ocpVersion: "4.6.0"
-  tolerations:
-    - key: dedicated
-      operator: Exists
-      effect: NoSchedule
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/infra
-      operator: Exists
 
 console:
   resources:

--- a/pkg/templates/charts/toggle/console/values.yaml
+++ b/pkg/templates/charts/toggle/console/values.yaml
@@ -1,0 +1,56 @@
+# Default values for console-chart
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+org: open-cluster-management
+
+global:
+  imageOverrides:
+    console: ""
+  namespace: default
+  pullSecret: null
+  imageRepository: "" # utils.GetImageRepository(m)
+hubconfig:
+  nodeSelector: null
+  proxyConfigs: {}
+  replicaCount: 1
+  tolerations: []
+
+
+
+
+global:
+  imageOverrides:
+    console: ""
+    pullPolicy: Always
+
+pullSecret: null
+arch:
+- amd64
+- ppc64le
+- s390x
+- arm64
+
+ocpingress: ""
+
+hubconfig:
+  nodeSelector: null
+  replicaCount: 1
+  ocpVersion: "4.6.0"
+  tolerations:
+    - key: dedicated
+      operator: Exists
+      effect: NoSchedule
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      operator: Exists
+
+console:
+  resources:
+    requests:
+      memory: "40Mi"
+      cpu: "3m"
+
+clusterImageSets:
+  subscriptionPause: "false"
+  acmHiveOpenshiftReleaseUrl: "https://github.com/stolostron/acm-hive-openshift-releases.git"

--- a/pkg/templates/charts/toggle/console/values.yaml
+++ b/pkg/templates/charts/toggle/console/values.yaml
@@ -26,11 +26,6 @@ arch:
 
 ocpingress: ""
 
-console:
-  resources:
-    requests:
-      memory: "40Mi"
-      cpu: "3m"
 
 clusterImageSets:
   subscriptionPause: "false"

--- a/pkg/templates/crds/console/user-preference-crd.yaml
+++ b/pkg/templates/crds/console/user-preference-crd.yaml
@@ -1,0 +1,85 @@
+# Copyright (c) 2020 Red Hat, Inc.
+
+# Copyright Contributors to the Open Cluster Management project
+
+# Dynamic user preference data
+# The CR will be created with the name of the user who will access the information
+# CR will hold info such as saved searches, homepage, search history etc.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: userpreferences.console.open-cluster-management.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: console.open-cluster-management.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                savedSearches: # Saved user searches to be displayed on main search page
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      searchText:
+                        type: string
+                      name:
+                        type: string
+                      description:
+                        type: string
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: userpreferences
+    # singular name to be used as an alias on the CLI and for display
+    singular: userpreference
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: UserPreference
+
+  # TODO Need to see if we can have a non-structural schema that leaves this CR dynamica to new user preferences?
+  # validation:
+  #   openAPIV3Schema:
+  #     type: object
+  #     properties:
+  #       spec:
+  #         type: object
+  #         properties:
+  #           savedSearches: # Saved user searches to be displayed on main search page
+  #             type: array
+  #             items:
+  #               type: object
+  #               properties:
+  #                 id:
+  #                   type: string
+  #                 searchText:
+  #                   type: string
+  #                 name:
+  #                   type: string
+  #                 description:
+  #                   type: string
+  #           homepage: # User is able to set a homepage that creates a link on header icon
+  #             type: string
+
+  #           TODO - implement recent search history data for recomended searches
+  #           searchHistory:
+  #             type: array
+  #             items:
+  #               type: object
+  #               properties:
+  #                 searchText:
+  #                   type: string 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -416,12 +416,6 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedN
 
 func GetAppsubsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 	nn := []types.NamespacedName{}
-	if m.Enabled(operatorsv1.Console) {
-		nn = append(nn, types.NamespacedName{Name: "console-chart-sub", Namespace: m.Namespace})
-	}
-	if m.Enabled(operatorsv1.GRC) {
-		nn = append(nn, types.NamespacedName{Name: "grc-sub", Namespace: m.Namespace})
-	}
 	if m.Enabled(operatorsv1.ManagementIngress) {
 		nn = append(nn, types.NamespacedName{Name: "management-ingress-sub", Namespace: m.Namespace})
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -54,6 +54,7 @@ const (
 	CLCChartLocation           = "/charts/toggle/cluster-lifecycle"
 	ClusterBackupChartLocation = "/charts/toggle/cluster-backup"
 	GRCChartLocation           = "/charts/toggle/grc"
+	ConsoleChartLocation       = "/charts/toggle/console"
 )
 
 var (
@@ -293,7 +294,7 @@ func GetTestImages() []string {
 		"search_collector", "search_indexer", "search_v2_api", "postgresql_13", "search_v2_operator", "klusterlet_addon_controller",
 		"governance_policy_propagator", "governance_policy_addon_controller", "cert_policy_controller", "iam_policy_controller",
 		"config_policy_controller", "governance_policy_spec_sync", "governance_policy_status_sync", "governance_policy_template_sync",
-		"cluster_backup_controller"}
+		"cluster_backup_controller", "console"}
 
 }
 
@@ -366,7 +367,6 @@ func GetDeployments(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 
 func GetAppsubs(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 	appsubs := []types.NamespacedName{
-		{Name: "console-chart-sub", Namespace: m.Namespace},
 		{Name: "management-ingress-sub", Namespace: m.Namespace},
 		{Name: "volsync-addon-controller-sub", Namespace: m.Namespace},
 	}
@@ -408,6 +408,9 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedN
 		nn = append(nn, types.NamespacedName{Name: "grc-policy-addon-controller", Namespace: m.Namespace})
 		nn = append(nn, types.NamespacedName{Name: "grc-policy-propagator", Namespace: m.Namespace})
 	}
+	if m.Enabled(operatorsv1.Console) {
+		nn = append(nn, types.NamespacedName{Name: "console-chart-console-v2", Namespace: m.Namespace})
+	}
 	return nn
 }
 
@@ -415,6 +418,9 @@ func GetAppsubsForStatus(m *operatorsv1.MultiClusterHub) []types.NamespacedName 
 	nn := []types.NamespacedName{}
 	if m.Enabled(operatorsv1.Console) {
 		nn = append(nn, types.NamespacedName{Name: "console-chart-sub", Namespace: m.Namespace})
+	}
+	if m.Enabled(operatorsv1.GRC) {
+		nn = append(nn, types.NamespacedName{Name: "grc-sub", Namespace: m.Namespace})
 	}
 	if m.Enabled(operatorsv1.ManagementIngress) {
 		nn = append(nn, types.NamespacedName{Name: "management-ingress-sub", Namespace: m.Namespace})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -171,7 +171,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
 			appsubs := GetAppsubs(&mch)
-			Expect(len(appsubs)).To(Equal(3))
+			Expect(len(appsubs)).To(Equal(2))
 		})
 		It("gets deployments in Community Mode", func() {
 			os.Setenv("OPERATOR_PACKAGE", "stolostron")
@@ -186,7 +186,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(operatorsv1.ClusterBackup)
 			appsubs := GetAppsubs(&mch)
-			Expect(len(appsubs)).To(Equal(3))
+			Expect(len(appsubs)).To(Equal(2))
 		})
 		It("gets custom resources", func() {
 			mch := resources.EmptyMCH()
@@ -243,7 +243,7 @@ var _ = Describe("utility functions", func() {
 			mch.Enable(operatorsv1.Search)
 			mch.Enable(operatorsv1.Volsync)
 			appsubs := GetAppsubsForStatus(&mch)
-			Expect(len(appsubs)).To(Equal(3))
+			Expect(len(appsubs)).To(Equal(2))
 		})
 		It("Sets Default Component values", func() {
 			mch := resources.EmptyMCH()

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -187,7 +187,6 @@ var _ = Describe("utility functions", func() {
 			mch.Enable(operatorsv1.ClusterBackup)
 			appsubs := GetAppsubs(&mch)
 			Expect(len(appsubs)).To(Equal(3))
-
 		})
 		It("gets custom resources", func() {
 			mch := resources.EmptyMCH()
@@ -226,6 +225,12 @@ var _ = Describe("utility functions", func() {
 			mch.Enable(operatorsv1.GRC)
 			d := GetDeploymentsForStatus(&mch)
 			Expect(len(d)).To(Equal(2))
+		})
+		It("gets deployments for status with console enabled", func() {
+			mch := resources.EmptyMCH()
+			mch.Enable(operatorsv1.Console)
+			d := GetDeploymentsForStatus(&mch)
+			Expect(len(d)).To(Equal(1))
 		})
 		It("gets appsubs for status", func() {
 			mch := resources.EmptyMCH()

--- a/test/unit-tests/crds/appsub_subscription.yaml
+++ b/test/unit-tests/crds/appsub_subscription.yaml
@@ -14,12 +14,19 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: subscription status
+    - description: subscription state
       jsonPath: .status.phase
-      name: Status
+      name: SubscriptionState
       type: string
+    - description: subscription status reference
+      jsonPath: .status.appstatusReference
+      name: AppstatusReference
+      type: string      
     - jsonPath: .metadata.creationTimestamp
       name: Age
+      type: date
+    - jsonPath: .status.lastUpdateTime
+      name: Updated
       type: date
     - jsonPath: .spec.placement.local
       name: Local placement
@@ -48,6 +55,8 @@ spec:
             description: SubscriptionSpec defines the desired state of Subscription
             properties:
               channel:
+                type: string
+              secondaryChannel:
                 type: string
               hooksecretref:
                 description: 'ObjectReference contains enough information to let you
@@ -216,6 +225,41 @@ spec:
                   - packageName
                   type: object
                 type: array
+              allow:
+                description: To allow deployment of listed resources
+                items:
+                  description: Set of kubernetes group resources allowed to be deployed
+                  properties:
+                    apiVersion:
+                      type: string
+                    kinds:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - apiVersion
+                  - kinds
+                  type: object
+                type: array
+              deny:
+                description: To deny deployment of listed resources
+                items:
+                  description: Set of kubernetes group resources not allowed to be deployed
+                  properties:
+                    apiVersion:
+                      type: string
+                    kinds:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - apiVersion
+                  - kinds
+                  type: object
+                type: array
+              watchHelmNamespaceScopedResources:
+                description: WatchHelmNamespaceScopedResources is used to enable watching namespace scope Helm chart resources
+                type: boolean
               placement:
                 description: For hub use only, to specify which clusters to go to
                 properties:
@@ -402,6 +446,8 @@ spec:
                       type: string
                     type: array
                 type: object
+              appstatusReference:
+                type: string
               lastUpdateTime:
                 format: date-time
                 type: string

--- a/test/unit-tests/crds/console_link.yaml
+++ b/test/unit-tests/crds/console_link.yaml
@@ -1,0 +1,162 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
+    capability.openshift.io/name: Console
+    description: Extension for customizing OpenShift web console links
+    displayName: ConsoleLinks
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: consolelinks.console.openshift.io
+spec:
+  group: console.openshift.io
+  names:
+    kind: ConsoleLink
+    listKind: ConsoleLinkList
+    plural: consolelinks
+    singular: consolelink
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.text
+      name: Text
+      type: string
+    - jsonPath: .spec.href
+      name: URL
+      type: string
+    - jsonPath: .spec.menu
+      name: Menu
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleLink is an extension for customizing OpenShift web console
+          links. \n Compatibility level 2: Stable within a major release for a minimum
+          of 9 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleLinkSpec is the desired console link configuration.
+            properties:
+              applicationMenu:
+                description: applicationMenu holds information about section and icon
+                  used for the link in the application menu, and it is applicable
+                  only when location is set to ApplicationMenu.
+                properties:
+                  imageURL:
+                    description: imageUrl is the URL for the icon used in front of
+                      the link in the application menu. The URL must be an HTTPS URL
+                      or a Data URI. The image should be square and will be shown
+                      at 24x24 pixels.
+                    type: string
+                  section:
+                    description: section is the section of the application menu in
+                      which the link should appear. This can be any text that will
+                      appear as a subheading in the application menu dropdown. A new
+                      section will be created if the text does not match text of an
+                      existing section.
+                    type: string
+                required:
+                - section
+                type: object
+              href:
+                description: href is the absolute secure URL for the link (must use
+                  https)
+                pattern: ^https://
+                type: string
+              location:
+                description: location determines which location in the console the
+                  link will be appended to (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard).
+                pattern: ^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$
+                type: string
+              namespaceDashboard:
+                description: namespaceDashboard holds information about namespaces
+                  in which the dashboard link should appear, and it is applicable
+                  only when location is set to NamespaceDashboard. If not specified,
+                  the link will appear in all namespaces.
+                properties:
+                  namespaceSelector:
+                    description: namespaceSelector is used to select the Namespaces
+                      that should contain dashboard link by label. If the namespace
+                      labels match, dashboard link will be shown for the namespaces.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  namespaces:
+                    description: namespaces is an array of namespace names in which
+                      the dashboard link should appear.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              text:
+                description: text is the display text for the link
+                type: string
+            required:
+            - href
+            - location
+            - text
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/25584

Moves source-of-truth for MCH console templates from https://github.com/stolostron/multiclusterhub-repo/tree/main/multiclusterhub/charts/console-chart and CRDs from https://github.com/stolostron/hub-crds/tree/main/crds/console-chart to this repo.

Templates changelog (roughly):
```
.Release.Name -> "console" (before console-chart-ed5e3)
REMOVED label - app.kubernetes.io/managed-by: Helm
MODIFED template {{ template "console.name" . }} -> "console-chart"
REMOVED label - helm.sh/chart REMOVED label - "heritage: Helm"
MODIFIED template {{ template "console.fullname" . }} -> console-chart (before console-chart-ed5e3)
MODIFIED .Values.hubconfig.namespace -> .Values.global.namespace
MODIFIED .Values.pullSecret -> .Values.global.pullSecret
MODIFIED template {{ template "console.chart" . }} -> console-chart-{{ .Values.hubconfig.hubVersion }}
MODIFIED {{ .Release.Namespace }} -> {{ .Values.global.namespace }}
MODIFIED {{ .Values.ocpingress }} -> {{ .Values.hubconfig.ocpIngress }}
MODIFIED {{ .Values.clusterImageSets.subscriptionPause | quote }} -> {{ .Values.hubconfig.subscriptionPause | quote }}
REMOVED {{- if include "dynamicPlugins.supported" . }} from ConsolePlugin
MODIFIED tolerations template format

NOTE:  subscription git-branch left at `release-2.6`
```