### PR TITLE
console: Set new env to DISABLE_EVENTS for ACM

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -117,12 +117,10 @@ spec:
         env:
         - name: PORT
           value: "3000"
-        - name: FRONTEND_URL
-          value: "https://multicloud-console.{{ .Values.hubconfig.ocpIngress }}/multicloud"
-        - name: BACKEND_URL
-          value: "https://multicloud-console.{{ .Values.hubconfig.ocpIngress }}/multicloud"
         - name: CLUSTER_API_URL
           value: https://kubernetes.default.svc:443
+        - name: DISABLE_EVENTS
+          value: "true"
         {{- if .Values.hubconfig.proxyConfigs }}
         - name: HTTP_PROXY
           value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
Also removes obsolete env FRONTEND_URL and BACKEND_URL

https://github.com/stolostron/backlog/issues/22342

Adds environment variable switch to disable resource watching and the events API in the console backend. ACM plugin data fetching is shared with MCE in 2.7, so there is no reason for the ACM pods to consume memory and CPU watching resources for data that will never be queried.