### PR TITLE
Move the GRC Prometheus configuration out of the openshift-monitoring ns

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -301,6 +301,11 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
+	err = r.removeLegacyGRCPrometheusConfig(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Install CRDs
 	var reason string
 	reason, err = r.installCRDs(r.Log, multiClusterHub)

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -36,7 +36,9 @@ import (
 	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -847,6 +849,84 @@ var _ = Describe("MultiClusterHub controller", func() {
 
 			result, err = reconciler.ensureNoComponent(ctx, mch, operatorv1.Appsub, testImages)
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 20000000000}))
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Legacy clean up tasks", func() {
+		It("Removes the legacy GRC Prometheus configuration", func() {
+			By("Applying prereqs")
+			ApplyPrereqs(k8sClient)
+
+			By("Creating the legacy GRC PrometheusRule and ServiceMonitor")
+			pr := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"groups": []interface{}{
+							map[string]interface{}{
+								"name": "some-group",
+								"rules": []interface{}{
+									map[string]interface{}{
+										"expr": "something else",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			pr.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "monitoring.coreos.com",
+				Kind:    "PrometheusRule",
+				Version: "v1",
+			})
+			pr.SetName("ocm-grc-policy-propagator-metrics")
+			pr.SetNamespace("openshift-monitoring")
+
+			err := k8sClient.Create(context.TODO(), pr)
+			Expect(err).To(BeNil())
+
+			sm := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"endpoints": []interface{}{
+							map[string]interface{}{
+								"path": "/some/path",
+							},
+						},
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"app": "grc",
+							},
+						},
+					},
+				},
+			}
+			sm.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "monitoring.coreos.com",
+				Kind:    "ServiceMonitor",
+				Version: "v1",
+			})
+			sm.SetName("ocm-grc-policy-propagator-metrics")
+			sm.SetNamespace("openshift-monitoring")
+
+			err = k8sClient.Create(context.TODO(), sm)
+			Expect(err).To(BeNil())
+
+			By("Running the cleanup of the legacy Prometheus configuration")
+			err = reconciler.removeLegacyGRCPrometheusConfig(context.TODO())
+			Expect(err).To(BeNil())
+
+			By("Verifying that the legacy GRC PrometheusRule is deleted")
+			err = k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pr), pr)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			By("Verifying that the legacy GRC ServiceMonitor is deleted")
+			err = k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(sm), sm)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			By("Running the cleanup of the legacy Prometheus configuration again should do nothing")
+			err = reconciler.removeLegacyGRCPrometheusConfig(context.TODO())
 			Expect(err).To(BeNil())
 		})
 	})

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-prometheusrule.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: ocm-grc-policy-propagator-metrics
-  namespace: openshift-monitoring
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: grc
     chart: grc-chart-{{ .Values.hubconfig.hubVersion }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-metrics-servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: ocm-grc-policy-propagator-metrics
-  namespace: openshift-monitoring
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: grc
     chart: grc-chart-{{ .Values.hubconfig.hubVersion }}


### PR DESCRIPTION
# Description

Move the GRC Prometheus configuration out of the openshift-monitoring ns.

It is a best practice to not add PrometheusRules and ServiceMonitors in the openshift-monitoring namespace. Instead a namespace can have the openshift.io/cluster-monitoring label set for the Prometheus operator to use this configuration.

This also handles deleting the old GRC Prometheus configuration in the openshift-monitoring namespace.

## Related Issue

https://issues.redhat.com/browse/ACM-7633

## Changes Made

The GRC PrometheusRule and ServiceMonitor are placed in the controller's namespace instead of the openshift-monitoring namespace. The existing objects in the openshift-monitoring namespace are deleted.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

I haven't tried running this locally but the unit test is comprehensive and runs against a real Kubernetes API server.

This should likely not be merged until the following is complete:
https://issues.redhat.com/browse/ACM-7637

## Reviewers

@dislbenn 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
