### PR TITLE
Remove ingress spec

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,15 @@
 approvers:
 - cameronmwall
+- dislbenn
 - eemurphy
 - JakobGray
 - joeg-pro
-- ray-harris
-- zkayyali812
+- ngraham20
 
 reviewers:
 - cameronmwall
+- dislbenn
 - eemurphy
 - JakobGray
 - joeg-pro
-- ray-harris
-- zkayyali812
+- ngraham20

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -1361,11 +1361,6 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 	}
 	log.Info("MultiClusterHub is Invalid. Updating with proper defaults")
 
-	if len(m.Spec.Ingress.SSLCiphers) == 0 {
-		m.Spec.Ingress.SSLCiphers = utils.DefaultSSLCiphers
-		updateNecessary = true
-	}
-
 	if !utils.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig) {
 		m.Spec.AvailabilityConfig = operatorv1.HAHigh
 		updateNecessary = true

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -94,7 +93,7 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 	Eventually(func() bool {
 		err := k8sClient.Get(ctx, resources.MCHLookupKey, createdMCH)
 		Expect(err).Should(BeNil())
-		return reflect.DeepEqual(createdMCH.Spec.Ingress.SSLCiphers, utils.DefaultSSLCiphers) && createdMCH.Spec.AvailabilityConfig == mchov1.HAHigh
+		return createdMCH.Spec.AvailabilityConfig == mchov1.HAHigh
 	}, timeout, interval).Should(BeTrue())
 
 	By("Ensuring Deployments")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -59,16 +59,6 @@ const (
 	VolsyncChartLocation       = "/charts/toggle/volsync-controller"
 )
 
-var (
-	// DefaultSSLCiphers defines the default cipher configuration used by management ingress
-	DefaultSSLCiphers = []string{
-		"ECDHE-ECDSA-AES256-GCM-SHA384",
-		"ECDHE-RSA-AES256-GCM-SHA384",
-		"ECDHE-ECDSA-AES128-GCM-SHA256",
-		"ECDHE-RSA-AES128-GCM-SHA256",
-	}
-)
-
 // CertManagerNS returns the namespace to deploy cert manager objects
 func CertManagerNS(m *operatorsv1.MultiClusterHub) string {
 	if m.Spec.SeparateCertificateManagement {


### PR DESCRIPTION
The `ingress` spec has been `deprecated` since the removal of the `management-ingress`. These changes will remove the condition to auto-populate the `ingress` spec.