### PR TITLE
Fix typo in API name: storageclass -> storageclasses

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
@@ -177,7 +177,7 @@ rules:
   apiGroups:
   - storage.k8s.io
   resources:
-  - storageclass
+  - storageclasses
 
 - verbs:
   - list


### PR DESCRIPTION
Signed-off-by: Kevin Cormier <kcormier@redhat.com>