### PR TITLE
Vary MCE operand namespace based on community build vs. product build

### DIFF
--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -28,15 +28,16 @@ var (
 	packageName            = "multicluster-engine"
 	catalogSourceName      = "redhat-operators"
 	catalogSourceNamespace = "openshift-marketplace" // https://olm.operatorframework.io/docs/tasks/troubleshooting/subscription/#a-subscription-in-namespace-x-cant-install-operators-from-a-catalogsource-in-namespace-y
+	operandNameSpace       = "multicluster-engine"
 
 	// community MCE variables
 	communityChannel           = "community-0.1"
 	communityPackageName       = "stolostron-engine"
 	communityCatalogSourceName = "community-operators"
+	communityOperandNamepace   = "stolostron-engine"
 
 	// default names
 	MulticlusterengineName      = "multiclusterengine"
-	MulticlusterengineNamespace = "multicluster-engine"
 	operatorGroupName           = "default"
 )
 
@@ -86,7 +87,7 @@ func NewMultiClusterEngine(m *operatorsv1.MultiClusterHub, infrastructureCustomN
 			Tolerations:        utils.GetTolerations(m),
 			NodeSelector:       m.Spec.NodeSelector,
 			AvailabilityConfig: availConfig,
-			TargetNamespace:    MulticlusterengineNamespace,
+			TargetNamespace:    OperandNameSpace(),
 			Overrides: &mcev1.Overrides{
 				Components: utils.GetMCEComponents(m),
 			},
@@ -243,6 +244,15 @@ func DesiredPackage() string {
 		return communityPackageName
 	} else {
 		return packageName
+	}
+}
+
+// OperandNameSpace is determined by whether operator is running in community mode or production mode
+func OperandNameSpace() string {
+	if utils.IsCommunityMode() {
+		return communityOperandNamepace
+	} else {
+		return operandNameSpace
 	}
 }
 

--- a/pkg/multiclusterengine/multiclusterengine_test.go
+++ b/pkg/multiclusterengine/multiclusterengine_test.go
@@ -68,6 +68,17 @@ func TestDesiredPackage(t *testing.T) {
 	}
 }
 
+func TestOperandNameSpace(t *testing.T) {
+	os.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
+	if got := OperandNameSpace(); got != operandNameSpace {
+		t.Errorf("OperandNameSpace() = %v, want %v", got, operandNameSpace)
+	}
+	os.Unsetenv("OPERATOR_PACKAGE")
+	if got := OperandNameSpace(); got != communityOperandNamepace {
+		t.Errorf("OperandNameSpace() = %v, want %v", got, communityOperandNamepace)
+	}
+}
+
 func TestFindAndManageMCE(t *testing.T) {
 
 	managedmce1 := &mcev1.MultiClusterEngine{
@@ -250,7 +261,7 @@ func TestNewMultiClusterEngine(t *testing.T) {
 					},
 					NodeSelector:       nil,
 					AvailabilityConfig: mcev1.HAHigh,
-					TargetNamespace:    MulticlusterengineNamespace,
+					TargetNamespace:    OperandNameSpace(),
 					Overrides: &mcev1.Overrides{
 						Components: []mcev1.ComponentConfig{
 							{Name: operatorsv1.MCELocalCluster, Enabled: true},
@@ -312,7 +323,7 @@ func TestNewMultiClusterEngine(t *testing.T) {
 						"select": "this",
 					},
 					AvailabilityConfig: mcev1.HABasic,
-					TargetNamespace:    MulticlusterengineNamespace,
+					TargetNamespace:    OperandNameSpace(),
 					Overrides: &mcev1.Overrides{
 						ImagePullPolicy: corev1.PullNever,
 						Components: []mcev1.ComponentConfig{


### PR DESCRIPTION
Configure the operand namespace into which MCE is installed based on whether the operator is the community-build one (stolostron) or the product-build one (advanced-cluster-management).