### PR TITLE
Bug: delete all policies when management + hub hosted mode

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -252,3 +252,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - patch
+  - update


### PR DESCRIPTION
Add role for crd update

Bug: delete all policies when management + hub hosted mode

description:
When hcp clusters are created on the MCV2, policies are rolled out well. When deleting the hcp cluster, we see that all the ACM policies on the ACM hub are also deleted.

ref: https://issues.redhat.com/browse/ACM-6604