### PR TITLE
Support addondeploymentconfigs for grc addons

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/cert-policy-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/cert-policy-clustermanagementaddon.yaml
@@ -6,3 +6,6 @@ spec:
   addOnMeta:
     description: Monitors certificate expiration based on distributed policies.
     displayName: Certificate Policy Addon
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs

--- a/pkg/templates/charts/toggle/grc/templates/config-policy-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/config-policy-clustermanagementaddon.yaml
@@ -6,3 +6,6 @@ spec:
   addOnMeta:
     description: Audits k8s resources and remediates violation based on configuration policies.
     displayName: Config Policy Addon
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs

--- a/pkg/templates/charts/toggle/grc/templates/governance-policy-framework-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/governance-policy-framework-clustermanagementaddon.yaml
@@ -6,3 +6,6 @@ spec:
   addOnMeta:
     description: Distributes policies and collects policy evaluation results.
     displayName: Governance Policy Framework Addon
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs

--- a/pkg/templates/charts/toggle/grc/templates/iam-policy-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/iam-policy-clustermanagementaddon.yaml
@@ -6,3 +6,6 @@ spec:
   addOnMeta:
     description: Monitors identity controls based on distributed policies.
     displayName: IAM Policy Addon
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs


### PR DESCRIPTION
Previously we added permissions so that the policy-addon-controller could use these resources for configuring some details of addons on managed clusters, specifically to help configuration of nodeSelectors and tolerations. But in order to apply a configuration, both the CMAO and the MCAO would need to be updated to allow it. This change makes it so that only the MCAO needs to be updated, to specifically point to an addondeploymentconfig.

It does not result in any changes by default. It only makes it easier to configure in the future.

Refs:
 - https://issues.redhat.com/browse/ACM-1706
 - https://github.com/stolostron/multicloud-operators-foundation/pull/532/files#diff-8baaa1096e19937690454565dfd62a62a10ca325aff30a7f543748cf52ec75e1
 - https://github.com/stolostron/multiclusterhub-operator/pull/918