### PR TITLE
Default governance-policy-propagator container

### DIFF
--- a/pkg/templates/charts/toggle/grc/OWNERS
+++ b/pkg/templates/charts/toggle/grc/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- ckandag
+- dhaiducek
+- gparvin
+- willkutler
+- JustinKuli
+- mprahl
+- yiraeChristineKim
+reviewers:
+- ckandag
+- dhaiducek
+- gparvin
+- willkutler
+- JustinKuli
+- mprahl
+- yiraeChristineKim

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       release: grc
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: governance-policy-propagator
       labels:
         app: grc
         ocm-antiaffinity-selector: "grcpolicypropagator"


### PR DESCRIPTION
- Adds a default container for the governance-policy-propagator as a convenience so that `oc logs` defaults to the propagator rather than the proxy
- Also adds an OWNERS file for the GRC chart