### PR TITLE
New policy to report issues related to backup restore auto import configs

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-auto-import.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-auto-import.yaml
@@ -31,21 +31,21 @@ spec:
           remediationAction: enforce
           severity: medium
           object-templates-raw: |
-            {{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}
-              {{- range $ss := (lookup "v1" "Secret" $ns.metadata.name "").items  }} 
-                {{- if or (eq $ss.metadata.name "auto-import-account") (eq $ss.metadata.name "auto-import-account-pair") }}    
+            {{ `{{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}` }}
+              {{ `{{- range $ss := (lookup "v1" "Secret" $ns.metadata.name "").items }}` }} 
+                {{ `{{- if or (eq $ss.metadata.name "auto-import-account") (eq $ss.metadata.name "auto-import-account-pair") }}` }}    
             - complianceType: musthave
               objectDefinition:
                 kind: Secret
                 apiVersion: v1
                 metadata:
-                  name: {{ $ss.metadata.name }}
-                  namespace: {{ $ns.metadata.name }}
+                  name: {{ `{{ $ss.metadata.name }}` }}
+                  namespace: {{ `{{ $ns.metadata.name }}` }}
                   labels:
                     cluster.open-cluster-management.io/backup: msa
-                {{- end }}
-              {{- end }}
-            {{- end }}
+                {{ `{{- end }}` }}
+              {{ `{{- end }}` }}
+            {{ `{{- end }}` }}
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -55,16 +55,16 @@ spec:
           remediationAction: inform
           severity: medium
           object-templates-raw: |
-            {{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}
-            {{- $ms := (lookup "authentication.open-cluster-management.io/v1alpha1" "ManagedServiceAccount" $ns.metadata.name "auto-import-account") }} 
-              {{- if $ms }}   
+            {{ `{{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}` }}
+            {{ `{{- $ms := (lookup "authentication.open-cluster-management.io/v1alpha1" "ManagedServiceAccount" $ns.metadata.name "auto-import-account") }}` }} 
+              {{ `{{- if $ms }}` }}   
             - complianceType: musthave
               objectDefinition:
                 kind: Secret
                 apiVersion: v1
                 metadata:
                   name: "auto-import-account"
-                  namespace: {{ $ns.metadata.name }}
-              {{- end }}
-            {{- end }}
+                  namespace: {{ `{{ $ns.metadata.name }}` }}
+              {{ `{{- end }}` }}
+            {{ `{{- end }}` }}
 

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-auto-import.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-auto-import.yaml
@@ -1,0 +1,70 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+    release: cluster-backup-chart
+    heritage: Helm
+    app.kubernetes.io/instance: cluster-backup-chart
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cluster-backup-chart
+    helm.sh/chart: cluster-backup-chart
+    velero.io/exclude-from-backup: "true"
+    component: policy
+  annotations:
+    policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
+    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/source: system
+  name: backup-restore-auto-import
+  namespace: open-cluster-management-backup
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: auto-import-backup-label
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates-raw: |
+            {{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}
+              {{- range $ss := (lookup "v1" "Secret" $ns.metadata.name "").items  }} 
+                {{- if or (eq $ss.metadata.name "auto-import-account") (eq $ss.metadata.name "auto-import-account-pair") }}    
+            - complianceType: musthave
+              objectDefinition:
+                kind: Secret
+                apiVersion: v1
+                metadata:
+                  name: {{ $ss.metadata.name }}
+                  namespace: {{ $ns.metadata.name }}
+                  labels:
+                    cluster.open-cluster-management.io/backup: msa
+                {{- end }}
+              {{- end }}
+            {{- end }}
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: auto-import-account-secret
+        spec:
+          remediationAction: inform
+          severity: medium
+          object-templates-raw: |
+            {{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}
+            {{- $ms := (lookup "authentication.open-cluster-management.io/v1alpha1" "ManagedServiceAccount" $ns.metadata.name "auto-import-account") }} 
+              {{- if $ms }}   
+            - complianceType: musthave
+              objectDefinition:
+                kind: Secret
+                apiVersion: v1
+                metadata:
+                  name: "auto-import-account"
+                  namespace: {{ $ns.metadata.name }}
+              {{- end }}
+            {{- end }}
+

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-policy-set.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-policy-set.yaml
@@ -10,3 +10,4 @@ spec:
   description: ACM Hub backup and restore 
   policies:
     - backup-restore-enabled
+    - backup-restore-auto-import

--- a/pkg/templates/charts/toggle/cluster-backup/templates/managed-hub-policy-set.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/managed-hub-policy-set.yaml
@@ -10,3 +10,4 @@ spec:
   description: ACM Managed Hub backup and restore 
   policies:
     - backup-restore-enabled
+    - backup-restore-auto-import


### PR DESCRIPTION
# Description

A new policy is added to both _acm-hub-backup_ and _acm-managed-hub-backup_ policy sets. It includes two templates:
- _auto-import-account-secret_ **informs** if in managed cluster namespaces other than local-cluster, there is a ManagedServiceAccount named auto-import-account, but there is not a secret named auto-import-account
- _auto-import-backup-label_ **enforces** the backup label _cluster.open-cluster-management.io/backup: msa_ on auto-import-account secrets found in managed cluster namespaces other than local-cluster

## Related Issue

https://issues.redhat.com/browse/ACM-7850

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
