### PR TITLE
Add permissions required by the kube-rbac-proxy

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
@@ -69,6 +69,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - 'authentication.k8s.io'
+  resources:
+  - 'tokenreviews'
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - '*'
   resources:
   - '*'


### PR DESCRIPTION
the 'create' permission on TokenReview and SubjectAccessReview is required by kube-rbac-proxy container in the propagator deployment for controlling access to metrics endpoint

related to:
https://github.com/stolostron/backlog/issues/26873
https://github.com/stolostron/backlog/issues/26574



Signed-off-by: Chaitanya Kandagatla <ckandaga@redhat.com>