### PR TITLE
intial commit of adding a watch on mce

### DIFF
--- a/api/v1/webhook_test.go
+++ b/api/v1/webhook_test.go
@@ -137,7 +137,10 @@ var _ = Describe("V1 API Webhook", func() {
 				Scheme: k8sManager.GetScheme(),
 				Log:    ctrl.Log.WithName("controllers").WithName("MultiClusterHub"),
 			}
-			Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
+			//Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
+			success, err := reconciler.SetupWithManager(k8sManager)
+			Expect(success).ToNot(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			// By("starting the k8s manager")
 			// go func() {

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -53,6 +53,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -507,7 +508,7 @@ func (r *MultiClusterHubReconciler) setOperatorUpgradeableStatus(ctx context.Con
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MultiClusterHubReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *MultiClusterHubReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Controller, error) {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(
 			&operatorv1.MultiClusterHub{},
@@ -595,7 +596,7 @@ func (r *MultiClusterHubReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				},
 			),
 		).
-		Complete(r)
+		Build(r)
 }
 
 func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operatorv1.MultiClusterHub, template *unstructured.Unstructured) (ctrl.Result, error) {

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -382,7 +382,9 @@ var _ = Describe("MultiClusterHub controller", func() {
 			// 	ImageOverrides: map[string]string{},
 			// },
 		}
-		Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
+		//Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
+		success, _ := reconciler.SetupWithManager(k8sManager)
+		Expect(success).To(BeTrue())
 
 		go func() {
 			// For explanation of GinkgoRecover in a go routine, see

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -384,7 +384,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 		}
 		//Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
 		success, _ := reconciler.SetupWithManager(k8sManager)
-		Expect(success).To(BeTrue())
+		Expect(success).ToNot(BeNil())
 
 		go func() {
 			// For explanation of GinkgoRecover in a go routine, see

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -383,8 +383,9 @@ var _ = Describe("MultiClusterHub controller", func() {
 			// },
 		}
 		//Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
-		success, _ := reconciler.SetupWithManager(k8sManager)
+		success, err := reconciler.SetupWithManager(k8sManager)
 		Expect(success).ToNot(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 
 		go func() {
 			// For explanation of GinkgoRecover in a go routine, see

--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func addMultiClusterEngineWatch(ctx context.Context, uncachedClient client.Clien
 		crdKey := client.ObjectKey{Name: multiclusterengine.Namespace().GetObjectMeta().GetName()}
 		err := uncachedClient.Get(ctx, crdKey, &mcev1.MultiClusterEngine{})
 		if err != nil {
-			mchController.Watch(&source.Kind{Type: &mcev1.MultiClusterEngine{}},
+			err := mchController.Watch(&source.Kind{Type: &mcev1.MultiClusterEngine{}},
 				handler.Funcs{
 					UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 						labels := e.ObjectNew.GetLabels()
@@ -292,8 +292,10 @@ func addMultiClusterEngineWatch(ctx context.Context, uncachedClient client.Clien
 						)
 					},
 				})
-			setupLog.Info("mce watch added")
-			return
+			if err != nil {
+				setupLog.Info("mce watch added")
+				return
+			}
 		} else {
 			setupLog.Info("mce cr wasnt created yet, retrying in 30 seconds")
 			time.Sleep(30 * time.Second)

--- a/main.go
+++ b/main.go
@@ -260,10 +260,10 @@ const (
 )
 
 func addMultiClusterEngineWatch(ctx context.Context, uncachedClient client.Client) {
-	// try to see if mce cr exist, for loop
-	// uncached client to get mce crd
 	for {
-		_, err := multiclusterengine.GetManagedMCE(ctx, uncachedClient)
+		//_, err := multiclusterengine.GetManagedMCE(ctx, uncachedClient)
+		crdKey := client.ObjectKey{Name: multiclusterengine.Namespace().GetObjectMeta().GetName()}
+		err := uncachedClient.Get(ctx, crdKey, &mcev1.MultiClusterEngine{})
 		if err != nil {
 			mchController.Watch(&source.Kind{Type: &mcev1.MultiClusterEngine{}},
 				handler.Funcs{

--- a/main.go
+++ b/main.go
@@ -292,8 +292,10 @@ func addMultiClusterEngineWatch(ctx context.Context, uncachedClient client.Clien
 						)
 					},
 				})
+			setupLog.Info("mce watch added")
 			return
 		} else {
+			setupLog.Info("mce cr wasnt created yet, retrying in 30 seconds")
 			time.Sleep(30 * time.Second)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -58,12 +58,19 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/util/workqueue"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 	//+kubebuilder:scaffold:imports
 )
@@ -74,8 +81,9 @@ const (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme        = runtime.NewScheme()
+	setupLog      = ctrl.Log.WithName("setup")
+	mchController controller.Controller
 )
 
 func init() {
@@ -199,14 +207,16 @@ func main() {
 		setupLog.Error(err, "unable to create uncached client")
 		os.Exit(1)
 	}
-
-	if err = (&controllers.MultiClusterHubReconciler{
+	mchReconciler := &controllers.MultiClusterHubReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		UncachedClient:  uncachedClient,
 		Log:             ctrl.Log.WithName("Controller").WithName("Multiclusterhub"),
 		UpgradeableCond: upgradeableCondition,
-	}).SetupWithManager(mgr); err != nil {
+	}
+
+	mchController, err = mchReconciler.SetupWithManager(mgr)
+	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MultiClusterHub")
 		os.Exit(1)
 	}
@@ -233,6 +243,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// go routine to check if mce exist, if it does add watch
+	go addMultiClusterEngineWatch()
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
@@ -244,6 +257,42 @@ const (
 	ForceRunModeEnv = "OSDK_FORCE_RUN_MODE"
 	LocalRunMode    = "local"
 )
+
+func addMultiClusterEngineWatch() {
+	err := mchController.Watch(&source.Kind{Type: &mcev1.MultiClusterEngine{}},
+		handler.Funcs{
+			UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+				labels := e.ObjectNew.GetLabels()
+				name := labels["installer.name"]
+				if name == "" {
+					name = labels["multiclusterhub.name"]
+				}
+				namespace := labels["installer.namespace"]
+				if namespace == "" {
+					namespace = labels["multiclusterhub.namespace"]
+				}
+				if name == "" || namespace == "" {
+					l := log.FromContext(context.Background())
+					l.Info(fmt.Sprintf("MCE updated, but did not find required labels: %v", labels))
+					return
+				}
+				q.Add(
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name:      name,
+							Namespace: namespace,
+						},
+					},
+				)
+			},
+		})
+	if err != nil {
+		setupLog.Error(err, "unable to watch mce")
+		os.Exit(1)
+	} else {
+		time.Sleep(30 * time.Second)
+	}
+}
 
 func isRunModeLocal() bool {
 	return os.Getenv(ForceRunModeEnv) == LocalRunMode


### PR DESCRIPTION
Add a watch of mce in multiclusterhub-operator so if MCE gets changed, multiclusterhub-operator notices that it is not configured to match MCH's configuration, and changes it back

Changed the way SetupWithManager function works to return a controller that can be used to add a watch whenever mce is found, if so add a watch to it.