### PR TITLE
Console PrometheusRule for page visit counts

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-prometheus-rules.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-prometheus-rules.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: acm-console-prometheus-rules
-  namespace: openshift-monitoring
+  namespace: {{ .Values.global.namespace }}
 spec:
   groups:
     - name: acm-console.rules

--- a/pkg/templates/charts/toggle/console/templates/console-prometheus-rules.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-prometheus-rules.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2023 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: acm-console-prometheus-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: acm-console.rules
+      rules:
+        - expr: sum by (page) (acm_console_page_count)
+          record: 'acm_console_page_count:sum'


### PR DESCRIPTION
# Description

Includes a PrometheusRule resource that exposes a metric: acm_console_page_count:sum. This metric sums all page visits across the ACM Console, and reduces the cardinality of the original metric so we can upload to Telemetry.

## Related Issue

https://issues.redhat.com/browse/ACM-7492

## Changes Made

The PR adds a PrometheusRule resource for the acm console. The PromRule resource will include one rule that sums page count visits across the console pods (running and previous).

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [x] All checks and tests pass.
- [x] Approved by at least one reviewer.
- [x] Merged into the main/master branch.
