### PR TITLE
[ACM-7574] Remove submariner ClusterManagementAddOn as pre-req to cleanup

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -166,8 +166,8 @@ func GetDefaultHostedComponents() []string {
 	return defaultHostedComponents
 }
 
-// GetClusterManagementAddon returns the name of the ClusterManagementAddOn based on the provided component name.
-func GetClusterManagementAddon(component string) (string, error) {
+// GetClusterManagementAddonName returns the name of the ClusterManagementAddOn based on the provided component name.
+func GetClusterManagementAddonName(component string) (string, error) {
 	if val, ok := clusterManagementAddOns[component]; !ok {
 		return val, fmt.Errorf("failed to find ClusterManagementAddOn name for: %s component", component)
 	} else {

--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -2,11 +2,12 @@ package v1
 
 import (
 	"errors"
+	"fmt"
 	"os"
 )
 
+// Component related to MultiClusterHub (MCH)
 const (
-	// MCH
 	Appsub                    string = "app-lifecycle"
 	ClusterBackup             string = "cluster-backup"
 	ClusterLifecycle          string = "cluster-lifecycle"
@@ -21,8 +22,10 @@ const (
 	Search                    string = "search"
 	SubmarinerAddon           string = "submariner-addon"
 	Volsync                   string = "volsync"
+)
 
-	// MCE
+// Component related to MultiCluster Engine (MCE)
+const (
 	MCEAssistedService              string = "assisted-service"
 	MCEClusterLifecycle             string = "cluster-lifecycle-mce"
 	MCEClusterManager               string = "cluster-manager"
@@ -39,8 +42,8 @@ const (
 	MCEServerFoundation             string = "server-foundation"
 )
 
+// allComponents is a slice containing all the component names from both "MCH" and "MCE" categories.
 var allComponents = []string{
-	// MCH
 	Appsub,
 	ClusterBackup,
 	ClusterLifecycle,
@@ -56,7 +59,6 @@ var allComponents = []string{
 	SubmarinerAddon,
 	Volsync,
 
-	// MCE
 	MCEAssistedService,
 	MCEClusterLifecycle,
 	MCEClusterManager,
@@ -75,6 +77,7 @@ var allComponents = []string{
 	MCEServerFoundation,
 }
 
+// MCHComponents is a slice containing component names specific to the "MCH" category.
 var MCHComponents = []string{
 	Appsub,
 	ClusterBackup,
@@ -91,6 +94,7 @@ var MCHComponents = []string{
 	Volsync,
 }
 
+// MCEComponents is a slice containing component names specific to the "MCE" category.
 var MCEComponents = []string{
 	MCEAssistedService,
 	MCEClusterLifecycle,
@@ -109,6 +113,13 @@ var MCEComponents = []string{
 	MCEServerFoundation,
 }
 
+// clusterManagementAddOns is a map that associates certain component names with their corresponding add-ons.
+var clusterManagementAddOns = map[string]string{
+	SubmarinerAddon: "submariner",
+	// Add other components here when clusterManagementAddOns is required.
+}
+
+// GetDefaultEnabledComponents returns a slice of default enabled component names. It is expected to be used to get a list of components that are enabled by default.
 func GetDefaultEnabledComponents() ([]string, error) {
 	var defaultEnabledComponents = []string{
 		//Repo,
@@ -128,6 +139,7 @@ func GetDefaultEnabledComponents() ([]string, error) {
 	return defaultEnabledComponents, nil
 }
 
+// GetDefaultDisabledComponents returns a slice of default disabled component names. It is expected to be used to get a list of components that are disabled by default.
 func GetDefaultDisabledComponents() ([]string, error) {
 	var defaultDisabledComponents = []string{
 		ClusterBackup,
@@ -135,15 +147,26 @@ func GetDefaultDisabledComponents() ([]string, error) {
 	return defaultDisabledComponents, nil
 }
 
+// GetDefaultHostedComponents returns a slice of default hosted components. These are components that are hosted within the system.
 func GetDefaultHostedComponents() []string {
 	var defaultHostedComponents = []string{
 		MultiClusterEngine,
-		//Add other components here when added to hostedmode
+		// Add other components here when added to hostedmode
 	}
 
 	return defaultHostedComponents
 }
 
+// GetClusterManagementAddon returns the name of the ClusterManagementAddOn based on the provided component name.
+func GetClusterManagementAddon(component string) (string, error) {
+	if val, ok := clusterManagementAddOns[component]; !ok {
+		return val, fmt.Errorf("failed to find ClusterManagementAddOn name for: %s component", component)
+	} else {
+		return val, nil
+	}
+}
+
+// ComponentPresent checks if a specific component is present based on the provided component name in the MultiClusterHub struct.
 func (mch *MultiClusterHub) ComponentPresent(s string) bool {
 	if mch.Spec.Overrides == nil {
 		return false
@@ -156,6 +179,7 @@ func (mch *MultiClusterHub) ComponentPresent(s string) bool {
 	return false
 }
 
+// Enabled checks if a specific component is enabled based on the provided component name in the MultiClusterHub struct.
 func (mch *MultiClusterHub) Enabled(s string) bool {
 	if mch.Spec.Overrides == nil {
 		return false
@@ -169,6 +193,7 @@ func (mch *MultiClusterHub) Enabled(s string) bool {
 	return false
 }
 
+// Enable enables a specific component based on the provided component name in the MultiClusterHub struct.
 func (mch *MultiClusterHub) Enable(s string) {
 	if mch.Spec.Overrides == nil {
 		mch.Spec.Overrides = &Overrides{}
@@ -185,6 +210,7 @@ func (mch *MultiClusterHub) Enable(s string) {
 	})
 }
 
+// Disable disables a specific component based on the provided component name in the MultiClusterHub struct.
 func (mch *MultiClusterHub) Disable(s string) {
 	if mch.Spec.Overrides == nil {
 		mch.Spec.Overrides = &Overrides{}
@@ -201,7 +227,7 @@ func (mch *MultiClusterHub) Disable(s string) {
 	})
 }
 
-// Prune removes the component from the component list. Returns true if changes are made
+// Prune removes a specific component from the component list in the MultiClusterHub struct. It returns true if changes were made.
 func (mch *MultiClusterHub) Prune(s string) bool {
 	if mch.Spec.Overrides == nil {
 		return false
@@ -223,7 +249,7 @@ func (mch *MultiClusterHub) Prune(s string) bool {
 	return false
 }
 
-// a component is valid if its name matches a known component
+// ValidComponent checks if a given component configuration is valid by comparing its name to the known component names.
 func ValidComponent(c ComponentConfig) bool {
 	for _, name := range allComponents {
 		if c.Name == name {

--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -119,7 +119,10 @@ var clusterManagementAddOns = map[string]string{
 	// Add other components here when clusterManagementAddOns is required.
 }
 
-// GetDefaultEnabledComponents returns a slice of default enabled component names. It is expected to be used to get a list of components that are enabled by default.
+/*
+GetDefaultEnabledComponents returns a slice of default enabled component names.
+It is expected to be used to get a list of components that are enabled by default.
+*/
 func GetDefaultEnabledComponents() ([]string, error) {
 	var defaultEnabledComponents = []string{
 		//Repo,
@@ -139,7 +142,10 @@ func GetDefaultEnabledComponents() ([]string, error) {
 	return defaultEnabledComponents, nil
 }
 
-// GetDefaultDisabledComponents returns a slice of default disabled component names. It is expected to be used to get a list of components that are disabled by default.
+/*
+GetDefaultDisabledComponents returns a slice of default disabled component names.
+It is expected to be used to get a list of components that are disabled by default.
+*/
 func GetDefaultDisabledComponents() ([]string, error) {
 	var defaultDisabledComponents = []string{
 		ClusterBackup,
@@ -147,7 +153,10 @@ func GetDefaultDisabledComponents() ([]string, error) {
 	return defaultDisabledComponents, nil
 }
 
-// GetDefaultHostedComponents returns a slice of default hosted components. These are components that are hosted within the system.
+/*
+GetDefaultHostedComponents returns a slice of default hosted components.
+These are components that are hosted within the system.
+*/
 func GetDefaultHostedComponents() []string {
 	var defaultHostedComponents = []string{
 		MultiClusterEngine,
@@ -166,7 +175,10 @@ func GetClusterManagementAddon(component string) (string, error) {
 	}
 }
 
-// ComponentPresent checks if a specific component is present based on the provided component name in the MultiClusterHub struct.
+/*
+ComponentPresent checks if a specific component is present based on the provided component name in the
+MultiClusterHub struct.
+*/
 func (mch *MultiClusterHub) ComponentPresent(s string) bool {
 	if mch.Spec.Overrides == nil {
 		return false
@@ -227,7 +239,10 @@ func (mch *MultiClusterHub) Disable(s string) {
 	})
 }
 
-// Prune removes a specific component from the component list in the MultiClusterHub struct. It returns true if changes were made.
+/*
+Prune removes a specific component from the component list in the MultiClusterHub struct.
+It returns true if changes were made.
+*/
 func (mch *MultiClusterHub) Prune(s string) bool {
 	if mch.Spec.Overrides == nil {
 		return false

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -156,7 +156,7 @@ func TestGetDefaultHostedComponents(t *testing.T) {
 	}
 }
 
-func TestGetClusterManagementAddon(t *testing.T) {
+func TestGetClusterManagementAddonName(t *testing.T) {
 	tests := []struct {
 		name      string
 		component string
@@ -176,13 +176,13 @@ func TestGetClusterManagementAddon(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetClusterManagementAddon(tt.component)
+			got, err := GetClusterManagementAddonName(tt.component)
 			if err != nil && tt.component != "unknown" {
-				t.Errorf("GetClusterManagementAddon(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+				t.Errorf("GetClusterManagementAddonName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
 			}
 
 			if got != tt.want {
-				t.Errorf("GetClusterManagementAddon(%v) = %v, want: %v", tt.component, got, tt.want)
+				t.Errorf("GetClusterManagementAddonName(%v) = %v, want: %v", tt.component, got, tt.want)
 			}
 		})
 	}

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -76,3 +76,114 @@ func TestMultiClusterHub_Prune(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDisabledComponents(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		want      bool
+		want2     int
+	}{
+		{
+			name:      "default disabled components",
+			component: ClusterBackup,
+			want:      true,
+			want2:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			disabledComponents, err := GetDefaultDisabledComponents()
+
+			if err != nil {
+				t.Errorf("GetDefaultDisabledComponents() = %v, want: %v", err.Error(), nil)
+			}
+
+			pass := false
+			for _, c := range disabledComponents {
+				if c == tt.component {
+					pass = true
+				}
+			}
+
+			if !pass {
+				t.Errorf("GetDefaultDisabledComponents() = %v, want: %v", pass, tt.want)
+			}
+
+			if len(disabledComponents) != 1 {
+				t.Errorf("GetDefaultDisabledComponents() = %v, want: %v", len(disabledComponents), tt.want2)
+			}
+		})
+	}
+}
+
+func TestGetDefaultHostedComponents(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		want      int
+		want2     bool
+	}{
+		{
+			name:      "default hosted components",
+			component: MultiClusterEngine,
+			want:      1,
+			want2:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostedComponents := GetDefaultHostedComponents()
+
+			if len(hostedComponents) != 1 {
+				t.Errorf("GetDefaultHostedComponents() = %v, want: %v", len(hostedComponents), tt.want)
+			}
+
+			pass := false
+			for _, c := range hostedComponents {
+				if c == tt.component {
+					pass = true
+				}
+			}
+
+			if !pass {
+				t.Errorf("GetDefaultHostedComponents() = %v, want: %v", pass, tt.want2)
+			}
+
+		})
+	}
+}
+
+func TestGetClusterManagementAddon(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		want      string
+	}{
+		{
+			name:      "submariner ClusterManagementAddOn",
+			component: SubmarinerAddon,
+			want:      "submariner",
+		},
+		{
+			name:      "unknown ClusterManagementAddOn",
+			component: "unknown",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetClusterManagementAddon(tt.component)
+			if err != nil && tt.component != "unknown" {
+				t.Errorf("GetClusterManagementAddon(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+			}
+
+			if got != tt.want {
+				t.Errorf("GetClusterManagementAddon(%v) = %v, want: %v", tt.component, got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -831,17 +831,16 @@ func (r *MultiClusterHubReconciler) ensureNoClusterManagementAddOn(m *operatorv1
 	ctx := context.Background()
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		addonName, err := operatorv1.GetClusterManagementAddon(component)
+		addonName, err := operatorv1.GetClusterManagementAddonName(component)
 		if err != nil {
 			r.Log.Info(fmt.Sprintf("Detected unregistered ClusterManagementAddon component: %s", err.Error()))
 			return err
 		}
 
-		clusterMgmtAddon := &ocmapi.ClusterManagementAddOn{}
-		err = r.Client.Get(ctx, types.NamespacedName{Name: addonName}, clusterMgmtAddon)
-		if err != nil && (!errors.IsNotFound(err) || !errors.IsGone(err)) {
-			r.Log.Info(fmt.Sprintf("Error fetching ClusterManagementAddOn CR: %s", err.Error()))
-			return err
+		clusterMgmtAddon := &ocmapi.ClusterManagementAddOn{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: addonName,
+			},
 		}
 
 		err = r.Client.Delete(context.TODO(), clusterMgmtAddon)

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -842,16 +842,17 @@ func (r *MultiClusterHubReconciler) ensureNoClusterManagementAddOn(m *operatorv1
 	}
 
 	err = r.Client.Delete(context.TODO(), clusterMgmtAddon)
-	if err != nil && (!errors.IsNotFound(err) || !errors.IsGone(err)) {
+	if err != nil && !errors.IsNotFound(err) {
 		r.Log.Error(err, fmt.Sprintf("Error deleting ClusterManagementAddOn CR"))
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	err = r.Client.Get(ctx, types.NamespacedName{Name: addonName}, clusterMgmtAddon)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterMgmtAddon.GetName()}, clusterMgmtAddon)
 	if err == nil {
 		return ctrl.Result{Requeue: true}, errors.NewBadRequest("ClusterManagementAddOn CR has not been deleted")
 	}
 
+	r.Log.Info(fmt.Sprintf("Successfully deleted ClusterManagementAddOn CR: %s", clusterMgmtAddon.GetName()))
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -839,13 +839,13 @@ func (r *MultiClusterHubReconciler) ensureNoClusterManagementAddOn(m *operatorv1
 
 		clusterMgmtAddon := &ocmapi.ClusterManagementAddOn{}
 		err = r.Client.Get(ctx, types.NamespacedName{Name: addonName}, clusterMgmtAddon)
-		if err != nil {
-			r.Log.Info(fmt.Sprintf("Error locating ClusterManagementAddOn CR: %s", err.Error()))
+		if err != nil && (!errors.IsNotFound(err) || !errors.IsGone(err)) {
+			r.Log.Info(fmt.Sprintf("Error fetching ClusterManagementAddOn CR: %s", err.Error()))
 			return err
 		}
 
 		err = r.Client.Delete(context.TODO(), clusterMgmtAddon)
-		if err != nil {
+		if err != nil && (!errors.IsNotFound(err) || !errors.IsGone(err)) {
 			r.Log.Error(err, fmt.Sprintf("Error deleting ClusterManagementAddOn CR"))
 			return err
 		}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -709,9 +709,12 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 			return result, err
 		}
 
-	// In ACM 2.9 we need to ensure that the submariner ClusterManagementAddOn is removed before removing the submariner-addon component.
+	/*
+		In ACM 2.9 we need to ensure that the submariner ClusterManagementAddOn is removed before
+		removing the submariner-addon component.
+	*/
 	case operatorv1.SubmarinerAddon:
-		_, err := r.ensureNoClusterManagementAddOn(m, component)
+		result, err := r.ensureNoClusterManagementAddOn(m, component)
 		if err != nil {
 			return result, err
 		}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -708,6 +708,13 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 		if err != nil {
 			return result, err
 		}
+
+	// In ACM 2.9 we need to ensure that the submariner ClusterManagementAddOn is removed before removing the submariner-addon component.
+	case operatorv1.SubmarinerAddon:
+		_, err := r.ensureNoClusterManagementAddOn(m, component)
+		if err != nil {
+			return result, err
+		}
 	}
 
 	// Renders all templates from charts

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -64,6 +64,7 @@ func ApplyPrereqs(k8sClient client.Client) {
 	ctx := context.Background()
 	Expect(k8sClient.Create(ctx, resources.OCMNamespace())).Should(Succeed())
 	Expect(k8sClient.Create(ctx, resources.MonitoringNamespace())).Should(Succeed())
+	Expect(k8sClient.Create(ctx, resources.SampleClusterManagementAddOn(operatorv1.SubmarinerAddon)))
 }
 
 func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler, mchoDeployment *appsv1.Deployment) {

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -819,6 +819,11 @@ var _ = Describe("MultiClusterHub controller", func() {
 			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).To(BeNil())
 
+			By("Ensuring No ClusterManagementAddon")
+			result, err = reconciler.ensureNoClusterManagementAddOn(mch, "unknown")
+			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+			Expect(err).To(Not(BeNil()))
+
 			By("Ensuring No Unregistered Component")
 			result, err = reconciler.ensureNoComponent(ctx, mch, "unknown", testImages)
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: resyncPeriod}))

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -816,9 +816,10 @@ var _ = Describe("MultiClusterHub controller", func() {
 			Expect(err).To(BeNil())
 
 			By("Ensuring No SubmarinerAddon")
-			result, err = reconciler.ensureNoComponent(ctx, mch, operatorv1.SubmarinerAddon, testImages)
-			Expect(result).To(Equal(ctrl.Result{}))
-			Expect(err).To(BeNil())
+			Eventually(func() bool {
+				result, err := reconciler.ensureNoComponent(ctx, mch, operatorv1.SubmarinerAddon, testImages)
+				return (err == nil && result == ctrl.Result{})
+			}, timeout, interval).Should(BeTrue())
 
 			By("Ensuring No ClusterManagementAddon")
 			result, err = reconciler.ensureNoClusterManagementAddOn(mch, "unknown")

--- a/main.go
+++ b/main.go
@@ -46,6 +46,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	ocmapi "open-cluster-management.io/api/addon/v1alpha1"
+
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmapi "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 
@@ -122,6 +124,8 @@ func init() {
 	utilruntime.Must(olmapi.AddToScheme(scheme))
 
 	utilruntime.Must(networking.AddToScheme(scheme))
+
+	utilruntime.Must(ocmapi.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }

--- a/test/unit-tests/resources.go
+++ b/test/unit-tests/resources.go
@@ -206,7 +206,7 @@ func SampleService(m *operatorsv1.MultiClusterHub) *corev1.Service {
 }
 
 func SampleClusterManagementAddOn(component string) *ocmapi.ClusterManagementAddOn {
-	addonName, err := operatorsv1.GetClusterManagementAddon(component)
+	addonName, err := operatorsv1.GetClusterManagementAddonName(component)
 	if err != nil {
 		addonName = "unknown"
 	}

--- a/test/unit-tests/resources.go
+++ b/test/unit-tests/resources.go
@@ -10,6 +10,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ocmapi "open-cluster-management.io/api/addon/v1alpha1"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -201,4 +203,25 @@ func SampleService(m *operatorsv1.MultiClusterHub) *corev1.Service {
 	}
 
 	return s
+}
+
+func SampleClusterManagementAddOn(component string) *ocmapi.ClusterManagementAddOn {
+	addonName, err := operatorsv1.GetClusterManagementAddon(component)
+	if err != nil {
+		addonName = "unknown"
+	}
+
+	addon := &ocmapi.ClusterManagementAddOn{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: addonName,
+		},
+		Spec: ocmapi.ClusterManagementAddOnSpec{
+			AddOnMeta: ocmapi.AddOnMeta{
+				Description: "Sample addon description",
+				DisplayName: component,
+			},
+		},
+	}
+
+	return addon
 }


### PR DESCRIPTION
# Description

Before the `submariner-addon` component can be cleaned up and removed, we need to ensure that the `ClusterManagementAddOn` is removed from the cluster. This will allow MCH to proceed with the component removal.

## Related Issue

https://issues.redhat.com/browse/ACM-7574

## Changes Made

Update the disable/uninstall process to ensure that the `ClusterManagementAddOn` CR is removed for the `submariner-addon` before removing the `submariner-addon` component.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @ngraham20 @cameronmwall 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

/hold