### PR TITLE
Enable template overrides for console cpu/memory requests and limits

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -105,8 +105,17 @@ spec:
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
           requests:
-            memory: "40Mi"
-            cpu: "3m"
+            memory: {{ .Values.global.templateOverrides.console_deployment_container_memory_request | default "40Mi" | quote }}
+            cpu: {{ .Values.global.templateOverrides.console_deployment_container_cpu_request | default "3m" | quote }}
+        {{- if or .Values.global.templateOverrides.console_deployment_container_memory_limit .Values.global.templateOverrides.console_deployment_container_cpu_limit }}
+          limits:
+          {{- if .Values.global.templateOverrides.console_deployment_container_memory_limit }}
+            memory: {{ .Values.global.templateOverrides.console_deployment_container_memory_limit | quote }}
+          {{- end }}
+          {{- if .Values.global.templateOverrides.console_deployment_container_cpu_limit }}
+            cpu: {{ .Values.global.templateOverrides.console_deployment_container_cpu_limit | quote }}
+          {{- end }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -105,14 +105,22 @@ spec:
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
           requests:
-            memory: {{ .Values.global.templateOverrides.console_deployment_container_memory_request | default "40Mi" | quote }}
-            cpu: {{ .Values.global.templateOverrides.console_deployment_container_cpu_request | default "3m" | quote }}
-        {{- if or .Values.global.templateOverrides.console_deployment_container_memory_limit .Values.global.templateOverrides.console_deployment_container_cpu_limit }}
+          {{- if hasKey .Values.global.templateOverrides "console_deployment_container_memory_request" }}
+            memory: {{ .Values.global.templateOverrides.console_deployment_container_memory_request | quote }}
+          {{- else }}
+            memory: "40Mi"
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "console_deployment_container_cpu_request" }}
+            cpu: {{ .Values.global.templateOverrides.console_deployment_container_cpu_request | quote }}
+          {{- else }}
+            cpu: "3m"
+          {{- end }}
+        {{- if or (hasKey .Values.global.templateOverrides "console_deployment_container_memory_limit") (hasKey .Values.global.templateOverrides "console_deployment_container_cpu_limit") }}
           limits:
-          {{- if .Values.global.templateOverrides.console_deployment_container_memory_limit }}
+          {{- if hasKey .Values.global.templateOverrides "console_deployment_container_memory_limit" }}
             memory: {{ .Values.global.templateOverrides.console_deployment_container_memory_limit | quote }}
           {{- end }}
-          {{- if .Values.global.templateOverrides.console_deployment_container_cpu_limit }}
+          {{- if hasKey .Values.global.templateOverrides "console_deployment_container_cpu_limit" }}
             cpu: {{ .Values.global.templateOverrides.console_deployment_container_cpu_limit | quote }}
           {{- end }}
         {{- end }}

--- a/pkg/templates/charts/toggle/console/values.yaml
+++ b/pkg/templates/charts/toggle/console/values.yaml
@@ -7,6 +7,12 @@ org: open-cluster-management
 global:
   imageOverrides:
     console: ""
+  templateOverrides: {}
+    # Available template overrides:
+    # console_deployment_container_memory_request: <memory-value>
+    # console_deployment_container_memory_limit: <memory-value>
+    # console_deployment_container_cpu_request: <cpu-value>
+    # console_deployment_container_cpu_limit: <cpu-value>
   namespace: default
   pullSecret: null
   pullPolicy: Always


### PR DESCRIPTION
# Description

This PR provides template-override capability for  console deployment cpu/memory requests and limits.  Four template-override keys are defined, one for each:

- `console_deployment_container_memory_request`
- `console_deployment_container_cpu_request`
- `console_deployment_container_memory_limit`
- `console_deployment_container_cpu_limit`

These template overrides can be defined using the mechanisms being implemented by PR #1333 .

If no template overrides are defined, the updated chart produces the same deployment as it does prior to this PR.  

## Changes Made

- Add default (empty) global.templateOverrides to value.yaml (with comments aboute available overrides)
- Update console-deployment.yaml to use cpu/memory request and limit overrides if they are found to have been defined as Values.global.templateOverrides.

## Checklist

- [X] I have tested the changes locally and they are functioning as expected.
- [ ] I N/A: have updated the documentation (if necessary) to reflect the changes. 
- [ ] N/A: I have added/updated relevant unit tests (if applicable). 
- [X] I have ensured that my code follows the project's coding standards.
- [X] I have checked for any potential security issues and addressed them.
- [ ] N/A: I have added necessary comments to the code, especially in complex or unclear sections.
- [X] I have rebased my branch on top of the latest main/master branch.