### PR TITLE
Add back AppSub part that is not being picked up by bundle automation

### DIFF
--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-applications-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-applications-clustermanagementaddon.yaml
@@ -1,0 +1,8 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: application-manager
+spec:
+  addOnMeta:
+    description: Synchronizes application on the managed clusters from the hub
+    displayName: Application Manager


### PR DESCRIPTION
Our bundle-update automation is not recognizing/picking up ClusterManagementAddon resources from the source bundle.  So the last bundle-update PR was incomplete and deleted this part out of the App Sub templates directly.  

I will work on updates to the generate-bundle script, but to unblock the AppSub folks I am just manually adding the part back.  The auto-generated bundle update PR will once again want to delete this part out, so we should just leave that PR pending (eventually delete it) until the fixes to generate-bundle are in.