### PR TITLE
Fix console-chart scale issues

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -139,13 +139,13 @@ spec:
             path: /readinessProbe
             port: 3000
             scheme: HTTPS
-          failureThreshold: 1
+          timeoutSeconds: 5
         livenessProbe:
           httpGet:
             path: /livenessProbe
             port: 3000
             scheme: HTTPS
-          failureThreshold: 1
+          timeoutSeconds: 5
           initialDelaySeconds: 10
       {{- if .Values.global.pullSecret }}
       imagePullSecrets:


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/22342

Use default failureThreshold (3)
Allow 5 seconds for timeout for hubs with large workloads