### PR TITLE
Add permissions to the GRC addon controller for compliance history

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -174,6 +174,12 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
   resourceNames:
   - governance-policy-database
   - policy-encryption-key
@@ -183,6 +189,36 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - open-cluster-management-compliance-history-api-recorder
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - open-cluster-management-compliance-history-api-recorder
+  resources:
+  - serviceaccounts
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
 - apiGroups:
   - policy.open-cluster-management.io
   resources:
@@ -219,6 +255,7 @@ rules:
   - rbac.authorization.k8s.io
   resourceNames:
   - open-cluster-management:cert-policy-controller-hub
+  - open-cluster-management:compliance-history-api-recorder
   - open-cluster-management:config-policy-controller-hub
   - open-cluster-management:iam-policy-controller-hub
   - open-cluster-management:policy-framework-hub
@@ -239,6 +276,7 @@ rules:
   - rbac.authorization.k8s.io
   resourceNames:
   - open-cluster-management:cert-policy-controller-hub
+  - open-cluster-management:compliance-history-api-recorder
   - open-cluster-management:config-policy-controller-hub
   - open-cluster-management:iam-policy-controller-hub
   - open-cluster-management:policy-framework-hub


### PR DESCRIPTION
This syncs the RBAC changes from this:
https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/133

Relates:
https://issues.redhat.com/browse/ACM-6889