### PR TITLE
[ACM-9574] Ensuring that non-mch components are removed from spec.override

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -107,7 +107,6 @@ var MCEComponents = []string{
 	MCEDiscovery,
 	MCEHive,
 	MCEServerFoundation,
-	MCEConsole,
 	MCEManagedServiceAccount,
 	MCEManagedServiceAccountPreview,
 	MCEHypershift,

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -1270,6 +1270,13 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 		updateNecessary = true
 	}
 
+	for _, c := range operatorv1.MCEComponents {
+		if m.Prune(c) {
+			log.Info(fmt.Sprintf("Removing MultiClusterEngine component: %v from existing MultiClusterHub", c))
+			updateNecessary = true
+		}
+	}
+
 	if utils.MchIsValid(m) && os.Getenv("ACM_HUB_OCP_VERSION") != "" && !updateNecessary {
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
# Description

Updating the MCH operator to `prune` any MCE component that is detected within the MCH CR.

## Related Issue

https://issues.redhat.com/browse/ACM-9574

## Changes Made

Updated the operator to prune MCE components from the MCH CR.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
