### PR TITLE
Add rbac aggregation for app lifecycle CRDs

### DIFF
--- a/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-admin.yaml
+++ b/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-admin.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-ocm-cluster-manager-admin: "true"
   name: "open-cluster-management:multicloud-operators-subscription:rbac-aggregate-admin"
 rules:
 - apiGroups:

--- a/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-admin.yaml
+++ b/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-admin.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: "open-cluster-management:multicloud-operators-subscription:rbac-aggregate-admin"
+rules:
+- apiGroups:
+  - app.k8s.io
+  resources:
+  - applications
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - channels
+  - deployables
+  - gitopsclusters
+  - helmreleases
+  - placementrules
+  - subscriptionreports
+  - subscriptions
+  - subscriptionstatuses
+  verbs:
+  - '*'

--- a/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-edit.yaml
+++ b/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-edit.yaml
@@ -1,0 +1,34 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: "open-cluster-management:multicloud-operators-subscription:rbac-aggregate-edit"
+rules:
+- apiGroups:
+  - app.k8s.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - channels
+  - deployables
+  - gitopsclusters
+  - helmreleases
+  - placementrules
+  - subscriptionreports
+  - subscriptions
+  - subscriptionstatuses
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-view.yaml
+++ b/pkg/templates/multiclusterhub/base/multicluster-applications-rbac-aggregate-view.yaml
@@ -1,0 +1,48 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: "open-cluster-management:multicloud-operators-subscription:rbac-aggregate-view"
+rules:
+- apiGroups:
+  - app.k8s.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - channels
+  - deployables
+  - gitopsclusters
+  - helmreleases
+  - placementrules
+  - subscriptionreports
+  - subscriptions
+  - subscriptionstatuses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - applications.app.k8s.io
+  - channels.apps.open-cluster-management.io
+  - deployables.apps.open-cluster-management.io
+  - gitopsclusters.apps.open-cluster-management.io
+  - helmreleases.apps.open-cluster-management.io
+  - placementrules.apps.open-cluster-management.io
+  - subscriptionreports.apps.open-cluster-management.io
+  - subscriptions.apps.open-cluster-management.io
+  - subscriptionstatuses.apps.open-cluster-management.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get


### PR DESCRIPTION
This mimics what OLM did when the app lifecycle CRDs were included in the ACM bundle.

Jira: https://issues.redhat.com/browse/ACM-3055 & https://issues.redhat.com/browse/ACM-3203

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>