### PR TITLE
[ACM-8547] Added service and servicemonitor to collect MCH operator metrics

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -126,25 +126,23 @@ var (
 	LegacyConfigKind = []string{"PrometheusRule", "Service", "ServiceMonitor"}
 )
 
-// MCHPrometheusRules is a map that associates certain component names with their corresponding prometheus rules.
-var MCHPrometheusRules = map[string]string{
+// MCHLegacyPrometheusRules is a map that associates certain component names with their corresponding prometheus rules.
+var MCHLegacyPrometheusRules = map[string]string{
 	Console: "acm-console-prometheus-rules",
 	GRC:     "ocm-grc-policy-propagator-metrics",
 	// Add other components here when PrometheusRules is required.
 }
 
-// MCHServiceMonitors is a map that associates certain component names with their corresponding service monitors.
-var MCHServiceMonitors = map[string]string{
+// MCHLegacyServiceMonitors is a map that associates certain component names with their corresponding service monitors.
+var MCHLegacyServiceMonitors = map[string]string{
 	Console:  "console-monitor",
 	GRC:      "ocm-grc-policy-propagator-metrics",
 	Insights: "acm-insights",
-	MCH:      "multiclusterhub-operator-metrics",
 	// Add other components here when ServiceMonitors is required.
 }
 
-// MCHServices is a map that associates certain component names with their corresponding services.
-var MCHServices = map[string]string{
-	MCH: "multiclusterhub-operator-metrics",
+// MCHLegacyServices is a map that associates certain component names with their corresponding services.
+var MCHLegacyServices = map[string]string{
 	// Add other components here when Services is required.
 }
 
@@ -218,27 +216,27 @@ func GetLegacyConfigKind() []string {
 	return LegacyConfigKind
 }
 
-// GetPrometheusRulesName returns the name of the PrometheusRules based on the provided component name.
-func GetPrometheusRulesName(component string) (string, error) {
-	if val, ok := MCHPrometheusRules[component]; !ok {
+// GetLegacyPrometheusRulesName returns the name of the PrometheusRules based on the provided component name.
+func GetLegacyPrometheusRulesName(component string) (string, error) {
+	if val, ok := MCHLegacyPrometheusRules[component]; !ok {
 		return val, fmt.Errorf("failed to find PrometheusRules name for: %s component", component)
 	} else {
 		return val, nil
 	}
 }
 
-// GetServiceMonitorName returns the name of the ServiceMonitors based on the provided component name.
-func GetServiceMonitorName(component string) (string, error) {
-	if val, ok := MCHServiceMonitors[component]; !ok {
+// GetLegacyServiceMonitorName returns the name of the ServiceMonitors based on the provided component name.
+func GetLegacyServiceMonitorName(component string) (string, error) {
+	if val, ok := MCHLegacyServiceMonitors[component]; !ok {
 		return val, fmt.Errorf("failed to find ServiceMonitors name for: %s component", component)
 	} else {
 		return val, nil
 	}
 }
 
-// GetServiceName returns the name of the Services based on the provided component name.
-func GetServiceName(component string) (string, error) {
-	if val, ok := MCHServices[component]; !ok {
+// GetLegacyServiceName returns the name of the Services based on the provided component name.
+func GetLegacyServiceName(component string) (string, error) {
+	if val, ok := MCHLegacyServices[component]; !ok {
 		return val, fmt.Errorf("failed to find Services name for: %s component", component)
 	} else {
 		return val, nil

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -225,7 +225,7 @@ func TestGetLegacyPrometheusKind(t *testing.T) {
 	}
 }
 
-func TestGetPrometheusRulesName(t *testing.T) {
+func TestGetLegacyPrometheusRulesName(t *testing.T) {
 	tests := []struct {
 		name      string
 		component string
@@ -234,30 +234,30 @@ func TestGetPrometheusRulesName(t *testing.T) {
 		{
 			name:      "console PrometheusRule",
 			component: Console,
-			want:      MCHPrometheusRules[Console],
+			want:      MCHLegacyPrometheusRules[Console],
 		},
 		{
 			name:      "unknown PrometheusRule",
 			component: "unknown",
-			want:      MCHPrometheusRules["unknown"],
+			want:      MCHLegacyPrometheusRules["unknown"],
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetPrometheusRulesName(tt.component)
+			got, err := GetLegacyPrometheusRulesName(tt.component)
 			if err != nil && tt.component != "unknown" {
-				t.Errorf("GetPrometheusRulesName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+				t.Errorf("GetLegacyPrometheusRulesName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
 			}
 
 			if got != tt.want {
-				t.Errorf("GetPrometheusRulesName(%v) = %v, want: %v", tt.component, got, tt.want)
+				t.Errorf("GetLegacyPrometheusRulesName(%v) = %v, want: %v", tt.component, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestGetServiceMonitorName(t *testing.T) {
+func TestGetLegacyServiceMonitorName(t *testing.T) {
 	tests := []struct {
 		name      string
 		component string
@@ -266,56 +266,51 @@ func TestGetServiceMonitorName(t *testing.T) {
 		{
 			name:      "console ServiceMonitor",
 			component: Console,
-			want:      MCHServiceMonitors[Console],
+			want:      MCHLegacyServiceMonitors[Console],
 		},
 		{
 			name:      "unknown ServiceMonitor",
 			component: "unknown",
-			want:      MCHServiceMonitors["unknown"],
+			want:      MCHLegacyServiceMonitors["unknown"],
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetServiceMonitorName(tt.component)
+			got, err := GetLegacyServiceMonitorName(tt.component)
 			if err != nil && tt.component != "unknown" {
-				t.Errorf("GetServiceMonitorName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+				t.Errorf("GetLegacyServiceMonitorName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
 			}
 
 			if got != tt.want {
-				t.Errorf("GetServiceMonitorName(%v) = %v, want: %v", tt.component, got, tt.want)
+				t.Errorf("GetLegacyServiceMonitorName(%v) = %v, want: %v", tt.component, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestGetServiceName(t *testing.T) {
+func TestGetLegacyServiceName(t *testing.T) {
 	tests := []struct {
 		name      string
 		component string
 		want      string
 	}{
 		{
-			name:      "multiclusterhub Service",
-			component: MCH,
-			want:      MCHServices[MCH],
-		},
-		{
 			name:      "unknown Service",
 			component: "unknown",
-			want:      MCHServices["unknown"],
+			want:      MCHLegacyServices["unknown"],
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetServiceName(tt.component)
+			got, err := GetLegacyServiceName(tt.component)
 			if err != nil && tt.component != "unknown" {
-				t.Errorf("GetServiceName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
+				t.Errorf("GetLegacyServiceName(%v) = %v, want: %v", tt.component, err.Error(), tt.want)
 			}
 
 			if got != tt.want {
-				t.Errorf("GetServiceName(%v) = %v, want: %v", tt.component, got, tt.want)
+				t.Errorf("GetLegacyServiceName(%v) = %v, want: %v", tt.component, got, tt.want)
 			}
 		})
 	}

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -306,23 +306,23 @@ func (r *MultiClusterHubReconciler) removeLegacyConfigurations(ctx context.Conte
 		case "PrometheusRule":
 			configType = "PrometheusRule"
 			getObjectName = func() (string, error) {
-				return operatorsv1.GetPrometheusRulesName(c)
+				return operatorsv1.GetLegacyPrometheusRulesName(c)
 			}
 
 		case "ServiceMonitor":
 			configType = "ServiceMonitor"
 			getObjectName = func() (string, error) {
-				return operatorsv1.GetServiceMonitorName(c)
+				return operatorsv1.GetLegacyServiceMonitorName(c)
 			}
 
 		case "Service":
 			configType = "Service"
 			getObjectName = func() (string, error) {
-				return operatorsv1.GetServiceName(c)
+				return operatorsv1.GetLegacyServiceName(c)
 			}
 
 		default:
-			return fmt.Errorf("Unsupported kind detected when trying to remove legacy configuration: %s", kind)
+			return fmt.Errorf("unsupported kind detected when trying to remove legacy configuration: %s", kind)
 		}
 
 		res, err := getObjectName()
@@ -331,15 +331,7 @@ func (r *MultiClusterHubReconciler) removeLegacyConfigurations(ctx context.Conte
 		}
 
 		obj.SetName(res)
-
-		switch c {
-		case operatorsv1.MCH:
-			mchNamespace, _ := utils.OperatorNamespace()
-			obj.SetNamespace(mchNamespace)
-
-		default:
-			obj.SetNamespace(targetNamespace)
-		}
+		obj.SetNamespace(targetNamespace)
 
 		err = r.Client.Delete(ctx, obj)
 		if err != nil {
@@ -411,19 +403,19 @@ func (r *MultiClusterHubReconciler) cleanupGRCAppsub(m *operatorsv1.MultiCluster
 	}
 
 	// Manually delete GRC cluster-scope and cross-namespace resources
-	r.Log.Info(fmt.Sprintf("Deleting GRC clusterroles"))
+	r.Log.Info("Deleting GRC clusterroles")
 	err = r.Client.DeleteAllOf(context.TODO(), &rbacv1.ClusterRole{}, client.MatchingLabels{"app": "grc"})
 	if err != nil {
 		r.Log.Error(err, "Error while deleting clusterroles")
 		return err
 	}
-	r.Log.Info(fmt.Sprintf("Deleting GRC clusterrolebindings"))
+	r.Log.Info("Deleting GRC clusterrolebindings")
 	err = r.Client.DeleteAllOf(context.TODO(), &rbacv1.ClusterRoleBinding{}, client.MatchingLabels{"app": "grc"})
 	if err != nil {
 		r.Log.Error(err, "Error while deleting clusterroles")
 		return err
 	}
-	r.Log.Info(fmt.Sprintf("Deleting GRC PrometheusRule"))
+	r.Log.Info("Deleting GRC PrometheusRule")
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   MonitoringAPIGroup,
@@ -437,7 +429,7 @@ func (r *MultiClusterHubReconciler) cleanupGRCAppsub(m *operatorsv1.MultiCluster
 	}
 
 	// Delete appsub
-	r.Log.Info(fmt.Sprintf("Deleting GRC appsub"))
+	r.Log.Info("Deleting GRC appsub")
 	err = r.Client.Delete(context.Background(), grcAppsub)
 	if err != nil {
 		return err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,13 +8,11 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,12 +28,6 @@ const (
 
 	// podNamespaceEnvVar is the environment variable name for the pod's namespace.
 	podNamespaceEnvVar = "POD_NAMESPACE"
-
-	// rsaKeySize is the size of the RSA key in bits.
-	rsaKeySize = 2048
-
-	// duration365d is the duration of 365 days in hours.
-	duration365d = time.Hour * 24 * 365
 
 	// DefaultRepository is the default repository for images.
 	DefaultRepository = "quay.io/stolostron"
@@ -96,6 +88,20 @@ const (
 
 	// VolsyncChartLocation is the location of the Volsync Controller chart.
 	VolsyncChartLocation = "/charts/toggle/volsync-controller"
+)
+
+const (
+	/*
+	   MCHOperatorMetricsServiceName is the name of the service used to expose the metrics
+	   endpoint for the multiclusterhub-operator.
+	*/
+	MCHOperatorMetricsServiceName = "multiclusterhub-operator-metrics"
+
+	/*
+	   MCHOperatorMetricsServiceMonitorName is the name of the service monitor used to expose
+	   the metrics for the multiclusterhub-operator.
+	*/
+	MCHOperatorMetricsServiceMonitorName = "multiclusterhub-operator-metrics"
 )
 
 var (
@@ -266,7 +272,7 @@ func DistributePods(key string, value string) *corev1.Affinity {
 }
 
 // GetImagePullPolicy returns either pull policy from CR overrides or default of Always
-func GetImagePullPolicy(m *operatorsv1.MultiClusterHub) v1.PullPolicy {
+func GetImagePullPolicy(m *operatorsv1.MultiClusterHub) corev1.PullPolicy {
 	if m.Spec.Overrides == nil || m.Spec.Overrides.ImagePullPolicy == "" {
 		return corev1.PullIfNotPresent
 	}
@@ -279,7 +285,7 @@ func GetContainerArgs(dep *appsv1.Deployment) []string {
 }
 
 // GetContainerEnvVars returns environment variables for first container in deployment
-func GetContainerEnvVars(dep *appsv1.Deployment) []v1.EnvVar {
+func GetContainerEnvVars(dep *appsv1.Deployment) []corev1.EnvVar {
 	return dep.Spec.Template.Spec.Containers[0].Env
 }
 
@@ -395,7 +401,7 @@ func GetDeployments(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 	}
 	// community, _ := operatorsv1.IsCommunity()
 	// if community {
-	// 	nn = append(nn, types.NamespacedName{Name: "search-v2-operator-controller-manager", Namespace: m.Namespace})
+	//  nn = append(nn, types.NamespacedName{Name: "search-v2-operator-controller-manager", Namespace: m.Namespace})
 	// }
 	return nn
 }

--- a/test/unit-tests/resources.go
+++ b/test/unit-tests/resources.go
@@ -229,7 +229,7 @@ func SampleClusterManagementAddOn(component string) *ocmapi.ClusterManagementAdd
 }
 
 func SampleServiceMonitor(component string, namespace string) *promv1.ServiceMonitor {
-	smName, err := operatorsv1.GetServiceMonitorName(component)
+	smName, err := operatorsv1.GetLegacyServiceMonitorName(component)
 	if err != nil {
 		smName = "unknown"
 	}


### PR DESCRIPTION
# Description

Updated MCH operator to create a `service` and `servicemonitor` to allow OCP to begin collecting `controller-runtime` metrics for the operator.

## Related Issue

https://issues.redhat.com/browse/ACM-8547

## Changes Made

Updated MCH operator to deploy metrics `service` and `servicemonitor` to collect `controller-runtime` metrics.

## Screenshots (if applicable)

![Screenshot 2023-11-16 at 1 09 12 PM](https://github.com/stolostron/multiclusterhub-operator/assets/28898909/adf36c48-2a94-482f-8d90-89efc4940fa9)

![Screenshot 2023-11-16 at 1 09 43 PM](https://github.com/stolostron/multiclusterhub-operator/assets/28898909/07be0514-ab5c-48d9-9629-3f550d763493)

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

/hold