### PR TITLE
jira acm-2231: fix missing managed cluster addons

### DIFF
--- a/controllers/managedcluster_test.go
+++ b/controllers/managedcluster_test.go
@@ -1,0 +1,18 @@
+package controllers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func LocalClusterNamespace() *corev1.Namespace {
+	return &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "local-cluster",
+		},
+	}
+}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -426,7 +426,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if !multiClusterHub.Spec.DisableHubSelfManagement {
 		result, err = r.ensureKlusterletAddonConfig(multiClusterHub)
-		if result != (ctrl.Result{}) {
+		if result != (ctrl.Result{}) || err != nil {
 			return result, err
 		}
 	}

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -149,7 +149,7 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 	By("Ensuring Klusterlet Addon is created")
 	Eventually(func() bool {
 		ns := LocalClusterNamespace()
-		_, err = reconciler.ensureNamespace(createdMCH, ns)
+		_, err := reconciler.ensureNamespace(createdMCH, ns)
 		return err == nil
 
 	}, timeout, interval).Should(BeTrue())

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -146,6 +146,14 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 		}
 	})
 
+	By("Ensuring Klusterlet Addon is created")
+	Eventually(func() bool {
+		ns := LocalClusterNamespace()
+		_, err = reconciler.ensureNamespace(createdMCH, ns)
+		return err == nil
+
+	}, timeout, interval).Should(BeTrue())
+
 	By("Waiting for MCH to be in the running state")
 	Eventually(func() bool {
 		mch := &mchov1.MultiClusterHub{}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-2231

When re-enabling the local cluster, there will be several errors reported while waiting for the `local-cluster` namespace to be recreated.

Signed-off-by: Ray Harris <raharris@redhat.com>