### PR TITLE
Update channel for stolostron-engine to 0.3

### DIFF
--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -32,7 +32,7 @@ var (
 	operandNameSpace       = "multicluster-engine"
 
 	// community MCE variables
-	communityChannel           = "community-0.1"
+    communityChannel           = "community-0.3"
 	communityPackageName       = "stolostron-engine"
 	communityCatalogSourceName = "community-operators"
 	communityOperandNamepace   = "stolostron-engine"


### PR DESCRIPTION
# Description

Just as each version of ACM requires a specific version of MCE, so too does each version of the community Stolostron operator requires a corresponding version of Stolostron Engine.  For the ACM 2.10 release cycle, the product pairings are ACM 2.10 / MCE 2.5 and the community pairings are Stolostron 0.3 / Stolostron-Engine 0.3. 

The update to the required Stolostron-Engine channel was not made by PR #1244 but should have been.  ACtually, it looks like no update was made  for ACM 2.9 / Stolostron 0.2 either (oops!).

## Changes Made

Update the constant identifying the required Stolostron-Engine update channel.