### PR TITLE
chore: Increase frequency of regnerate-bundles runs on main branch

### DIFF
--- a/.github/workflows/regenerate-bundles.yml
+++ b/.github/workflows/regenerate-bundles.yml
@@ -4,9 +4,9 @@ name: Regenerate Operator Bundles
 
 # Controls when the action will run. 
 on:
-  # Runs every day
+  # Runs every three hours
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 */3 * * *"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Our regenerate-bundles workflow for the main branch (i.e. the active dev branch) is configured to run only once a day.  That pace seems fine for branches that are shipped and in maintenance/support as bundle changes happen very infrequently (hopefully not at all) in the Z-Stream.  But this pace seems way to  slow for the in-dev branch, especially as we deal with end-of-sprint deadlines where changes show up.

This PR changes the main-branch frequency to every 3 hours.  If that proves too expensive re action-run quotas, we can consider backing off.