### PR TITLE
ACM upgrade to 2.7 failed in grc addon with permissions

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -159,6 +159,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - policies


### PR DESCRIPTION
When upgrading ACM 2.6 to 2.7 there was a permissions problem that kept the upgrade from working.  These permissions were needed.

Refs:
 - https://issues.redhat.com/browse/ACM-2355

Signed-off-by: Gus Parvin <gparvin@redhat.com>