### PR TITLE
[ACM-9642] Updated validating webhook to only ensure MCH components

### DIFF
--- a/api/v1/methods_test.go
+++ b/api/v1/methods_test.go
@@ -134,8 +134,8 @@ var _ = Describe("V1 API Methods", func() {
 	})
 
 	It("correctly validates a component name", func() {
-		Expect(api.ValidComponent(config(api.Search, true))).To(BeTrue())
-		Expect(api.ValidComponent(config("invalid", true))).To(BeFalse())
+		Expect(api.ValidComponent(config(api.Search, true), api.MCHComponents)).To(BeTrue())
+		Expect(api.ValidComponent(config("invalid", true), api.MCHComponents)).To(BeFalse())
 	})
 
 	It("gets the correct number of default enabled components", func() {

--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -89,8 +89,8 @@ var MCHComponents = []string{
 	Console,
 	GRC,
 	Insights,
-	// MultiClusterEngine,
-	MCH, // Adding MCH name to ensure legacy resources are cleaned up properly.
+	MultiClusterEngine, // Adding MCE component to ensure that the component is validated by the webhook.
+	MCH,                // Adding MCH component to ensure legacy resources are cleaned up properly.
 	MultiClusterObservability,
 	//Repo,
 	Search,

--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -333,8 +333,8 @@ func (mch *MultiClusterHub) Prune(s string) bool {
 }
 
 // ValidComponent checks if a given component configuration is valid by comparing its name to the known component names.
-func ValidComponent(c ComponentConfig) bool {
-	for _, name := range allComponents {
+func ValidComponent(c ComponentConfig, validComponents []string) bool {
+	for _, name := range validComponents {
 		if c.Name == name {
 			return true
 		}

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -135,7 +135,7 @@ func (r *MultiClusterHub) ValidateCreate() error {
 	// Validate components
 	if r.Spec.Overrides != nil {
 		for _, c := range r.Spec.Overrides.Components {
-			if !ValidComponent(c) {
+			if !ValidComponent(c, MCHComponents) {
 				return fmt.Errorf("invalid component config: %s is not a known component", c.Name)
 			}
 		}
@@ -169,7 +169,7 @@ func (r *MultiClusterHub) ValidateUpdate(old runtime.Object) error {
 	// Validate components
 	if r.Spec.Overrides != nil {
 		for _, c := range r.Spec.Overrides.Components {
-			if !ValidComponent(c) {
+			if !ValidComponent(c, MCHComponents) {
 				return fmt.Errorf("invalid componentconfig: %s is not a known component", c.Name)
 			}
 		}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -698,7 +698,7 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 		If the component is detected to be MCH, we can simply return successfully. MCH is only listed in the components
 		list for cleanup purposes.
 	*/
-	if component == operatorv1.MCH {
+	if component == operatorv1.MCH || component == operatorv1.MultiClusterEngine {
 		return ctrl.Result{}, nil
 	}
 
@@ -745,9 +745,10 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 
 	/*
 		If the component is detected to be MCH, we can simply return successfully. MCH is only listed in the components
-		list for cleanup purposes.
+		list for cleanup purposes. If the component is detected to be MCE, we can simply return successfully.
+		MCE is only listed in the components list for webhook validation purposes.
 	*/
-	if component == operatorv1.MCH {
+	if component == operatorv1.MCH || component == operatorv1.MultiClusterEngine {
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
# Description

Updating the validating webhook for MCH to validate and compare entries only against valid MCH components. This will prevent users from adding MCE component names to the MCH CR resource.

## Related Issue

https://issues.redhat.com/browse/ACM-9642

## Changes Made

Updated MCH validating webhook to validate and accept components, only if they are valid MCH components.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 
## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
