### PR TITLE
Update the CMA CRD being used for unit tests

### DIFF
--- a/test/unit-tests/crds/cluster_management_addons.yaml
+++ b/test/unit-tests/crds/cluster_management_addons.yaml
@@ -9,94 +9,522 @@ spec:
     listKind: ClusterManagementAddOnList
     plural: clustermanagementaddons
     singular: clustermanagementaddon
-  scope: Cluster
   preserveUnknownFields: false
+  scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.addOnMeta.displayName
-          name: DISPLAY NAME
-          type: string
-        - jsonPath: .spec.addOnConfiguration.crdName
-          name: CRD NAME
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ClusterManagementAddOn represents the registration of an add-on to the cluster manager. This resource allows the user to discover which add-on is available for the cluster manager and also provides metadata information about the add-on. This resource also provides a linkage to ManagedClusterAddOn, the name of the ClusterManagementAddOn resource will be used for the namespace-scoped ManagedClusterAddOn resource. ClusterManagementAddOn is a cluster-scoped resource.
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec represents a desired configuration for the agent on the cluster management add-on.
-              type: object
-              properties:
-                addOnConfiguration:
-                  description: 'Deprecated: Use supportedConfigs filed instead addOnConfiguration is a reference to configuration information for the add-on. In scenario where a multiple add-ons share the same add-on CRD, multiple ClusterManagementAddOn resources need to be created and reference the same AddOnConfiguration.'
-                  type: object
+  - additionalPrinterColumns:
+    - jsonPath: .spec.addOnMeta.displayName
+      name: DISPLAY NAME
+      type: string
+    - jsonPath: .spec.addOnConfiguration.crdName
+      name: CRD NAME
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterManagementAddOn represents the registration of an add-on
+          to the cluster manager. This resource allows the user to discover which
+          add-on is available for the cluster manager and also provides metadata information
+          about the add-on. This resource also provides a linkage to ManagedClusterAddOn,
+          the name of the ClusterManagementAddOn resource will be used for the namespace-scoped
+          ManagedClusterAddOn resource. ClusterManagementAddOn is a cluster-scoped
+          resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec represents a desired configuration for the agent on
+              the cluster management add-on.
+            properties:
+              addOnConfiguration:
+                description: 'Deprecated: Use supportedConfigs filed instead addOnConfiguration
+                  is a reference to configuration information for the add-on. In scenario
+                  where a multiple add-ons share the same add-on CRD, multiple ClusterManagementAddOn
+                  resources need to be created and reference the same AddOnConfiguration.'
+                properties:
+                  crName:
+                    description: crName is the name of the CR used to configure instances
+                      of the managed add-on. This field should be configured if add-on
+                      CR have a consistent name across the all of the ManagedCluster
+                      instaces.
+                    type: string
+                  crdName:
+                    description: crdName is the name of the CRD used to configure
+                      instances of the managed add-on. This field should be configured
+                      if the add-on have a CRD that controls the configuration of
+                      the add-on.
+                    type: string
+                  lastObservedGeneration:
+                    description: lastObservedGeneration is the observed generation
+                      of the custom resource for the configuration of the addon.
+                    format: int64
+                    type: integer
+                type: object
+              addOnMeta:
+                description: addOnMeta is a reference to the metadata information
+                  for the add-on.
+                properties:
+                  description:
+                    description: description represents the detailed description of
+                      the add-on.
+                    type: string
+                  displayName:
+                    description: displayName represents the name of add-on that will
+                      be displayed.
+                    type: string
+                type: object
+              installStrategy:
+                default:
+                  type: Manual
+                description: InstallStrategy represents that related ManagedClusterAddOns
+                  should be installed on certain clusters.
+                properties:
+                  placements:
+                    description: Placements is a list of placement references honored
+                      when install strategy type is Placements. All clusters selected
+                      by these placements will install the addon If one cluster belongs
+                      to multiple placements, it will only apply the strategy defined
+                      later in the order. That is to say, The latter strategy overrides
+                      the previous one.
+                    items:
+                      properties:
+                        configs:
+                          description: Configs is the configuration of managedClusterAddon
+                            during installation. User can override the configuration
+                            by updating the managedClusterAddon directly.
+                          items:
+                            properties:
+                              group:
+                                default: ""
+                                description: group of the add-on configuration.
+                                type: string
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              resource:
+                                description: resource of the add-on configuration.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - resource
+                            type: object
+                          type: array
+                        name:
+                          description: Name is the name of the placement
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the placement
+                          minLength: 1
+                          type: string
+                        rolloutStrategy:
+                          default:
+                            type: UpdateAll
+                          description: The rollout strategy to apply addon configurations
+                            change. The rollout strategy only watches the addon configurations
+                            defined in ClusterManagementAddOn.
+                          properties:
+                            rollingUpdate:
+                              description: Rolling update with placement config params.
+                                Present only if the type is RollingUpdate.
+                              properties:
+                                maxConcurrency:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  default: 25%
+                                  description: 'The maximum concurrently updating
+                                    number of clusters. Value can be an absolute number
+                                    (ex: 5) or a percentage of desired addons (ex:
+                                    10%). Absolute number is calculated from percentage
+                                    by rounding up. Defaults to 25%. Example: when
+                                    this is set to 30%, once the addon configs change,
+                                    the addon on 30% of the selected clusters will
+                                    adopt the new configs. When the addons with new
+                                    configs are healthy, the addon on the remaining
+                                    clusters will be further updated.'
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            rollingUpdateWithCanary:
+                              description: Rolling update with placement config params.
+                                Present only if the type is RollingUpdateWithCanary.
+                              properties:
+                                maxConcurrency:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  default: 25%
+                                  description: 'The maximum concurrently updating
+                                    number of clusters. Value can be an absolute number
+                                    (ex: 5) or a percentage of desired addons (ex:
+                                    10%). Absolute number is calculated from percentage
+                                    by rounding up. Defaults to 25%. Example: when
+                                    this is set to 30%, once the addon configs change,
+                                    the addon on 30% of the selected clusters will
+                                    adopt the new configs. When the addons with new
+                                    configs are healthy, the addon on the remaining
+                                    clusters will be further updated.'
+                                  x-kubernetes-int-or-string: true
+                                placement:
+                                  description: Canary placement reference.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the placement
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of the
+                                        placement
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - namespace
+                                  type: object
+                              required:
+                              - placement
+                              type: object
+                            type:
+                              default: UpdateAll
+                              description: "Type is the type of the rollout strategy,
+                                it supports UpdateAll, RollingUpdate and RollingUpdateWithCanary:
+                                - UpdateAll: when configs change, apply the new configs
+                                to all the selected clusters at once. This is the
+                                default strategy. - RollingUpdate: when configs change,
+                                apply the new configs to all the selected clusters
+                                with the concurrence rate defined in MaxConcurrency.
+                                - RollingUpdateWithCanary: when configs change, wait
+                                and check if add-ons on the canary placement selected
+                                clusters have applied the new configs and are healthy,
+                                then apply the new configs to all the selected clusters
+                                with the concurrence rate defined in MaxConcurrency.
+                                \n The field lastKnownGoodConfig in the status record
+                                the last successfully applied spec hash of canary
+                                placement. If the config spec hash changes after the
+                                canary is passed and before the rollout is done, the
+                                current rollout will continue, then roll out to the
+                                latest change. \n For example, the addon configs have
+                                spec hash A. The canary is passed and the lastKnownGoodConfig
+                                would be A, and all the selected clusters are rolling
+                                out to A. Then the config spec hash changes to B.
+                                At this time, the clusters will continue rolling out
+                                to A. When the rollout is done and canary passed B,
+                                the lastKnownGoodConfig would be B and all the clusters
+                                will start rolling out to B. \n The canary placement
+                                does not have to be a subset of the install placement,
+                                and it is more like a reference for finding and checking
+                                canary clusters before upgrading all. To trigger the
+                                rollout on the canary clusters, you can define another
+                                rollout strategy with the type RollingUpdate, or even
+                                manually upgrade the addons on those clusters."
+                              enum:
+                              - UpdateAll
+                              - RollingUpdate
+                              - RollingUpdateWithCanary
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                    x-kubernetes-list-type: map
+                  type:
+                    default: Manual
+                    description: 'Type is the type of the install strategy, it can
+                      be: - Manual: no automatic install - Placements: install to
+                      clusters selected by placements.'
+                    enum:
+                    - Manual
+                    - Placements
+                    type: string
+                type: object
+              supportedConfigs:
+                description: supportedConfigs is a list of configuration types supported
+                  by add-on. An empty list means the add-on does not require configurations.
+                  The default is an empty list
+                items:
+                  description: ConfigMeta represents a collection of metadata information
+                    for add-on configuration.
                   properties:
