### PR TITLE
[ACM-7637] Updated MCH operator namespace to support openshift.io/cluster-monito…

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -183,7 +183,7 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 			return ctrl.Result{Requeue: true}, err
 		}
 		if configured {
-			ns, err := utils.FindNamespace()
+			ns, err := utils.OperatorNamespace()
 			if err != nil {
 				return ctrl.Result{Requeue: true}, err
 			}
@@ -647,7 +647,7 @@ func mergeErrors(errs []error) string {
 // GetSubConfig returns a SubscriptionConfig based on proxy variables and the mch operator configuration
 func (r *MultiClusterHubReconciler) GetSubConfig() (*subv1alpha1.SubscriptionConfig, error) {
 	found := &appsv1.Deployment{}
-	mchOperatorNS, err := utils.FindNamespace()
+	mchOperatorNS, err := utils.OperatorNamespace()
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -754,6 +754,10 @@ func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Co
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	if existingNs.Labels == nil || len(existingNs.Labels) == 0 {
+		existingNs.Labels = make(map[string]string)
+	}
+
 	if _, ok := existingNs.Labels[utils.OpenShiftClusterMonitoringLabel]; !ok {
 		r.Log.Info(fmt.Sprintf("Adding label: %s to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
 			m.GetNamespace()))

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -251,6 +251,18 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	/*
+		In ACM 2.9, we need to ensure that the openshift.io/cluster-monitoring is added to the same namespace as the
+		MultiClusterHub to avoid conflicts with the openshift-* namespace when deploying PrometheusRules and
+		ServiceMonitors in ACM.
+	*/
+	result, err = r.ensureOpenShiftNamespaceLabel(ctx, multiClusterHub)
+	if err != nil {
+		r.Log.Error(err, "Failed to add to %s label to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
+			multiClusterHub.GetNamespace())
+		return ctrl.Result{}, err
+	}
+
 	err = r.maintainImageManifestConfigmap(multiClusterHub)
 	if err != nil {
 		r.Log.Error(err, "Error storing image manifests in configmap")
@@ -727,6 +739,34 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 			return result, err
 		}
 	}
+	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Context,
+	m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
+
+	log := log.FromContext(ctx)
+	existingNs := &corev1.Namespace{}
+
+	err := r.Client.Get(ctx, types.NamespacedName{Name: m.GetNamespace()}, existingNs)
+	if err != nil || errors.IsNotFound(err) {
+		log.Error(err, fmt.Sprintf("Failed to find namespace for MultiClusterHub: %s", m.GetNamespace()))
+		return ctrl.Result{Requeue: true}, err
+	}
+
+	if _, ok := existingNs.Labels[utils.OpenShiftClusterMonitoringLabel]; !ok {
+		r.Log.Info(fmt.Sprintf("Adding label: %s to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
+			m.GetNamespace()))
+		existingNs.Labels[utils.OpenShiftClusterMonitoringLabel] = "true"
+
+		err = r.Client.Update(ctx, existingNs)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Failed to update namespace for MultiClusterHub: %s with the label: %s",
+				m.GetNamespace(), utils.OpenShiftClusterMonitoringLabel))
+			return ctrl.Result{Requeue: true}, err
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -164,7 +164,7 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 		return false
 	}, timeout, interval).Should(BeTrue())
 
-	By("ensuring the trusted-ca-bundle ConfigMap is created")
+	By("Ensuring the trusted-ca-bundle ConfigMap is created")
 	Eventually(func(g Gomega) {
 		ctx := context.Background()
 		namespacedName := types.NamespacedName{
@@ -823,6 +823,14 @@ var _ = Describe("MultiClusterHub controller", func() {
 			result, err = reconciler.ensureNoComponent(ctx, mch, "unknown", testImages)
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: resyncPeriod}))
 			Expect(err).To(BeNil())
+
+			By("Ensuring No OpenShift Cluster Monitoring Labels")
+			mch2 := &mchov1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{Name: "mch", Namespace: "test-ns-1"},
+			}
+
+			result, err = reconciler.ensureOpenShiftNamespaceLabel(ctx, mch2)
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: resyncPeriod}))
 		})
 	})
 

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -830,7 +830,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 			}
 
 			result, err = reconciler.ensureOpenShiftNamespaceLabel(ctx, mch2)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: resyncPeriod}))
+			Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 		})
 	})
 

