### PR TITLE
[ACM-9005] Updated multiclusterhub phase status to Paused when the operator is paused

### DIFF
--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -224,6 +224,7 @@ type HubPhaseType string
 
 const (
 	HubPending         HubPhaseType = "Pending"
+	HubPaused          HubPhaseType = "Paused"
 	HubRunning         HubPhaseType = "Running"
 	HubInstalling      HubPhaseType = "Installing"
 	HubUpdating        HubPhaseType = "Updating"

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -20,6 +20,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -194,24 +195,24 @@ func calculateStatus(hub *operatorsv1.MultiClusterHub, allDeps []*appsv1.Deploym
 	if successful {
 		// don't label as complete until component pruning succeeds
 		if !hubPruning(status) && !utils.IsPaused(hub) {
-			available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
+			available := NewHubCondition(operatorsv1.Complete, v1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
 			SetHubCondition(&status, *available)
 		} else {
 			// only add unavailable status if complete status already present
 			if HubConditionPresent(status, operatorsv1.Complete) {
-				unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, OldComponentNotRemovedReason, "Not all components successfully pruned.")
+				unavailable := NewHubCondition(operatorsv1.Complete, v1.ConditionFalse, OldComponentNotRemovedReason, "Not all components successfully pruned.")
 				SetHubCondition(&status, *unavailable)
 			}
 		}
 	} else {
 		// hub is progressing unless otherwise specified
 		if !HubConditionPresent(status, operatorsv1.Progressing) {
-			progressing := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, ReconcileReason, "Hub is reconciling.")
+			progressing := NewHubCondition(operatorsv1.Progressing, v1.ConditionTrue, ReconcileReason, "Hub is reconciling.")
 			SetHubCondition(&status, *progressing)
 		}
 		// only add unavailable status if complete status already present
 		if HubConditionPresent(status, operatorsv1.Complete) {
-			unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, ComponentsUnavailableReason, "Not all hub components ready.")
+			unavailable := NewHubCondition(operatorsv1.Complete, v1.ConditionFalse, ComponentsUnavailableReason, "Not all hub components ready.")
 			SetHubCondition(&status, *unavailable)
 		}
 	}

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -20,7 +20,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -187,7 +186,9 @@ func calculateStatus(hub *operatorsv1.MultiClusterHub, allDeps []*appsv1.Deploym
 
 	// Copy conditions one by one to not affect original object
 	conditions := hub.Status.HubConditions
-	status.HubConditions = append(status.HubConditions, conditions...)
+	for i := range conditions {
+		status.HubConditions = append(status.HubConditions, conditions[i])
+	}
 
 	// Update hub conditions
 	if successful {
@@ -583,7 +584,7 @@ func aggregatePhase(status operatorsv1.MultiClusterHubStatus) operatorsv1.HubPha
 }
 
 // NewHubCondition creates a new hub condition.
-func NewHubCondition(condType operatorsv1.HubConditionType, status v1.ConditionStatus, reason, message string) *operatorsv1.HubCondition {
+func NewHubCondition(condType operatorsv1.HubConditionType, status metav1.ConditionStatus, reason, message string) *operatorsv1.HubCondition {
 	return &operatorsv1.HubCondition{
 		Type:               condType,
 		Status:             status,

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -134,14 +134,10 @@ func (r *MultiClusterHubReconciler) ComponentsAreRunning(m *operatorsv1.MultiClu
 }
 
 // syncHubStatus checks if the status is up-to-date and sync it if necessary
-func (r *MultiClusterHubReconciler) syncHubStatus(
-	m *operatorsv1.MultiClusterHub,
-	original *operatorsv1.MultiClusterHubStatus,
-	allDeps []*appsv1.Deployment,
-	allCRs map[string]*unstructured.Unstructured,
-	ocpConsole bool,
-) (reconcile.Result, error) {
-	// localCluster, err := r.ensureManagedClusterIsRunning(m, ocpConsole)
+func (r *MultiClusterHubReconciler) syncHubStatus(m *operatorsv1.MultiClusterHub,
+	original *operatorsv1.MultiClusterHubStatus, allDeps []*appsv1.Deployment,
+	allCRs map[string]*unstructured.Unstructured, ocpConsole bool) (reconcile.Result, error) {
+
 	newStatus := calculateStatus(m, allDeps, allCRs, ocpConsole)
 	if reflect.DeepEqual(m.Status, original) {
 		r.Log.Info("Status hasn't changed")
@@ -169,14 +165,14 @@ func (r *MultiClusterHubReconciler) syncHubStatus(
 	}
 }
 
-func calculateStatus(
-	hub *operatorsv1.MultiClusterHub,
-	allDeps []*appsv1.Deployment,
-	allCRs map[string]*unstructured.Unstructured,
-	//	importClusterStatus []interface{},
-	ocpConsole bool,
-) operatorsv1.MultiClusterHubStatus {
-	components := getComponentStatuses(hub, allDeps, allCRs, ocpConsole)
+func calculateStatus(hub *operatorsv1.MultiClusterHub, allDeps []*appsv1.Deployment,
+	allCRs map[string]*unstructured.Unstructured, ocpConsole bool) operatorsv1.MultiClusterHubStatus {
+
+	components := map[string]operatorsv1.StatusCondition{}
+	if paused := utils.IsPaused(hub); !paused {
+		components = getComponentStatuses(hub, allDeps, allCRs, ocpConsole)
+	}
+
 	status := operatorsv1.MultiClusterHubStatus{
 		CurrentVersion: hub.Status.CurrentVersion,
 		DesiredVersion: version.Version,
@@ -191,32 +187,34 @@ func calculateStatus(
 
 	// Copy conditions one by one to not affect original object
 	conditions := hub.Status.HubConditions
-	for i := range conditions {
-		status.HubConditions = append(status.HubConditions, conditions[i])
-	}
+	status.HubConditions = append(status.HubConditions, conditions...)
 
 	// Update hub conditions
 	if successful {
 		// don't label as complete until component pruning succeeds
-		if !hubPruning(status) {
-			available := NewHubCondition(operatorsv1.Complete, v1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
+		if !hubPruning(status) && !utils.IsPaused(hub) {
+			available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue,
+				ComponentsAvailableReason, "All hub components ready.")
 			SetHubCondition(&status, *available)
 		} else {
 			// only add unavailable status if complete status already present
 			if HubConditionPresent(status, operatorsv1.Complete) {
-				unavailable := NewHubCondition(operatorsv1.Complete, v1.ConditionFalse, OldComponentNotRemovedReason, "Not all components successfully pruned.")
+				unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse,
+					OldComponentNotRemovedReason, "Not all components successfully pruned.")
 				SetHubCondition(&status, *unavailable)
 			}
 		}
 	} else {
 		// hub is progressing unless otherwise specified
 		if !HubConditionPresent(status, operatorsv1.Progressing) {
-			progressing := NewHubCondition(operatorsv1.Progressing, v1.ConditionTrue, ReconcileReason, "Hub is reconciling.")
+			progressing := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue,
+				ReconcileReason, "Hub is reconciling.")
 			SetHubCondition(&status, *progressing)
 		}
 		// only add unavailable status if complete status already present
 		if HubConditionPresent(status, operatorsv1.Complete) {
-			unavailable := NewHubCondition(operatorsv1.Complete, v1.ConditionFalse, ComponentsUnavailableReason, "Not all hub components ready.")
+			unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse,
+				ComponentsUnavailableReason, "Not all hub components ready.")
 			SetHubCondition(&status, *unavailable)
 		}
 	}
@@ -234,12 +232,8 @@ func calculateStatus(
 }
 
 // getComponentStatuses populates a complete list of the hub component statuses
-func getComponentStatuses(
-	hub *operatorsv1.MultiClusterHub,
-	allDeps []*appsv1.Deployment,
-	allCRs map[string]*unstructured.Unstructured,
-	ocpConsole bool,
-) map[string]operatorsv1.StatusCondition {
+func getComponentStatuses(hub *operatorsv1.MultiClusterHub, allDeps []*appsv1.Deployment,
+	allCRs map[string]*unstructured.Unstructured, ocpConsole bool) map[string]operatorsv1.StatusCondition {
 	components := newComponentList(hub, ocpConsole)
 
 	for _, d := range allDeps {
@@ -276,12 +270,7 @@ func successfulDeploy(d *appsv1.Deployment) bool {
 		}
 	}
 
-	if d.Status.UnavailableReplicas > 0 {
-		return false
-	}
-
-	return true
-	// latest := latestDeployCondition(d.Status.Conditions)
+	return d.Status.UnavailableReplicas <= 0
 }
 
 func latestDeployCondition(conditions []appsv1.DeploymentCondition) appsv1.DeploymentCondition {
@@ -555,11 +544,17 @@ func allComponentsSuccessful(components map[string]operatorsv1.StatusCondition) 
 // aggregatePhase calculates overall HubPhaseType based on hub status. This does NOT account for
 // a hub in the process of deletion.
 func aggregatePhase(status operatorsv1.MultiClusterHubStatus) operatorsv1.HubPhaseType {
-	successful := allComponentsSuccessful(status.Components)
 	if utils.IsUnitTest() {
 		return operatorsv1.HubRunning
 	}
-	if successful {
+
+	for _, condition := range status.HubConditions {
+		if condition.Reason == PausedReason {
+			return operatorsv1.HubPaused
+		}
+	}
+
+	if successful := allComponentsSuccessful(status.Components); successful {
 		if hubPruning(status) {
 			// hub is in pruning phase
 			return operatorsv1.HubPending
@@ -585,7 +580,6 @@ func aggregatePhase(status operatorsv1.MultiClusterHubStatus) operatorsv1.HubPha
 		// Hub has reached desired version, but degraded
 		return operatorsv1.HubPending
 	}
-
 }
 
 // NewHubCondition creates a new hub condition.

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -193,28 +193,24 @@ func calculateStatus(hub *operatorsv1.MultiClusterHub, allDeps []*appsv1.Deploym
 	if successful {
 		// don't label as complete until component pruning succeeds
 		if !hubPruning(status) && !utils.IsPaused(hub) {
-			available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue,
-				ComponentsAvailableReason, "All hub components ready.")
+			available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
 			SetHubCondition(&status, *available)
 		} else {
 			// only add unavailable status if complete status already present
 			if HubConditionPresent(status, operatorsv1.Complete) {
-				unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse,
-					OldComponentNotRemovedReason, "Not all components successfully pruned.")
+				unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, OldComponentNotRemovedReason, "Not all components successfully pruned.")
 				SetHubCondition(&status, *unavailable)
 			}
 		}
 	} else {
 		// hub is progressing unless otherwise specified
 		if !HubConditionPresent(status, operatorsv1.Progressing) {
-			progressing := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue,
-				ReconcileReason, "Hub is reconciling.")
+			progressing := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, ReconcileReason, "Hub is reconciling.")
 			SetHubCondition(&status, *progressing)
 		}
 		// only add unavailable status if complete status already present
 		if HubConditionPresent(status, operatorsv1.Complete) {
-			unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse,
-				ComponentsUnavailableReason, "Not all hub components ready.")
+			unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, ComponentsUnavailableReason, "Not all hub components ready.")
 			SetHubCondition(&status, *unavailable)
 		}
 	}
@@ -270,7 +266,11 @@ func successfulDeploy(d *appsv1.Deployment) bool {
 		}
 	}
 
-	return d.Status.UnavailableReplicas <= 0
+	if d.Status.UnavailableReplicas > 0 {
+		return false
+	}
+
+	return true
 }
 
 func latestDeployCondition(conditions []appsv1.DeploymentCondition) appsv1.DeploymentCondition {

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -335,6 +335,24 @@ func Test_aggregatePhase(t *testing.T) {
 			},
 			want: operatorsv1.HubRunning,
 		},
+		{
+			name: "Running hub with paused",
+			status: operatorsv1.MultiClusterHubStatus{
+				CurrentVersion: "",
+				Components: map[string]operatorsv1.StatusCondition{
+					"foo": available,
+				},
+				HubConditions: []operatorsv1.HubCondition{
+					{
+						Message: "Multiclusterhub is paused",
+						Reason:  PausedReason,
+						Status:  metav1.ConditionUnknown,
+						Type:    operatorsv1.Progressing,
+					},
+				},
+			},
+			want: operatorsv1.HubPaused,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

Updated MCH operator to show `Pending` status when the MCH CR has the `mch-pause` annotation set to `true`.

## Related Issue

https://issues.redhat.com/browse/ACM-9005

## Changes Made

Updated MCH CR to show a `Pending` status when the MCH operator is paused.

## Screenshots (if applicable)

<img width="679" alt="Screenshot 2023-12-13 at 3 50 48 PM" src="https://github.com/stolostron/multiclusterhub-operator/assets/28898909/6187b926-100e-4831-b002-c7dda65657a0">

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
