### PR TITLE
Fixed clusterpermission chart location

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -651,7 +651,7 @@ func (r *MultiClusterHubReconciler) fetchChartLocation(ctx context.Context, comp
 		return utils.CLCChartLocation
 
 	case operatorv1.ClusterPermission:
-		return utils.CLCChartLocation
+		return utils.ClusterPermissionChartLocation
 
 	case operatorv1.Console:
 		return utils.ConsoleChartLocation


### PR DESCRIPTION
These changes will fix the incorrect path for the `clusterpermission` chart location.