### PR TITLE
Fix deployment label override issue since webhook-origin added

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     release: grc
     app.kubernetes.io/instance: grc
     app.kubernetes.io/name: grc
-    webhook-origin: governance-policy-propagator
 spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
   selector:
@@ -18,7 +17,6 @@ spec:
       app: grc
       component: "ocm-policy-propagator"
       release: grc
-      webhook-origin: governance-policy-propagator
   template:
     metadata:
       annotations:
@@ -32,7 +30,6 @@ spec:
         chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
         app.kubernetes.io/instance: grc
         app.kubernetes.io/name: grc
-        webhook-origin: governance-policy-propagator
     spec:
       serviceAccountName: grc-sa
       hostNetwork: false

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-webhook-service.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-webhook-service.yaml
@@ -11,4 +11,4 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
-    webhook-origin: governance-policy-propagator
+    name: governance-policy-propagator


### PR DESCRIPTION
# Description

 The label selector cannot be modified on an existing Deployment. When we update to 2.9, errors caused with a new label `webhook-origin`

So removed `webhook-origin` label