### PR TITLE
Revert "Update webhook server tls min version to 1.3 (#1029)"

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 		HealthProbeBindAddress:  probeAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "multicloudhub-operator-lock",
-		WebhookServer:           &ctrlwebhook.Server{TLSMinVersion: "1.3"},
+		WebhookServer:           &ctrlwebhook.Server{TLSMinVersion: "1.2"},
 		LeaderElectionNamespace: ns,
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,

--- a/pkg/webhook/setup.go
+++ b/pkg/webhook/setup.go
@@ -80,7 +80,7 @@ func registerWebhook(mgr manager.Manager, ns string) {
 	hookServer := &webhook.Server{
 		Port:          8443,
 		CertDir:       certDir,
-		TLSMinVersion: "1.3",
+		TLSMinVersion: "1.2",
 	}
 
 	log.Info("Add the webhook server.")


### PR DESCRIPTION
This reverts commit e3928dabb23d155aa1d0148c8126fb48ccaa37c2.

Jira: https://issues.redhat.com/browse/ACM-5997