--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -182,6 +182,9 @@ func Namespace() *corev1.Namespace {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
+			Labels: map[string]string{
+				utils.OpenShiftClusterMonitoringLabel: "true",
+			},
 		},
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,45 +22,80 @@ import (
 )
 
 const (
-	// WebhookServiceName ...
+	// WebhookServiceName is the name of the webhook service.
 	WebhookServiceName = "multiclusterhub-operator-webhook"
 
-	// CertManagerNamespace ...
+	// CertManagerNamespace is the namespace where CertManager is deployed.
 	CertManagerNamespace = "cert-manager"
 
+	// podNamespaceEnvVar is the environment variable name for the pod's namespace.
 	podNamespaceEnvVar = "POD_NAMESPACE"
-	rsaKeySize         = 2048
-	duration365d       = time.Hour * 24 * 365
 
-	// DefaultRepository ...
+	// rsaKeySize is the size of the RSA key in bits.
+	rsaKeySize = 2048
+
+	// duration365d is the duration of 365 days in hours.
+	duration365d = time.Hour * 24 * 365
+
+	// DefaultRepository is the default repository for images.
 	DefaultRepository = "quay.io/stolostron"
 
-	// UnitTestEnvVar ...
+	// UnitTestEnvVar is the environment variable for unit testing.
 	UnitTestEnvVar = "UNIT_TEST"
 
-	// MCHOperatorName is the name of this operator deployment
+	// MCHOperatorName is the name of the Multicluster Hub operator deployment.
 	MCHOperatorName = "multiclusterhub-operator"
 
-	// SubscriptionOperatorName is the name of the operator deployment managing application subscriptions
+	// SubscriptionOperatorName is the name of the operator deployment managing application subscriptions.
 	SubscriptionOperatorName = "multicluster-operators-standalone-subscription"
 
-	MCESubscriptionName          = "multicluster-engine"
-	MCESubscriptionNamespace     = "multicluster-engine"
+	// MCESubscriptionName is the name of the Multicluster Engine subscription.
+	MCESubscriptionName = "multicluster-engine"
+
+	// MCESubscriptionNamespace is the namespace for the Multicluster Engine subscription.
+	MCESubscriptionNamespace = "multicluster-engine"
+
+	// ClusterSubscriptionNamespace is the namespace for the open-cluster-management-backup subscription.
 	ClusterSubscriptionNamespace = "open-cluster-management-backup"
 
+	// MCEManagedByLabel is the label used to mark resources managed by Multicluster Hub.
 	MCEManagedByLabel = "multiclusterhubs.operator.open-cluster-management.io/managed-by"
 
-	AppsubChartLocation            = "/charts/toggle/multicloud-operators-subscription"
-	CLCChartLocation               = "/charts/toggle/cluster-lifecycle"
-	ClusterBackupChartLocation     = "/charts/toggle/cluster-backup"
+	// OpenShiftClusterMonitoringLabel is the label for OpenShift cluster monitoring.
+	OpenShiftClusterMonitoringLabel = "openshift.io/cluster-monitoring"
+
+	// AppsubChartLocation is the location of the App Subscription chart.
+	AppsubChartLocation = "/charts/toggle/multicloud-operators-subscription"
+
+	// CLCChartLocation is the location of the Cluster Lifecycle chart.
+	CLCChartLocation = "/charts/toggle/cluster-lifecycle"
+
+	// ClusterBackupChartLocation is the location of the Cluster Backup chart.
+	ClusterBackupChartLocation = "/charts/toggle/cluster-backup"
+
+	// ClusterPermissionChartLocation is the location of the Cluster Permission chart.
 	ClusterPermissionChartLocation = "/charts/toggle/cluster-permission"
-	ConsoleChartLocation           = "/charts/toggle/console"
-	GRCChartLocation               = "/charts/toggle/grc"
-	InsightsChartLocation          = "/charts/toggle/insights"
-	MCOChartLocation               = "/charts/toggle/multicluster-observability-operator"
-	SearchV2ChartLocation          = "/charts/toggle/search-v2-operator"
-	SubmarinerAddonChartLocation   = "/charts/toggle/submariner-addon"
-	VolsyncChartLocation           = "/charts/toggle/volsync-controller"
+
+	// ConsoleChartLocation is the location of the Console chart.
+	ConsoleChartLocation = "/charts/toggle/console"
+
+	// GRCChartLocation is the location of the GRC chart.
+	GRCChartLocation = "/charts/toggle/grc"
+
+	// InsightsChartLocation is the location of the Insights chart.
+	InsightsChartLocation = "/charts/toggle/insights"
+
+	// MCOChartLocation is the location of the Multicluster Observability Operator chart.
+	MCOChartLocation = "/charts/toggle/multicluster-observability-operator"
+
+	// SearchV2ChartLocation is the location of the Search V2 Operator chart.
+	SearchV2ChartLocation = "/charts/toggle/search-v2-operator"
+
+	// SubmarinerAddonChartLocation is the location of the Submariner Addon chart.
+	SubmarinerAddonChartLocation = "/charts/toggle/submariner-addon"
+
+	// VolsyncChartLocation is the location of the Volsync Controller chart.
+	VolsyncChartLocation = "/charts/toggle/volsync-controller"
 )
 
 var (
@@ -336,8 +371,8 @@ func ProxyEnvVarsAreSet() bool {
 	return false
 }
 
-// FindNamespace
-func FindNamespace() (string, error) {
+// OperatorNamespace returns the namespace where the MultiClusterHub operator is registered or deployed.
+func OperatorNamespace() (string, error) {
 	ns, found := os.LookupEnv(podNamespaceEnvVar)
 	if !found {
 		return "", fmt.Errorf("%s envvar is not set", podNamespaceEnvVar)

--- a/test/unit-tests/resources.go
+++ b/test/unit-tests/resources.go
@@ -74,7 +74,6 @@ func EmptyMCH() operatorsv1.MultiClusterHub {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MulticlusterhubName,
 			Namespace: MulticlusterhubNamespace,
-			Labels:    map[string]string{},
 		},
 		Spec: operatorsv1.MultiClusterHubSpec{
 			Overrides: &operatorsv1.Overrides{
@@ -94,7 +93,6 @@ func NoComponentMCH() operatorsv1.MultiClusterHub {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MulticlusterhubName,
 			Namespace: MulticlusterhubNamespace,
-			Labels:    map[string]string{},
 		},
 		Spec: operatorsv1.MultiClusterHubSpec{
 			Overrides: &operatorsv1.Overrides{
@@ -163,7 +161,8 @@ func InsightsMCH() operatorsv1.MultiClusterHub {
 func OCMNamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: MulticlusterhubNamespace,
+			Name:   MulticlusterhubNamespace,
+			Labels: map[string]string{},
 		},
 	}
 }
@@ -171,7 +170,8 @@ func OCMNamespace() *corev1.Namespace {
 func MCENamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "multicluster-engine",
+			Name:   "multicluster-engine",
+			Labels: map[string]string{},
 		},
 	}
 }

--- a/test/unit-tests/resources.go
+++ b/test/unit-tests/resources.go
@@ -162,7 +162,7 @@ func OCMNamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   MulticlusterhubNamespace,
-			Labels: map[string]string{},
+			Labels: make(map[string]string),
 		},
 	}
 }

--- a/test/unit-tests/resources.go
+++ b/test/unit-tests/resources.go
@@ -161,8 +161,7 @@ func InsightsMCH() operatorsv1.MultiClusterHub {
 func OCMNamespace() *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   MulticlusterhubNamespace,
-			Labels: make(map[string]string),
+			Name: MulticlusterhubNamespace,
 		},
 	}
 }