-                    crName:
-                      description: crName is the name of the CR used to configure instances of the managed add-on. This field should be configured if add-on CR have a consistent name across the all of the ManagedCluster instaces.
+                    defaultConfig:
+                      description: defaultConfig represents the namespace and name
+                        of the default add-on configuration. In scenario where all
+                        add-ons have a same configuration.
+                      properties:
+                        name:
+                          description: name of the add-on configuration.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: namespace of the add-on configuration. If this
+                            field is not set, the configuration is in the cluster
+                            scope.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    group:
+                      default: ""
+                      description: group of the add-on configuration.
                       type: string
-                    crdName:
-                      description: crdName is the name of the CRD used to configure instances of the managed add-on. This field should be configured if the add-on have a CRD that controls the configuration of the add-on.
+                    resource:
+                      description: resource of the add-on configuration.
+                      minLength: 1
                       type: string
-                    lastObservedGeneration:
-                      description: lastObservedGeneration is the observed generation of the custom resource for the configuration of the addon.
-                      type: integer
-                      format: int64
-                addOnMeta:
-                  description: addOnMeta is a reference to the metadata information for the add-on.
+                  required:
+                  - resource
                   type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: status represents the current status of cluster management
+              add-on.
+            properties:
+              defaultconfigReferences:
+                description: defaultconfigReferences is a list of current add-on default
+                  configuration references.
+                items:
+                  description: DefaultConfigReference is a reference to the current
+                    add-on configuration. This resource is used to record the configuration
+                    resource for the current add-on.
                   properties:
