### PR TITLE
create ManagedClusterSetBinding for the backup ns

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-clusterrolebinding.yml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-clusterrolebinding.yml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: default
+  namespace: open-cluster-management-backup
+spec:
+  clusterSet: default

--- a/test/unit-tests/crds/managedclustersetbindings.yaml
+++ b/test/unit-tests/crds/managedclustersetbindings.yaml
@@ -1,0 +1,144 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    operator.open-cluster-management.io/version: 0.0.0
+  name: managedclustersetbindings.cluster.open-cluster-management.io
+spec:
+  conversion:
+    strategy: None
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ManagedClusterSetBinding
+    listKind: ManagedClusterSetBindingList
+    plural: managedclustersetbindings
+    shortNames:
+    - mclsetbinding
+    - mclsetbindings
+    singular: managedclustersetbinding
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: ManagedClusterSetBinding projects a ManagedClusterSet into a
+          certain namespace. User is able to create a ManagedClusterSetBinding in
+          a namespace and bind it to a ManagedClusterSet if they have an RBAC rule
+          to CREATE on the virtual subresource of managedclustersets/bind. Workloads
+          created in the same namespace can only be distributed to ManagedClusters
+          in ManagedClusterSets bound in this namespace by higher level controllers.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the attributes of ManagedClusterSetBinding.
+            properties:
+              clusterSet:
+                description: ClusterSet is the name of the ManagedClusterSet to bind.
+                  It must match the instance name of the ManagedClusterSetBinding
+                  and cannot change once created. User is allowed to set this field
+                  if they have an RBAC rule to CREATE on the virtual subresource of
+                  managedclustersets/bind.
+                minLength: 1
+                type: string
+            type: object
+          status:
+            description: Status represents the current status of the ManagedClusterSetBinding
+            properties:
+              conditions:
+                description: Conditions contains the different condition statuses
+                  for this ManagedClusterSetBinding.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ManagedClusterSetBinding
+    listKind: ManagedClusterSetBindingList
+    plural: managedclustersetbindings
+    shortNames:
+    - mclsetbinding
+    - mclsetbindings
+    singular: managedclustersetbinding
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
# Description

Addition to https://github.com/stolostron/multiclusterhub-operator/pull/1289
The Placement resource needs a ManagedClusterSetBinding created in the same ns with the Placement

## Related Issue

https://issues.redhat.com/browse/ACM-8892

## Changes Made

Created a ManagedClusterSetBinding for the default clusterSet in the open-cluster-management-backup namespace, where the hub backup resources are installed 

## Screenshots (if applicable)
<img width="897" alt="Screenshot 2024-01-12 at 4 36 59 PM" src="https://github.com/stolostron/multiclusterhub-operator/assets/43010150/fa21ed9d-fe53-4ef7-907f-3f2e3be5b722">


## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
