### PR TITLE
increase placementrule memory limit to 1.5G

### DIFF
--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
@@ -83,7 +83,7 @@ spec:
         resources:
           limits:
             cpu: 1500m
-            memory: 512Mi
+            memory: 1.5Gi
           requests:
             cpu: 300m
             memory: 64Mi


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

https://issues.redhat.com/browse/ACM-2336

The memory limit for the placementrule controller is increased to 1.5 for better support of 3k cluster scale test