-                    description:
-                      description: description represents the detailed description of the add-on.
+                    desiredConfig:
+                      description: desiredConfig record the desired config spec hash.
+                      properties:
+                        name:
+                          description: name of the add-on configuration.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: namespace of the add-on configuration. If this
+                            field is not set, the configuration is in the cluster
+                            scope.
+                          type: string
+                        specHash:
+                          description: spec hash for an add-on configuration.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    group:
+                      default: ""
+                      description: group of the add-on configuration.
                       type: string
-                    displayName:
-                      description: displayName represents the name of add-on that will be displayed.
+                    resource:
+                      description: resource of the add-on configuration.
+                      minLength: 1
                       type: string
-                supportedConfigs:
-                  description: supportedConfigs is a list of configuration types supported by add-on. An empty list means the add-on does not require configurations. The default is an empty list
-                  type: array
-                  items:
-                    description: ConfigMeta represents a collection of metadata information for add-on configuration.
-                    type: object
-                    required:
-                      - resource
-                    properties:
-                      defaultConfig:
-                        description: defaultConfig represents the namespace and name of the default add-on configuration. In scenario where all add-ons have a same configuration.
-                        type: object
-                        required:
-                          - name
+                  required:
+                  - resource
+                  type: object
+                type: array
+              installProgressions:
+                description: installProgression is a list of current add-on configuration
+                  references per placement.
+                items:
+                  properties:
+                    conditions:
+                      description: conditions describe the state of the managed and
+                        monitored components for the operator.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
                         properties:
-                          name:
-                            description: name of the add-on configuration.
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
                             type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
                             minLength: 1
-                          namespace:
-                            description: namespace of the add-on configuration. If this field is not set, the configuration is in the cluster scope.
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             type: string
-                      group:
-                        description: group of the add-on configuration.
-                        type: string
-                      resource:
-                        description: resource of the add-on configuration.
-                        type: string
-                        minLength: 1
-            status:
-              description: status represents the current status of cluster management add-on.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    configReferences:
+                      description: configReferences is a list of current add-on configuration
+                        references.
+                      items:
+                        description: InstallConfigReference is a reference to the
+                          current add-on configuration. This resource is used to record
+                          the configuration resource for the current add-on.
+                        properties:
+                          desiredConfig:
+                            description: desiredConfig record the desired config name
+                              and spec hash.
+                            properties:
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              specHash:
+                                description: spec hash for an add-on configuration.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          group:
+                            default: ""
+                            description: group of the add-on configuration.
+                            type: string
+                          lastAppliedConfig:
+                            description: lastAppliedConfig records the config spec
+                              hash when the all the corresponding ManagedClusterAddOn
+                              are applied successfully.
+                            properties:
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              specHash:
+                                description: spec hash for an add-on configuration.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          lastKnownGoodConfig:
+                            description: lastKnownGoodConfig records the last known
+                              good config spec hash. For fresh install or rollout
+                              with type UpdateAll or RollingUpdate, the lastKnownGoodConfig
+                              is the same as lastAppliedConfig. For rollout with type
+                              RollingUpdateWithCanary, the lastKnownGoodConfig is
+                              the last successfully applied config spec hash of the
+                              canary placement.
+                            properties:
+                              name:
+                                description: name of the add-on configuration.
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: namespace of the add-on configuration.
+                                  If this field is not set, the configuration is in
+                                  the cluster scope.
+                                type: string
+                              specHash:
+                                description: spec hash for an add-on configuration.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          resource:
+                            description: resource of the add-on configuration.
+                            minLength: 1
+                            type: string
+                        required:
+                        - resource
+                        type: object
+                      type: array
+                    name:
+                      description: Name is the name of the placement
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the placement
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
# Description

The MCH unit tests use a "private" copy of various ACM CRDs, stashed in the `test/unit-tests/crds` directory of this repos.  Because they are a manually-updated copy, they can get old relative to evolution of the CRDs.  That usually isn't a problem (its just unit tests after all) until we find that Charts start to contain resource definitions for CRs that use new properties etc. not value in the copy of the CRD we have stashed for our unit testing.

In particular, we've seen issues related to use of the `installStrategy` property of the `ClusterManagementAddOn` CRD, including a problem brewing today for a recent bundle-update run.  This PR addresses that particular problem by updating the CMA CRD to match the copy currently in the `manifests/cluster-manager/hub` directory of the `stolostron/registration-operator` repo (which seems to be the source-of-truth for "clsuter manager" CRDs).

## Changes Made

- Update `cluster_management_addons.yaml` in `test/unit-tests/crds` as a copy of `0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml` from stolostron/registration-operator/manifests/clsuter-manager/hub` directory.