--- a/test/unit-tests/resources.go
+++ b/test/unit-tests/resources.go
@@ -74,6 +74,7 @@ func EmptyMCH() operatorsv1.MultiClusterHub {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MulticlusterhubName,
 			Namespace: MulticlusterhubNamespace,
+			Labels:    map[string]string{},
 		},
 		Spec: operatorsv1.MultiClusterHubSpec{
 			Overrides: &operatorsv1.Overrides{
@@ -93,6 +94,7 @@ func NoComponentMCH() operatorsv1.MultiClusterHub {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MulticlusterhubName,
 			Namespace: MulticlusterhubNamespace,
+			Labels:    map[string]string{},
 		},
 		Spec: operatorsv1.MultiClusterHubSpec{
 			Overrides: &operatorsv1.Overrides{


### PR DESCRIPTION
# Description

Update the MCH operator to add the `openshift.io/cluster-monitoring` label to the namespace where the MCH resource is deployed. The label will be updated during the operator reconciling phase.

## Related Issue

https://issues.redhat.com/browse/ACM-7637

## Changes Made

- Updated MCH operator to update the namespace object where MCH is deployed with the `openshift.io/cluster-monitoring` label. This will allow OpenShift to detect the namespace where the PrometheusRules and ServiceMonitors will now be deployed.

## Screenshots (if applicable)

<img width="1170" alt="Screenshot 2023-09-26 at 12 27 14 PM" src="https://github.com/stolostron/multiclusterhub-operator/assets/28898909/cede7f45-44f0-48c9-9ee0-0b84ceac139b">

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
