### PR TITLE
Sync GRC PlacementBinding CRD

### DIFF
--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
@@ -36,7 +36,8 @@ spec:
           metadata:
             type: object
           placementRef:
-            description: PlacementSubject reference
+            description: PlacementSubject defines the resource that can be used as
+              PlacementBinding placementRef
             properties:
               apiGroup:
                 enum:
@@ -63,7 +64,8 @@ spec:
             type: object
           subjects:
             items:
-              description: Subject reference
+              description: Subject defines the resource that can be used as PlacementBinding
+                subject
               properties:
                 apiGroup:
                   enum:


### PR DESCRIPTION
In preparation for CRD sync checks, this brings in changes to the CRD that hadn't previously been synced.