### PR TITLE
Update clusterrole to support managedserviceaccounts for gitopscluster controller

### DIFF
--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-applications-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-applications-clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
   - operator.open-cluster-management.io
   - work.open-cluster-management.io
   - view.open-cluster-management.io
+  - authentication.open-cluster-management.io
   resources:
   - channels
   - channels/status
@@ -28,6 +29,7 @@ rules:
   - managedclusterviews
   - managedclusterviews/status
   - managedclusteraddons
+  - managedserviceaccounts
   - multiclusterhubs
   - placements
   - placements/status


### PR DESCRIPTION
Gitopscluster controller needs to be able to access managed service accounts.
    
    Signed-off-by: philipwu08 <phwu@redhat.com>