### PR TITLE
Manual bundle-to-charts update for release-2.8

### DIFF
--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-integrations.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-integrations.yaml
@@ -214,6 +214,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-applications
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
@@ -232,6 +232,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-applications
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-channel.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-channel.yaml
@@ -112,8 +112,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-operators
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-hub-subscription.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-hub-subscription.yaml
@@ -114,8 +114,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-operators
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-standalone-subscription.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-standalone-subscription.yaml
@@ -113,8 +113,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-operators
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-subscription-report.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-subscription-report.yaml
@@ -108,6 +108,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-applications
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/search-v2-operator/templates/search-v2-operator-controller-manager.yaml
+++ b/pkg/templates/charts/toggle/search-v2-operator/templates/search-v2-operator-controller-manager.yaml
@@ -140,6 +140,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: search-v2-operator
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}


### PR DESCRIPTION
This PR is the result of a manual bundle-to-chart run on the release-2.8 branch after the changes made by PRs #1042 were merged into this branch.

This is *not* a cherry pick from a similar update done to the `main` branch since the `main` branch now already represents the `release-2.8` release.