### PR TITLE
Add GRC permissions for AddOnDeploymentConfig placement configurations

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -77,6 +77,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - addondeploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews


### PR DESCRIPTION
Relates:
https://issues.redhat.com/browse/ACM-2176
https://github.com/stolostron/backlog/issues/26713

Signed-off-by: mprahl <mprahl@users.noreply.github.com>