### PR TITLE
ACM-5184: Fix issue where MCE override annotation not removed

### DIFF
--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -120,6 +120,8 @@ func RenderMultiClusterEngine(existingMCE *mcev1.MultiClusterEngine, m *operator
 			newAnnotations[key] = val
 		}
 		copy.SetAnnotations(newAnnotations)
+	} else {
+		RemoveSupportedAnnotations(copy)
 	}
 
 	if m.Spec.AvailabilityConfig == operatorsv1.HABasic {
@@ -154,6 +156,18 @@ func GetSupportedAnnotations(m *operatorsv1.MultiClusterHub) map[string]string {
 	if m.GetAnnotations() != nil {
 		if val, ok := m.GetAnnotations()[utils.AnnotationImageRepo]; ok && val != "" {
 			mceAnnotations["imageRepository"] = val
+		}
+	}
+	return mceAnnotations
+}
+
+// RemoveSupportedAnnotations removes annotations relevant to MCE from MCE. If the annotation is
+// already present then sets value to empty rather than removing the key
+func RemoveSupportedAnnotations(mce *mcev1.MultiClusterEngine) map[string]string {
+	mceAnnotations := mce.GetAnnotations()
+	if mceAnnotations != nil {
+		if _, ok := mceAnnotations["imageRepository"]; ok {
+			mceAnnotations["imageRepository"] = ""
 		}
 	}
 	return mceAnnotations

--- a/pkg/multiclusterengine/multiclusterengine_test.go
+++ b/pkg/multiclusterengine/multiclusterengine_test.go
@@ -446,6 +446,15 @@ func TestRenderMultiClusterEngine(t *testing.T) {
 		g.Expect(got.Annotations["imageRepository"]).To(gomega.Equal(mch.Annotations["mch-imageRepository"]), "Override annotations should be updated")
 	})
 
+	// Annotation on MCE but not MCH
+	existingMCE.Annotations["imageRepository"] = "quay.io"
+	mch.SetAnnotations(map[string]string{})
+	got = RenderMultiClusterEngine(existingMCE, mch)
+	t.Run("Remove override annotation", func(t *testing.T) {
+		g.Expect(got.Annotations["random"]).To(gomega.Equal(existingMCE.Annotations["random"]), "Unrelated annotations should not be erased")
+		g.Expect(got.Annotations["imageRepository"]).To(gomega.Equal(""), "Override annotation should be be emptied")
+	})
+
 }
 
 func Test_filterPackageManifests(t *testing.T) {


### PR DESCRIPTION
When the MCH image repository override annotation is set and then removed the annotation remained on MCE. This fix makes sure the override is unset.

Jira: https://issues.redhat.com/browse/ACM-5184