### PR TITLE
[ACM-6959] backport operator conditions

### DIFF
--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	operatorsapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	olmapi "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
@@ -360,6 +361,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 		Expect(olmapi.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(ocmapi.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(networking.AddToScheme(clientScheme)).Should(Succeed())
+		Expect(operatorsapiv2.AddToScheme(clientScheme)).Should(Succeed())
 
 		k8sManager, err := ctrl.NewManager(clientConfig, ctrl.Options{
 			Scheme:                 clientScheme,
@@ -371,11 +373,13 @@ var _ = Describe("MultiClusterHub controller", func() {
 
 		k8sClient = k8sManager.GetClient()
 		Expect(k8sClient).ToNot(BeNil())
+		upgradeableCondition, _ := utils.NewOperatorCondition(k8sClient, operatorsapiv2.Upgradeable)
 
 		reconciler = &MultiClusterHubReconciler{
-			Client: k8sClient,
-			Scheme: k8sManager.GetScheme(),
-			Log:    ctrl.Log.WithName("controllers").WithName("MultiClusterHub"),
+			Client:          k8sClient,
+			Scheme:          k8sManager.GetScheme(),
+			Log:             ctrl.Log.WithName("controllers").WithName("MultiClusterHub"),
+			UpgradeableCond: upgradeableCondition,
 			// CacheSpec: CacheSpec{
 			// 	ImageOverrides: map[string]string{},
 			// },

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1 // indirect
 	github.com/operator-framework/operator-registry v1.17.5 // indirect
+	github.com/operator-framework/operator-lib v0.11.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -797,6 +797,8 @@ github.com/operator-framework/operator-lifecycle-manager v0.22.0 h1:7DEWOq24HQ0l
 github.com/operator-framework/operator-lifecycle-manager v0.22.0/go.mod h1:4zssIIl23ohxS1nXRU9xTkBmwt+qleuHMO02BaWOHLA=
 github.com/operator-framework/operator-registry v1.17.5 h1:LR8m1rFz5Gcyje8WK6iYt+gIhtzqo52zMRALdmTYHT0=
 github.com/operator-framework/operator-registry v1.17.5/go.mod h1:sRQIgDMZZdUcmHltzyCnM6RUoDF+WS8Arj1BQIARDS8=
+github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=
+github.com/operator-framework/operator-lib v0.11.0/go.mod h1:RpyKhFAoG6DmKTDIwMuO6pI3LRc8IE9rxEYWy476o6g=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=

--- a/hack/prereqs/kustomization.yaml
+++ b/hack/prereqs/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - namespace.yaml
   - pull-secret.yaml
   - operatorgroup.yaml
+  - oc.yaml

--- a/hack/prereqs/oc.yaml
+++ b/hack/prereqs/oc.yaml
@@ -1,0 +1,6 @@
+
+apiVersion: operators.coreos.com/v1
+kind: OperatorCondition
+metadata:
+  name: advanced-cluster-management-v2.7.0  
+  namespace: open-cluster-management 

--- a/main.go
+++ b/main.go
@@ -31,11 +31,13 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/controllers"
+	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	"github.com/stolostron/multiclusterhub-operator/pkg/webhook"
 	searchv2v1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
 
@@ -90,6 +92,8 @@ func init() {
 	utilruntime.Must(apiregistrationv1.AddToScheme(scheme))
 
 	utilruntime.Must(apixv1.AddToScheme(scheme))
+
+	utilruntime.Must(operatorsapiv2.AddToScheme(scheme))
 
 	utilruntime.Must(subv1alpha1.AddToScheme(scheme))
 
@@ -167,11 +171,24 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Force OperatorCondition Upgradeable to False
+	//
+	// We have to at least default the condition to False or
+	// OLM will use the Readiness condition via our readiness probe instead:
+	// https://olm.operatorframework.io/docs/advanced-tasks/communicating-operator-conditions-to-olm/#setting-defaults
+	setupLog.Info("Setting OperatorCondition.")
+	upgradeableCondition, err := utils.NewOperatorCondition(uncachedClient, operatorsapiv2.Upgradeable)
+	if err != nil {
+		setupLog.Error(err, "Cannot create the Upgradeable Operator Condition")
+		os.Exit(1)
+	}
+
 	if err = (&controllers.MultiClusterHubReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		UncachedClient: uncachedClient,
-		Log:            ctrl.Log.WithName("Controller").WithName("Multiclusterhub"),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		UncachedClient:  uncachedClient,
+		Log:             ctrl.Log.WithName("Controller").WithName("Multiclusterhub"),
+		UpgradeableCond: upgradeableCondition,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MultiClusterHub")
 		os.Exit(1)

--- a/pkg/utils/operatorconditions.go
+++ b/pkg/utils/operatorconditions.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"context"
+
+	operatorframeworkv2 "github.com/operator-framework/api/pkg/operators/v2"
+	"github.com/operator-framework/operator-lib/conditions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	operatorConditionFactory conditions.Factory
+)
+
+// Condition - We just need the Set method in our code.
+type Condition interface {
+	Set(ctx context.Context, status metav1.ConditionStatus, reason, message string) error
+}
+
+// OperatorCondition wraps operator-lib's Condition to make it not crash,
+// when running locally or in Kubernetes without OLM.
+type OperatorCondition struct {
+	cond conditions.Condition
+}
+
+const (
+	UpgradeableInitReason  = "Initializing"
+	UpgradeableInitMessage = "The mch operator is starting up"
+
+	UpgradeableUpgradingReason  = "AlreadyPerformingUpgrade"
+	UpgradeableUpgradingMessage = "upgrading the mch operator to version "
+
+	UpgradeableAllowReason  = "Upgradeable"
+	UpgradeableAllowMessage = ""
+)
+
+var GetFactory = func(cl client.Client) conditions.Factory {
+	if operatorConditionFactory == nil {
+		operatorConditionFactory = conditions.InClusterFactory{Client: cl}
+	}
+	return operatorConditionFactory
+}
+
+func NewOperatorCondition(cl client.Client, condType string) (*OperatorCondition, error) {
+	oc := &OperatorCondition{}
+
+	cond, err := GetFactory(cl).NewCondition(operatorframeworkv2.ConditionType(condType))
+	if err != nil {
+		return nil, err
+	}
+	oc.cond = cond
+	return oc, nil
+}
+
+func (oc *OperatorCondition) Set(ctx context.Context, status metav1.ConditionStatus, reason, message string) error {
+	if oc == nil || oc.cond == nil {
+		// no op
+		return nil
+	}
+
+	return oc.cond.Set(ctx, status, conditions.WithReason(reason), conditions.WithMessage(message))
+}

--- a/pkg/utils/operatorconditions_test.go
+++ b/pkg/utils/operatorconditions_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package utils
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// "reflect"
+	"testing"
+)
+
+func TestNewOperatorCondition(t *testing.T) {
+	t.Run("Unpaused MCH", func(t *testing.T) {
+		oc := &OperatorCondition{}
+		msg := UpgradeableAllowMessage
+		status := metav1.ConditionTrue
+		reason := UpgradeableAllowReason
+		ctx := context.Background()
+		err := oc.Set(ctx, status, reason, msg)
+		if err != nil {
+			t.Errorf("Unable to set")
+		}
+	})
+}


### PR DESCRIPTION
This is a  backport of  identical code from 2.8 which  should use operator conditions to prevent upgrading unless the MCH is available