### PR TITLE
Manual bundle-to-charts update for main branch

### DIFF
--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-integrations.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-integrations.yaml
@@ -214,6 +214,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-applications
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
@@ -232,6 +232,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-applications
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-channel.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-channel.yaml
@@ -112,8 +112,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-operators
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-hub-subscription.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-hub-subscription.yaml
@@ -114,8 +114,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-operators
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-standalone-subscription.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-standalone-subscription.yaml
@@ -113,8 +113,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
         seccompProfile:
           type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-operators
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-subscription-report.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-subscription-report.yaml
@@ -108,6 +108,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: multicluster-applications
 {{- with .Values.hubconfig.tolerations }}
       tolerations:

--- a/pkg/templates/charts/toggle/search-v2-operator/templates/search-v2-operator-controller-manager.yaml
+++ b/pkg/templates/charts/toggle/search-v2-operator/templates/search-v2-operator-controller-manager.yaml
@@ -140,6 +140,10 @@ spec:
 {{- end }}
       securityContext:
         runAsNonRoot: true
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
       serviceAccountName: search-v2-operator
       terminationGracePeriodSeconds: 10
 {{- with .Values.hubconfig.tolerations }}


### PR DESCRIPTION
DO NOT CHERRY PICK INTO RELEASE-2.8

This PR is the result of a manual bundle-to-chart run on the main branch after the changes made by PR #1041 were merged into this branch.

This is a main-branch counterpart to already-merged PR #1043 . It should NOT be cherry picked into the release-2.8 branch as that update has already been done. (It is necessary to do separate updates since the main branch has moved to representing the next-release (2.8) of ACM and the config for doing the bundle-to-chart generation will now differ between the branches).