### PR TITLE
Removed assisted service namespace allocation for MCE

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -180,17 +180,6 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 	if mce == nil {
 		// figure out if assisted service is already configured
 		infraNS := ""
-		configured, err := AssistedServiceConfigured(ctx, r.Client)
-		if err != nil {
-			return ctrl.Result{Requeue: true}, err
-		}
-		if configured {
-			ns, err := utils.OperatorNamespace()
-			if err != nil {
-				return ctrl.Result{Requeue: true}, err
-			}
-			infraNS = ns
-		}
 
 		mce = multiclusterengine.NewMultiClusterEngine(m, infraNS)
 		err = r.Client.Create(ctx, mce)

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -178,10 +178,7 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 	}
 
 	if mce == nil {
-		// figure out if assisted service is already configured
-		infraNS := ""
-
-		mce = multiclusterengine.NewMultiClusterEngine(m, infraNS)
+		mce = multiclusterengine.NewMultiClusterEngine(m)
 		err = r.Client.Create(ctx, mce)
 		if err != nil {
 			return ctrl.Result{Requeue: true}, fmt.Errorf("Error creating new MCE: %w", err)

--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -65,7 +65,7 @@ var mockPackageManifests = func() *olmapi.PackageManifestList {
 }
 
 // NewMultiClusterEngine returns an MCE configured from a Multiclusterhub
-func NewMultiClusterEngine(m *operatorsv1.MultiClusterHub, infrastructureCustomNamespace string) *mcev1.MultiClusterEngine {
+func NewMultiClusterEngine(m *operatorsv1.MultiClusterHub) *mcev1.MultiClusterEngine {
 	labels := map[string]string{
 		"installer.name":        m.GetName(),
 		"installer.namespace":   m.GetNamespace(),
@@ -97,10 +97,6 @@ func NewMultiClusterEngine(m *operatorsv1.MultiClusterHub, infrastructureCustomN
 
 	if m.Spec.Overrides != nil && m.Spec.Overrides.ImagePullPolicy != "" {
 		mce.Spec.Overrides.ImagePullPolicy = m.Spec.Overrides.ImagePullPolicy
-	}
-
-	if infrastructureCustomNamespace != "" {
-		mce.Spec.Overrides.InfrastructureCustomNamespace = infrastructureCustomNamespace
 	}
 
 	return mce

--- a/pkg/multiclusterengine/multiclusterengine_test.go
+++ b/pkg/multiclusterengine/multiclusterengine_test.go
@@ -368,7 +368,7 @@ func TestNewMultiClusterEngine(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewMultiClusterEngine(tt.args.m, tt.args.infrastructureCustomNamespace)
+			got := NewMultiClusterEngine(tt.args.m)
 			g.Expect(got.Labels).To(gomega.Equal(tt.want.Labels))
 			g.Expect(got.Spec.ImagePullSecret).To(gomega.Equal(tt.want.Spec.ImagePullSecret))
 			g.Expect(got.Spec.Tolerations).To(gomega.Equal(tt.want.Spec.Tolerations))

--- a/pkg/multiclusterengine/multiclusterengine_test.go
+++ b/pkg/multiclusterengine/multiclusterengine_test.go
@@ -329,7 +329,6 @@ func TestNewMultiClusterEngine(t *testing.T) {
 						},
 					},
 				},
-				infrastructureCustomNamespace: "open-cluster-management",
 			},
 			want: &mcev1.MultiClusterEngine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -360,7 +359,6 @@ func TestNewMultiClusterEngine(t *testing.T) {
 							{Name: operatorsv1.MCEDiscovery, Enabled: false},
 							{Name: operatorsv1.MCELocalCluster, Enabled: false},
 						},
-						InfrastructureCustomNamespace: "open-cluster-management",
 					},
 				},
 			},
@@ -377,8 +375,6 @@ func TestNewMultiClusterEngine(t *testing.T) {
 			g.Expect(got.Spec.TargetNamespace).To(gomega.Equal(tt.want.Spec.TargetNamespace))
 			g.Expect(got.Spec.Overrides.Components).To(gomega.Equal(tt.want.Spec.Overrides.Components))
 			g.Expect(got.Spec.Overrides.ImagePullPolicy).To(gomega.Equal(tt.want.Spec.Overrides.ImagePullPolicy))
-			g.Expect(got.Spec.Overrides.InfrastructureCustomNamespace).To(gomega.Equal(tt.want.Spec.Overrides.InfrastructureCustomNamespace))
-
 		})
 	}
 }


### PR DESCRIPTION
One thing I noticed, is that this code was the only reason that `NewMultiClusterEngine` accepts the custom namespace. Is it safe to remove this?