### PR TITLE
remove context from logs

### DIFF
--- a/controllers/hosted.go
+++ b/controllers/hosted.go
@@ -31,7 +31,7 @@ import (
 )
 
 func (r *MultiClusterHubReconciler) HostedReconcile(ctx context.Context, mch *operatorv1.MultiClusterHub) (retRes ctrl.Result, retErr error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	defer func() {
 		statusQueue, statusError := r.updateHostedHubStatus(mch) //1
@@ -101,7 +101,7 @@ func (r *MultiClusterHubReconciler) HostedReconcile(ctx context.Context, mch *op
 
 // setHostedDefaults configures the MCH with default values and updates
 func (r *MultiClusterHubReconciler) setHostedDefaults(ctx context.Context, m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	updateNecessary := false
 	if !operatorv1.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig) {

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -118,7 +118,7 @@ const (
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (retQueue ctrl.Result, retError error) {
-	r.Log = log.FromContext(ctx)
+	r.Log = log.Log.WithName("reconcile")
 	r.Log.Info("Reconciling MultiClusterHub")
 
 	// Fetch the MultiClusterHub instance
@@ -549,7 +549,7 @@ func (r *MultiClusterHubReconciler) SetupWithManager(mgr ctrl.Manager) (controll
 }
 
 func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operatorv1.MultiClusterHub, template *unstructured.Unstructured) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	// Set owner reference.
 	if (template.GetKind() == "ClusterRole") || (template.GetKind() == "ClusterRoleBinding") || (template.GetKind() == "ServiceMonitor") || (template.GetKind() == "CustomResourceDefinition") {
 		utils.AddInstallerLabel(template, m.Name, m.Namespace)
@@ -575,7 +575,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 }
 
 func (r *MultiClusterHubReconciler) fetchChartLocation(ctx context.Context, component string) string {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	switch component {
 	case operatorv1.Appsub:
@@ -625,7 +625,7 @@ func (r *MultiClusterHubReconciler) ensureComponentOrNoComponent(ctx context.Con
 	var result ctrl.Result
 	var err error
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	if !m.Enabled(component) {
 		if component == operatorv1.ClusterBackup {
@@ -683,7 +683,7 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 		return ctrl.Result{}, nil
 	}
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	chartLocation := r.fetchChartLocation(ctx, component)
 
 	// Renders all templates from charts
@@ -732,7 +732,7 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 		return ctrl.Result{}, nil
 	}
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	chartLocation := r.fetchChartLocation(ctx, component)
 
 	switch component {
@@ -793,7 +793,7 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Context,
 	m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	existingNs := &corev1.Namespace{}
 
 	err := r.Client.Get(ctx, types.NamespacedName{Name: m.GetNamespace()}, existingNs)
@@ -823,7 +823,7 @@ func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Co
 }
 
 func (r *MultiClusterHubReconciler) deleteTemplate(ctx context.Context, m *operatorv1.MultiClusterHub, template *unstructured.Unstructured) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	err := r.Client.Get(ctx, types.NamespacedName{Name: template.GetName(), Namespace: template.GetNamespace()}, template)
 
 	if err != nil && (errors.IsNotFound(err) || apimeta.IsNoMatchError(err)) {
@@ -848,7 +848,7 @@ func (r *MultiClusterHubReconciler) deleteTemplate(ctx context.Context, m *opera
 // createCAconfigmap creates a configmap that will be injected with the
 // trusted CA bundle for use with the OCP cluster wide proxy
 func (r *MultiClusterHubReconciler) createTrustBundleConfigmap(ctx context.Context, mch *operatorv1.MultiClusterHub) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	// Get Trusted Bundle configmap name
 	trustBundleName := defaultTrustBundleName
@@ -904,7 +904,7 @@ func (r *MultiClusterHubReconciler) createTrustBundleConfigmap(ctx context.Conte
 
 func (r *MultiClusterHubReconciler) createMetricsService(ctx context.Context, m *operatorv1.MultiClusterHub) (
 	ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	const Port = 8383
 
@@ -968,7 +968,7 @@ func (r *MultiClusterHubReconciler) createMetricsService(ctx context.Context, m 
 
 func (r *MultiClusterHubReconciler) createMetricsServiceMonitor(ctx context.Context, m *operatorv1.MultiClusterHub) (
 	ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 
 	smName := utils.MCHOperatorMetricsServiceMonitorName
 	smNamespace := m.GetNamespace()

--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func addMultiClusterEngineWatch(ctx context.Context, uncachedClient client.Clien
 							namespace = labels["multiclusterhub.namespace"]
 						}
 						if name == "" || namespace == "" {
-							l := log.FromContext(context.Background())
+							l := log.Log.WithName("mce")
 							l.Info(fmt.Sprintf("MCE updated, but did not find required labels: %v", labels))
 							return
 						}

--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -246,7 +246,7 @@ func filterPackageManifests(pkgManifests []olmapi.PackageManifest, desiredChanne
 				versionString := c.CurrentCSVDesc.Version.String()
 				v, err := semver.NewVersion(versionString)
 				if err != nil {
-					log.FromContext(context.Background()).Info("failed to parse version from packagemanifest", "catalogsource", p.Status.CatalogSource)
+					log.Log.WithName("reconcile").Info("failed to parse version from packagemanifest", "catalogsource", p.Status.CatalogSource)
 					continue
 				}
 				if len(filtered) == 0 {
@@ -295,7 +295,7 @@ func OperandNameSpace() string {
 // returns packagemanifests with the name multicluster-engine
 func GetMCEPackageManifests(k8sClient client.Client) ([]olmapi.PackageManifest, error) {
 	ctx := context.Background()
-	log := log.FromContext(ctx)
+	log := log.Log.WithName("reconcile")
 	packageManifests := &olmapi.PackageManifestList{}
 	var err error
 	if utils.IsUnitTest() {
@@ -357,7 +357,7 @@ func FindAndManageMCE(ctx context.Context, k8sClient client.Client) (*mcev1.Mult
 	}
 
 	// if label doesn't work find it via list
-	log.FromContext(ctx).Info("Failed to find subscription via label")
+	log.Log.WithName("reconcile").Info("Failed to find subscription via label")
 	wholeList := &mcev1.MultiClusterEngineList{}
 	err = k8sClient.List(ctx, wholeList)
 	if err != nil {
@@ -384,9 +384,9 @@ func FindAndManageMCE(ctx context.Context, k8sClient client.Client) (*mcev1.Mult
 	}
 	labels[utils.MCEManagedByLabel] = "true"
 	filteredMCEs[0].SetLabels(labels)
-	log.FromContext(ctx).Info("Adding label to MCE")
+	log.Log.WithName("reconcile").Info("Adding label to MCE")
 	if err := k8sClient.Update(ctx, &filteredMCEs[0]); err != nil {
-		log.FromContext(ctx).Error(err, "Failed to add managedBy label to preexisting MCE")
+		log.Log.WithName("reconcile").Error(err, "Failed to add managedBy label to preexisting MCE")
 		return &filteredMCEs[0], err
 	}
 	return &filteredMCEs[0], nil

--- a/pkg/multiclusterengine/subscription.go
+++ b/pkg/multiclusterengine/subscription.go
@@ -169,7 +169,7 @@ func FindAndManageMCESubscription(ctx context.Context, k8sClient client.Client) 
 
 	// if label doesn't work find it via .spec.name (it's package)
 	// we can't assume it's name or namespace
-	log.FromContext(ctx).Info("Failed to find subscription via label")
+	log.Log.WithName("reconcile").Info("Failed to find subscription via label")
 	wholeList := &subv1alpha1.SubscriptionList{}
 	err = k8sClient.List(ctx, wholeList)
 	if err != nil {
@@ -187,9 +187,9 @@ func FindAndManageMCESubscription(ctx context.Context, k8sClient client.Client) 
 			}
 			labels[utils.MCEManagedByLabel] = "true"
 			wholeList.Items[i].SetLabels(labels)
-			log.FromContext(ctx).Info("Adding label to subscription")
+			log.Log.WithName("reconcile").Info("Adding label to subscription")
 			if err := k8sClient.Update(ctx, &wholeList.Items[i]); err != nil {
-				log.FromContext(ctx).Error(err, "Failed to add managedBy label to preexisting MCE with MCH spec")
+				log.Log.WithName("reconcile").Error(err, "Failed to add managedBy label to preexisting MCE with MCH spec")
 				return &wholeList.Items[i], err
 			}
 			return &wholeList.Items[i], nil

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -2,7 +2,6 @@
 package renderer
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -185,7 +184,7 @@ func RenderCRDs(crdDir string) ([]*unstructured.Unstructured, []error) {
 }
 
 func RenderCharts(chartDir string, mch *v1.MultiClusterHub, images map[string]string) ([]*unstructured.Unstructured, []error) {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 	var templates []*unstructured.Unstructured
 	errs := []error{}
 	if val, ok := os.LookupEnv("DIRECTORY_OVERRIDE"); ok {
@@ -213,7 +212,7 @@ func RenderCharts(chartDir string, mch *v1.MultiClusterHub, images map[string]st
 }
 
 func RenderChart(chartPath string, mch *v1.MultiClusterHub, images map[string]string) ([]*unstructured.Unstructured, []error) {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 	errs := []error{}
 	if val, ok := os.LookupEnv("DIRECTORY_OVERRIDE"); ok {
 		chartPath = path.Join(val, chartPath)
@@ -234,7 +233,7 @@ func RenderChart(chartPath string, mch *v1.MultiClusterHub, images map[string]st
 }
 
 func renderTemplates(chartPath string, mch *v1.MultiClusterHub, images map[string]string) ([]*unstructured.Unstructured, []error) {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 	var templates []*unstructured.Unstructured
 	errs := []error{}
 	chart, err := loader.Load(chartPath)
@@ -323,7 +322,7 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 }
 
 func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval, string, string) {
-	log := log.FromContext(context.Background())
+	log := log.Log.WithName("reconcile")
 	sub := &subv1alpha1.SubscriptionSpec{}
 	var name, channel, source, sourceNamespace string
 	var installPlan subv1alpha1.Approval


### PR DESCRIPTION
# Description

There was a lot of excess information in every log statement. This has been removed.

## Related Issue

https://issues.redhat.com/browse/ACM-8349

## Changes Made

Change the log function from `log.FromContext()` to `log.Log.WithName()`

