### PR TITLE
[ACM-7876] Removed legacy resources created by operator-sdk

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -6,6 +6,9 @@ import (
 	"os"
 )
 
+// Name of the MultiClusterHub (MCH) operator.
+const MCH = "multiclusterhub-operator"
+
 // Component related to MultiClusterHub (MCH)
 const (
 	Appsub                    string = "app-lifecycle"
@@ -113,7 +116,19 @@ var MCEComponents = []string{
 	MCEServerFoundation,
 }
 
-var LegacyPrometheusKind = []string{"PrometheusRule", "ServiceMonitor"}
+var (
+	/*
+		LegacyOperatorSDKKind is a slice of strings that represents the legacy resource kinds
+		supported by the Operator SDK. These kinds include "Service" and "ServiceMonitor".
+	*/
+	LegacyOperatorSDKKind = []string{"Service", "ServiceMonitor"}
+
+	/*
+		LegacyPrometheusKind is a slice of strings that represents the legacy resource kinds
+		commonly used with Prometheus. These kinds include "PrometheusRule" and "ServiceMonitor".
+	*/
+	LegacyPrometheusKind = []string{"PrometheusRule", "ServiceMonitor"}
+)
 
 // MCHPrometheusRules is a map that associates certain component names with their corresponding prometheus rules.
 var MCHPrometheusRules = map[string]string{
@@ -127,7 +142,14 @@ var MCHServiceMonitors = map[string]string{
 	Console:  "console-monitor",
 	GRC:      "ocm-grc-policy-propagator-metrics",
 	Insights: "acm-insights",
+	MCH:      "multiclusterhub-operator-metrics",
 	// Add other components here when ServiceMonitors is required.
+}
+
+// MCHServices is a map that associates certain component names with their corresponding services.
+var MCHServices = map[string]string{
+	MCH: "multiclusterhub-operator-metrics",
+	// Add other components here when Services is required.
 }
 
 // ClusterManagementAddOns is a map that associates certain component names with their corresponding add-ons.
@@ -200,6 +222,14 @@ func GetLegacyPrometheusKind() []string {
 	return LegacyPrometheusKind
 }
 
+/*
+GetLegacyOperatorSDKKind returns a list of legacy kind resources that are required to be removed before updating to a
+later release.
+*/
+func GetLegacyOperatorSDKKind() []string {
+	return LegacyOperatorSDKKind
+}
+
 // GetPrometheusRulesName returns the name of the PrometheusRules based on the provided component name.
 func GetPrometheusRulesName(component string) (string, error) {
 	if val, ok := MCHPrometheusRules[component]; !ok {
@@ -213,6 +243,15 @@ func GetPrometheusRulesName(component string) (string, error) {
 func GetServiceMonitorName(component string) (string, error) {
 	if val, ok := MCHServiceMonitors[component]; !ok {
 		return val, fmt.Errorf("failed to find ServiceMonitors name for: %s component", component)
+	} else {
+		return val, nil
+	}
+}
+
+// GetServiceName returns the name of the Services based on the provided component name.
+func GetServiceName(component string) (string, error) {
+	if val, ok := MCHServices[component]; !ok {
+		return val, fmt.Errorf("failed to find Services name for: %s component", component)
 	} else {
 		return val, nil
 	}

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -288,3 +288,35 @@ func TestGetServiceMonitorName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetServiceName(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		want      string
+	}{
+		{
+			name:      "multiclusterhub Service",
+			component: MCH,
+			want:      MCHServices[MCH],
+		},
+		{
+			name:      "unknown Service",
+			component: "unknown",
+			want:      MCHServices["unknown"],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetServiceName(tt.component)
+			if err != nil && tt.component != "unknown" {
+				t.Errorf("GetServiceName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+			}
+
+			if got != tt.want {
+				t.Errorf("GetServiceName(%v) = %v, want: %v", tt.component, got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -317,6 +317,15 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err = r.removeLegacyPrometheusConfigurations(ctx, "openshift-monitoring", kind)
 	}
 
+	/*
+		Remove existing service and servicemonitor configurations, if present from upgrade. In ACM 2.2, operator-sdk
+		generated configurations for the MCH operator to be collecting metrics. In later releases, these resources are
+		no longer available; therefore, we need to explicitly remove them from the upgrade configuration.
+	*/
+	for _, kind := range operatorv1.GetLegacyOperatorSDKKind() {
+		err = r.removeLegacyOperatorSDKConfigurations(ctx, multiClusterHub.GetNamespace(), kind)
+	}
+
 	// Install CRDs
 	var reason string
 	reason, err = r.installCRDs(r.Log, multiClusterHub)


### PR DESCRIPTION
# Description

In ACM 2.2, operator-sdk created a service and servicemonitor for the multiclusterhub-operator. After upgrading, the `multiclusterhub-operator-metrics` resource for both `service` and `servicemonitor` remains within the cluster. Since this resource is not being cleaned up, it is causing alerts to trigger in cluster environments where the resources aren't being cleaned up. This PR will remove those resources.

## Related Issue

https://issues.redhat.com/browse/ACM-7876

## Changes Made

Updated the operator to remove legacy operator-sdk resources during reconciliation loop.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
