### PR TITLE
[ACM-7638] Remove legacy prometheuesrule and servicemonitor from openshift-monit…

### DIFF
--- a/.github/workflows/regenerate-bundles-2.7.yml
+++ b/.github/workflows/regenerate-bundles-2.7.yml
@@ -35,6 +35,7 @@ jobs:
     
       # Runs a set of commands using the runners shell
       - name: Regenerate Operator Bundles
+        continue-on-error: true
         id: generate_bundle
         run: |
           make regenerate-operator-bundles
@@ -43,9 +44,9 @@ jobs:
         id: job_status
         run: |
           if [[ ${{ steps.generate_bundle.outcome }} == 'failure' ]]; then
-            echo "::set-output name=status::failure"
+            echo "status=failure" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=status::success"
+            echo "status=success" >> $GITHUB_OUTPUT
           fi
 
       - name: Send Slack Message on Failure

--- a/.github/workflows/regenerate-bundles-2.8.yml
+++ b/.github/workflows/regenerate-bundles-2.8.yml
@@ -35,6 +35,7 @@ jobs:
     
       # Runs a set of commands using the runners shell
       - name: Regenerate Operator Bundles
+        continue-on-error: true
         id: generate_bundle
         run: |
           make regenerate-operator-bundles
@@ -43,9 +44,9 @@ jobs:
         id: job_status
         run: |
           if [[ ${{ steps.generate_bundle.outcome }} == 'failure' ]]; then
-            echo "::set-output name=status::failure"
+            echo "status=failure" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=status::success"
+            echo "status=success" >> $GITHUB_OUTPUT
           fi
 
       - name: Send Slack Message on Failure

--- a/.github/workflows/regenerate-bundles.yml
+++ b/.github/workflows/regenerate-bundles.yml
@@ -34,6 +34,7 @@ jobs:
     
       # Runs a set of commands using the runners shell
       - name: Regenerate Operator Bundles
+        continue-on-error: true
         id: generate_bundle
         run: |
           make regenerate-operator-bundles
@@ -42,9 +43,9 @@ jobs:
         id: job_status
         run: |
           if [[ ${{ steps.generate_bundle.outcome }} == 'failure' ]]; then
-            echo "::set-output name=status::failure"
+            echo "status=failure" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=status::success"
+            echo "status=success" >> $GITHUB_OUTPUT
           fi
 
       - name: Send Slack Message on Failure

--- a/.github/workflows/update-pregenerated-charts.yml
+++ b/.github/workflows/update-pregenerated-charts.yml
@@ -34,6 +34,7 @@ jobs:
     
       # Runs a set of commands using the runners shell
       - name: Regenerate Operator Bundles
+        continue-on-error: true
         id: generate_bundle
         run: |
           make copy-charts
@@ -42,9 +43,9 @@ jobs:
         id: job_status
         run: |
           if [[ ${{ steps.generate_bundle.outcome }} == 'failure' ]]; then
-            echo "::set-output name=status::failure"
+            echo "status=failure" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=status::success"
+            echo "status=success" >> $GITHUB_OUTPUT
           fi
 
       - name: Send Slack Message on Failure

--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -113,10 +113,27 @@ var MCEComponents = []string{
 	MCEServerFoundation,
 }
 
