### PR TITLE
Fix MCE catsrc ambiguity detection when more than 1 catsrc has latest version

### DIFF
--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -235,8 +235,9 @@ func GetCatalogSource(k8sClient client.Client) (types.NamespacedName, error) {
 }
 
 // filterPackageManifests returns a list of packagemanifests containing the desired channel
-// at the latest available version. Returns an empty list if no packagemanifests include the channel. If more
-// than one packagemanifest have the same latest version available it will return them both.
+// at the latest available version. Returns an empty list if no packagemanifests include the
+// channel. If more than one packagemanifest have the same latest version available it will
+// return them all.
 func filterPackageManifests(pkgManifests []olmapi.PackageManifest, desiredChannel string) []olmapi.PackageManifest {
 	filtered := []olmapi.PackageManifest{}
 	latestVersion := &semver.Version{}
@@ -258,6 +259,7 @@ func filterPackageManifests(pkgManifests []olmapi.PackageManifest, desiredChanne
 					filtered = append(filtered, p)
 				} else if v.GreaterThan(latestVersion) {
 					filtered = []olmapi.PackageManifest{p}
+					latestVersion = v
 				}
 			}
 		}

--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -32,7 +32,7 @@ var (
 	operandNameSpace       = "multicluster-engine"
 
 	// community MCE variables
-    communityChannel           = "community-0.3"
+	communityChannel           = "community-0.3"
 	communityPackageName       = "stolostron-engine"
 	communityCatalogSourceName = "community-operators"
 	communityOperandNamepace   = "stolostron-engine"

--- a/pkg/multiclusterengine/multiclusterengine_test.go
+++ b/pkg/multiclusterengine/multiclusterengine_test.go
@@ -513,7 +513,7 @@ func Test_filterPackageManifests(t *testing.T) {
 					},
 					{
 						Status: olmapi.PackageManifestStatus{
-							CatalogSource: "custom-operators",
+							CatalogSource: "custom-operators-1",
 							Channels: []olmapi.PackageChannel{
 								{
 									Name:       "stable",
@@ -527,12 +527,28 @@ func Test_filterPackageManifests(t *testing.T) {
 							},
 						},
 					},
+					{
+						Status: olmapi.PackageManifestStatus{
+							CatalogSource: "custom-operators-2",
+							Channels: []olmapi.PackageChannel{
+								{
+									Name:       "stable",
+									CurrentCSV: "multicluster-engine.v2.0.6-4",
+									CurrentCSVDesc: olmapi.CSVDescription{
+										Version: olmversion.OperatorVersion{
+											Version: semver.MustParse("2.0.6-4"),
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				channel: "stable",
 			},
 			want: []olmapi.PackageManifest{{
 				Status: olmapi.PackageManifestStatus{
-					CatalogSource: "custom-operators",
+					CatalogSource: "custom-operators-1",
 					Channels: []olmapi.PackageChannel{
 						{
 							Name:       "stable",
@@ -548,7 +564,7 @@ func Test_filterPackageManifests(t *testing.T) {
 			}},
 		},
 		{
-			name: "Return both packagemanifests because they have the same versions",
+			name: "Return both packagemanifests if two have the same versions",
 			args: args{
 				pkgManifests: []olmapi.PackageManifest{
 					{
@@ -621,6 +637,129 @@ func Test_filterPackageManifests(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Return multiple packagemanifests if they have the same versions",
+			args: args{
+				pkgManifests: []olmapi.PackageManifest{
+					{
+						Status: olmapi.PackageManifestStatus{
+							CatalogSource: "redhat-operators",
+							Channels: []olmapi.PackageChannel{
+								{
+									Name:       "stable",
+									CurrentCSV: "multicluster-engine.v2.0.6",
+									CurrentCSVDesc: olmapi.CSVDescription{
+										Version: olmversion.OperatorVersion{
+											Version: semver.MustParse("2.0.6"),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Status: olmapi.PackageManifestStatus{
+							CatalogSource: "custom-operators-1",
+							Channels: []olmapi.PackageChannel{
+								{
+									Name:       "stable",
+									CurrentCSV: "multicluster-engine.v2.0.7",
+									CurrentCSVDesc: olmapi.CSVDescription{
+										Version: olmversion.OperatorVersion{
+											Version: semver.MustParse("2.0.7"),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Status: olmapi.PackageManifestStatus{
+							CatalogSource: "custom-operators-2",
+							Channels: []olmapi.PackageChannel{
+								{
+									Name:       "stable",
+									CurrentCSV: "multicluster-engine.v2.0.7",
+									CurrentCSVDesc: olmapi.CSVDescription{
+										Version: olmversion.OperatorVersion{
+											Version: semver.MustParse("2.0.7"),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Status: olmapi.PackageManifestStatus{
+							CatalogSource: "custom-operators-3",
+							Channels: []olmapi.PackageChannel{
+								{
+									Name:       "stable",
+									CurrentCSV: "multicluster-engine.v2.0.7",
+									CurrentCSVDesc: olmapi.CSVDescription{
+										Version: olmversion.OperatorVersion{
+											Version: semver.MustParse("2.0.7"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				channel: "stable",
+			},
+			want: []olmapi.PackageManifest{
+				{
+					Status: olmapi.PackageManifestStatus{
+						CatalogSource: "custom-operators-1",
+						Channels: []olmapi.PackageChannel{
+							{
+								Name:       "stable",
+								CurrentCSV: "multicluster-engine.v2.0.7",
+								CurrentCSVDesc: olmapi.CSVDescription{
+									Version: olmversion.OperatorVersion{
+										Version: semver.MustParse("2.0.7"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Status: olmapi.PackageManifestStatus{
+						CatalogSource: "custom-operators-2",
+						Channels: []olmapi.PackageChannel{
+							{
+								Name:       "stable",
+								CurrentCSV: "multicluster-engine.v2.0.7",
+								CurrentCSVDesc: olmapi.CSVDescription{
+									Version: olmversion.OperatorVersion{
+										Version: semver.MustParse("2.0.7"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Status: olmapi.PackageManifestStatus{
+						CatalogSource: "custom-operators-3",
+						Channels: []olmapi.PackageChannel{
+							{
+								Name:       "stable",
+								CurrentCSV: "multicluster-engine.v2.0.7",
+								CurrentCSVDesc: olmapi.CSVDescription{
+									Version: olmversion.OperatorVersion{
+										Version: semver.MustParse("2.0.7"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
 		{
 			name: "Return the non-prerelease version",
 			args: args{


### PR DESCRIPTION
# Description

The ACM Hub operator has logic to automatically determine the catalog source to use when creating the OLM subscription to install MCE.  This logic looks through the `PackageManifest` resources for the MCE operator package (there will be one of these per `CatalogSource` that provides the package), and seeks to pick the `PackageManifest/CatalogSource` that includes the update channel we need for this ACM release.  

In normal cases, there is usually only one `PackageManifest`/`CatalogSource` (the built-into-OCP `redhat-operators`  `CatalogSource`) that provides the operator package, so there is no possibility of ambiguity.  But in special customer situations or in dev, there can be many, so there can be multiple ones that provide the needed update channel.  If there are multiple and one of them provides a operator version later than the others, then we guess that is the one to use.  But if there is no clear best one based on the operator versions, we want to be conservative and not make a guess at all.  (This is a case that will cause the ACM Hub operator to not create the subscription for MCE at all and note the issue in the operator logs.)

The logic for detecting ambiguity seems to have been written assuming there would only ever be two `PackageManifests`/`CatalogSources` to consider but that is probably an unsafe assumption.  This pR makes minor fix to extend the logic to work in the cases where there are more than two.

## Changes Made

-  Fix to ambiguity detection logic (1 line of code)
- Addition of unit test case for a case that previously was handled wrong.
