### PR TITLE
update grc policy automation crd

### DIFF
--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
@@ -46,6 +46,10 @@ spec:
                       time and is a known Ansible entity.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  jobTtl:
+                    description: JobTTL sets the time to live for the Kubernetes AnsibleJob
+                      object after the Ansible job run has finished.
+                    type: integer
                   name:
                     description: Name of the Ansible Template to run in Tower as a
                       job


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

For https://github.com/stolostron/backlog/issues/20158 we added a new "jobttl" field to the GRC policy automation CRD. This PR updates the copy of the CRD in multiclusterhub-operator.