### PR TITLE
GRC upgrade procedure for 2.6->2.7

### DIFF
--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2022-12-13T21:37:40Z"
+    createdAt: "2022-12-19T20:17:51Z"
     description: Open management of Openshift and Kubernetes clusters
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -500,6 +500,7 @@ spec:
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -389,6 +389,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch


### PR DESCRIPTION
Adds a step during upgrade to delete the GRC appsub and helmrelease and prevent finalizer logic from taking place. This is to preserve all GRC ClusterManagementAddOns when upgrading from 2.6 to 2.7.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>