### PR TITLE
Add support for the policy compliance history API

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -16,6 +16,14 @@ rules:
 - apiGroups:
   - addon.open-cluster-management.io
   resources:
+  - addondeploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
   - clustermanagementaddons
   verbs:
   - get
@@ -77,14 +85,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - addon.open-cluster-management.io
-  resources:
-  - addondeploymentconfigs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
@@ -110,8 +110,24 @@ rules:
   - approve
 - apiGroups:
   - cluster.open-cluster-management.io
+  resourceNames:
+  - id.k8s.io
+  resources:
+  - clusterclaims
+  verbs:
+  - get
+- apiGroups:
+  - cluster.open-cluster-management.io
   resources:
   - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
   verbs:
   - get
   - list
@@ -150,16 +166,6 @@ rules:
   - watch
 - apiGroups:
   - ""
-  resourceNames:
-  - policy-encryption-key
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
   resources:
   - pods
   verbs:
@@ -167,9 +173,12 @@ rules:
   - list
   - watch
 - apiGroups:
-  - config.openshift.io
+  - ""
+  resourceNames:
+  - governance-policy-database
+  - policy-encryption-key
   resources:
-  - infrastructures
+  - secrets
   verbs:
   - get
   - list
@@ -240,6 +249,24 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+- apiGroups:
+  - route.openshift.io
+  resourceNames:
+  - governance-history-api
+  resources:
+  - routes
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - work.open-cluster-management.io
   resources:

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-compliance-history-api-service.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-compliance-history-api-service.yaml
@@ -1,0 +1,27 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: governance-policy-compliance-history-api
+  labels:
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
+    component: "ocm-policy-propagator"
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: governance-policy-compliance-history-api-cert
+spec:
+  ports:
+  - name: compliance-history-api
+    port: 8384
+    protocol: TCP
+    targetPort: 8384
+  selector:
+    app: grc
+    component: "ocm-policy-propagator"
+    release: grc
+  sessionAffinity: None
+  type: ClusterIP

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-deployment.yaml
@@ -126,7 +126,12 @@ spec:
           capabilities:
             drop:
             - ALL
-        command: ["governance-policy-propagator"]
+        command:
+        - governance-policy-propagator
+        args:
+        - "--compliance-history-api-host=0.0.0.0"
+        - "--compliance-history-api-cert=/var/run/compliance-history-api-cert/tls.crt"
+        - "--compliance-history-api-key=/var/run/compliance-history-api-cert/tls.key"
         env:
           - name: WATCH_NAMESPACE
             value: ""
@@ -154,12 +159,18 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        - mountPath: "/var/run/compliance-history-api-cert"
+          name: compliance-history-api-cert
+          readOnly: true
       volumes:
       - name: tmp
         emptyDir: {}
       - name: metrics-cert
         secret:
           secretName: grc-grc-metrics-cert
+      - name: compliance-history-api-cert
+        secret:
+          secretName: governance-policy-compliance-history-api-cert
       - name: cert
         secret:
           defaultMode: 420


### PR DESCRIPTION
The compliance history API is not exposed outside of the cluster by default. The governance-policy-addon-controller handles creating a Route when the governance-policy-database Secret is defined.

Relates:
https://issues.redhat.com/browse/ACM-6870