-// clusterManagementAddOns is a map that associates certain component names with their corresponding add-ons.
-var clusterManagementAddOns = map[string]string{
+var LegacyPrometheusKind = []string{"PrometheusRule", "ServiceMonitor"}
+
+// MCHPrometheusRules is a map that associates certain component names with their corresponding prometheus rules.
+var MCHPrometheusRules = map[string]string{
+	Console: "acm-console-prometheus-rules",
+	GRC:     "ocm-grc-policy-propagator-metrics",
+	// Add other components here when PrometheusRules is required.
+}
+
+// MCHServiceMonitors is a map that associates certain component names with their corresponding service monitors.
+var MCHServiceMonitors = map[string]string{
+	Console:  "console-monitor",
+	GRC:      "ocm-grc-policy-propagator-metrics",
+	Insights: "acm-insights",
+	// Add other components here when ServiceMonitors is required.
+}
+
+// ClusterManagementAddOns is a map that associates certain component names with their corresponding add-ons.
+var ClusterManagementAddOns = map[string]string{
 	SubmarinerAddon: "submariner",
-	// Add other components here when clusterManagementAddOns is required.
+	// Add other components here when ClusterManagementAddOns is required.
 }
 
 /*
@@ -168,8 +185,34 @@ func GetDefaultHostedComponents() []string {
 
 // GetClusterManagementAddonName returns the name of the ClusterManagementAddOn based on the provided component name.
 func GetClusterManagementAddonName(component string) (string, error) {
-	if val, ok := clusterManagementAddOns[component]; !ok {
+	if val, ok := ClusterManagementAddOns[component]; !ok {
 		return val, fmt.Errorf("failed to find ClusterManagementAddOn name for: %s component", component)
+	} else {
+		return val, nil
+	}
+}
+
+/*
+GetLegacyPrometheusKind returns a list of legacy kind resources that are required to be removed before updating to
+ACM 2.9 and later.
+*/
+func GetLegacyPrometheusKind() []string {
+	return LegacyPrometheusKind
+}
+
+// GetPrometheusRulesName returns the name of the PrometheusRules based on the provided component name.
+func GetPrometheusRulesName(component string) (string, error) {
+	if val, ok := MCHPrometheusRules[component]; !ok {
+		return val, fmt.Errorf("failed to find PrometheusRules name for: %s component", component)
+	} else {
+		return val, nil
+	}
+}
+
+// GetServiceMonitorName returns the name of the ServiceMonitors based on the provided component name.
+func GetServiceMonitorName(component string) (string, error) {
+	if val, ok := MCHServiceMonitors[component]; !ok {
+		return val, fmt.Errorf("failed to find ServiceMonitors name for: %s component", component)
 	} else {
 		return val, nil
 	}

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -3,6 +3,8 @@ package v1
 import (
 	"reflect"
 	"testing"
+
+	"k8s.io/utils/strings/slices"
 )
 
 func TestMultiClusterHub_Prune(t *testing.T) {
@@ -183,6 +185,105 @@ func TestGetClusterManagementAddonName(t *testing.T) {
 
 			if got != tt.want {
 				t.Errorf("GetClusterManagementAddonName(%v) = %v, want: %v", tt.component, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLegacyPrometheusKind(t *testing.T) {
+	tests := []struct {
+		name  string
+		kind  string
+		want  int
+		want2 []string
+	}{
+		{
+			name:  "legacy Prometheus Configuration Kind",
+			kind:  "PrometheusRule",
+			want:  2,
+			want2: LegacyPrometheusKind,
+		},
+		{
+			name:  "legacy Prometheus Configuration Kind",
+			kind:  "ServiceMonitor",
+			want:  2,
+			want2: LegacyPrometheusKind,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetLegacyPrometheusKind()
+			if len(got) == 0 {
+				t.Errorf("GetLegacyPrometheusKind() = %v, want: %v", len(got), tt.want)
+			}
+
+			if ok := slices.Contains(got, tt.kind); !ok {
+				t.Errorf("GetLegacyPrometheusKind() = %v, want: %v", got, tt.want2)
+			}
+		})
+	}
+}
+
+func TestGetPrometheusRulesName(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		want      string
+	}{
+		{
+			name:      "console PrometheusRule",
+			component: Console,
+			want:      MCHPrometheusRules[Console],
+		},
+		{
+			name:      "unknown PrometheusRule",
+			component: "unknown",
+			want:      MCHPrometheusRules["unknown"],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetPrometheusRulesName(tt.component)
+			if err != nil && tt.component != "unknown" {
+				t.Errorf("GetPrometheusRulesName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+			}
+
+			if got != tt.want {
+				t.Errorf("GetPrometheusRulesName(%v) = %v, want: %v", tt.component, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetServiceMonitorName(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		want      string
+	}{
+		{
+			name:      "console ServiceMonitor",
+			component: Console,
+			want:      MCHServiceMonitors[Console],
+		},
+		{
+			name:      "unknown ServiceMonitor",
+			component: "unknown",
+			want:      MCHServiceMonitors["unknown"],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetServiceMonitorName(tt.component)
+			if err != nil && tt.component != "unknown" {
+				t.Errorf("GetServiceMonitorName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+			}
+
+			if got != tt.want {
+				t.Errorf("GetServiceMonitorName(%v) = %v, want: %v", tt.component, got, tt.want)
 			}
 		})
 	}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -313,9 +313,8 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
-	err = r.removeLegacyGRCPrometheusConfig(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
+	for _, kind := range operatorv1.GetLegacyPrometheusKind() {
+		err = r.removeLegacyPrometheusConfigurations(ctx, "openshift-monitoring", kind)
 	}
 
 	// Install CRDs

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -928,9 +928,14 @@ var _ = Describe("MultiClusterHub controller", func() {
 			err = k8sClient.Create(context.TODO(), sm)
 			Expect(err).To(BeNil())
 
+			legacyResourceKind := operatorv1.GetLegacyPrometheusKind()
+			ns := "openshift-monitoring"
+
 			By("Running the cleanup of the legacy Prometheus configuration")
-			err = reconciler.removeLegacyGRCPrometheusConfig(context.TODO())
-			Expect(err).To(BeNil())
+			for _, kind := range legacyResourceKind {
+				err = reconciler.removeLegacyPrometheusConfigurations(context.TODO(), ns, kind)
+				Expect(err).To(BeNil())
+			}
 
 			By("Verifying that the legacy GRC PrometheusRule is deleted")
 			err = k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pr), pr)
@@ -941,8 +946,10 @@ var _ = Describe("MultiClusterHub controller", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 
 			By("Running the cleanup of the legacy Prometheus configuration again should do nothing")
-			err = reconciler.removeLegacyGRCPrometheusConfig(context.TODO())
-			Expect(err).To(BeNil())
+			for _, kind := range legacyResourceKind {
+				err = reconciler.removeLegacyPrometheusConfigurations(context.TODO(), ns, kind)
+				Expect(err).To(BeNil())
+			}
 		})
 	})
 

--- a/pkg/templates/charts/toggle/console/templates/console-servicemonitor.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: console-monitor
-  namespace: openshift-monitoring
+  namespace: {{ .Values.global.namespace }}
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/pkg/templates/charts/toggle/insights/templates/policyreport-service-monitor.yaml
+++ b/pkg/templates/charts/toggle/insights/templates/policyreport-service-monitor.yaml
@@ -5,7 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: acm-insights
-  namespace: openshift-monitoring
+  namespace: {{ .Values.global.namespace }}
   labels:
     app: insights
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
…oring ns

# Description

Updating the MCH operator to remove the additional `PrometheusRule` and `ServiceMonitor` in the `openshift-monitoring` namespace.

## Related Issue

https://issues.redhat.com/browse/ACM-7638

## Changes Made

When the MCH operator reconciles, it will remove the legacy `PrometheusRules` and `ServiceMonitors` from the `openshift-monitoring` namespace.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [x] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
