### PR TITLE
[ACM-8781] Updated multiclusterhub-operator replicas count to 2

### DIFF
--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -571,7 +571,7 @@ spec:
           control-plane: multiclusterhub-operator
         name: multiclusterhub-operator
         spec:
-          replicas: 1
+          replicas: 2
           selector:
             matchLabels:
               name: multiclusterhub-operator


### PR DESCRIPTION
# Description

Updating MCH operator to support 2 replicas.

## Related Issue

https://issues.redhat.com/browse/ACM-8781

## Changes Made

Updated CSV to include 2 replicas for MCH operator pods.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @ngraham20 @cameronmwall 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
