### PR TITLE
Reduce permissions on grc clusterrole,

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-clusterrole.yaml
@@ -28,8 +28,6 @@ rules:
   - ""
   resources:
   - events
-  - configmaps
-  - configmaps/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
Removing permissions for  configmaps as
Leader Election, for which  ConfigMaps was needed, has since been removed

related to : stolostron/backlog#26574

Signed-off-by: Chaitanya Kandagatla <ckandaga@redhat.com>