### PR TITLE
Adding a policy template to verify OADP channel

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -256,19 +256,19 @@ spec:
           name: oadp-channel
         spec:
           remediationAction: inform
-          severity: medium
+          severity: high
           object-templates-raw: |
-            {{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "" "").items }}
-            {{- if eq $ss.spec.name "redhat-oadp-operator" }}
+            {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "" "").items }}` }}
+            {{ `{{- if eq $ss.spec.name "redhat-oadp-operator" }}` }}
             - complianceType: musthave
               objectDefinition:
                 kind: Subscription
                 apiVersion: operators.coreos.com/v1alpha1
                 metadata:
-                  name: {{ $ss.metadata.name }}
-                  namespace: {{ $ss.metadata.namespace }}
+                  name: {{ `{{ $ss.metadata.name }}` }}
+                  namespace: {{ `{{ $ss.metadata.namespace }}` }}
                 spec:
                   channel: {{ .Values.global.channel }}
-            {{- end }}
-            {{- end }}                                                                      
+            {{ `{{- end }}` }}
+            {{ `{{- end }}` }}                                                                      
   remediationAction: inform

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -248,5 +248,27 @@ spec:
                 status:
                   phase: Error                                                       
           remediationAction: inform
-          severity: high                                                                        
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: oadp-channel
+        spec:
+          remediationAction: inform
+          severity: medium
+          object-templates-raw: |
+            {{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "" "").items }}
+            {{- if eq $ss.spec.name "redhat-oadp-operator" }}
+            - complianceType: musthave
+              objectDefinition:
+                kind: Subscription
+                apiVersion: operators.coreos.com/v1alpha1
+                metadata:
+                  name: {{ $ss.metadata.name }}
+                  namespace: {{ $ss.metadata.namespace }}
+                spec:
+                  channel: {{ .Values.global.channel }}
+            {{- end }}
+            {{- end }}                                                                      
   remediationAction: inform


### PR DESCRIPTION
# Description

Adding a new policy template to find the OADP subscription and check if its channel version is what we have in Values.yaml file. If another version of OADP is manually installed by users, the policy shows as non compliant.

Note: The purpose for the backticks is for the Helm to process the template and return the raw string inside (i.e. the Policy template). We don't want Helm to process the policy templates.

## Related Issue

https://issues.redhat.com/browse/ACM-8490

## Changes Made

Adding a new policy template to find the OADP subscription and check if its channel is what we have in Values.yaml file

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
