### PR TITLE
enable readOnlyRootFilesystem on cluster permission pod

### DIFF
--- a/pkg/templates/charts/toggle/cluster-permission/templates/cluster-permission.yaml
+++ b/pkg/templates/charts/toggle/cluster-permission/templates/cluster-permission.yaml
@@ -77,6 +77,7 @@ spec:
             drop:
             - ALL
           privileged: false
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       hostIPC: false


### PR DESCRIPTION
# Description

Please provide a brief description of the purpose of this pull request.

enable readOnlyRootFilesystem on hub cluster permission pod

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

https://issues.redhat.com/browse/ACM-8463

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [X] I have tested the changes locally and they are functioning as expected.
- [X] I have updated the documentation (if necessary) to reflect the changes.
- [X] I have added/updated relevant unit tests (if applicable).
- [X] I have ensured that my code follows the project's coding standards.
- [X] I have checked for any potential security issues and addressed them.
- [X] I have added necessary comments to the code, especially in complex or unclear sections.
- [X] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
