### PR TITLE
Sync the GRC CRDs

### DIFF
--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: placementbindings.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io
@@ -24,9 +22,11 @@ spec:
         description: PlacementBinding is the Schema for the placementbindings API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           bindingOverrides:
             description: BindingOverrides defines the overrides to the Subjects
@@ -40,9 +40,12 @@ spec:
                 type: string
             type: object
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -113,9 +116,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policies.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policies.yaml
@@ -4,8 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: policies.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io
@@ -34,14 +33,19 @@ spec:
         description: Policy is the Schema for the policies API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -49,18 +53,18 @@ spec:
             description: PolicySpec defines the desired state of Policy
             properties:
               copyPolicyMetadata:
-                description: If set to true (default), all the policy's labels and
-                  annotations will be copied to the replicated policy. If set to false,
-                  only the policy framework specific policy labels and annotations
-                  will be copied to the replicated policy.
+                description: |-
+                  If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
+                  If set to false, only the policy framework specific policy labels and annotations will be copied to the
+                  replicated policy.
                 type: boolean
               dependencies:
                 description: PolicyDependencies that apply to each template in this
                   Policy
                 items:
-                  description: Each PolicyDependency defines an object reference which
-                    must be in a certain compliance state before the policy should
-                    be created.
+                  description: |-
+                    Each PolicyDependency defines an object reference which must be in a certain compliance
+                    state before the policy should be created.
                   oneOf:
                   - properties:
                       kind:
@@ -76,10 +80,11 @@ spec:
                           pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                   properties:
                     apiVersion:
-                      description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an object.
+                        Servers should convert recognized schemas to the latest internal value, and
+                        may reject unrecognized values.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                       type: string
                     compliance:
                       description: The ComplianceState (at path .status.compliant)
@@ -90,10 +95,12 @@ spec:
                       - NonCompliant
                       type: string
                     kind:
-                      description: 'Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind is a string value representing the REST resource this object represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
                       description: The name of the object to be checked
@@ -120,9 +127,9 @@ spec:
                       description: Additional PolicyDependencies that only apply to
                         this template
                       items:
-                        description: Each PolicyDependency defines an object reference
-                          which must be in a certain compliance state before the policy
-                          should be created.
+                        description: |-
+                          Each PolicyDependency defines an object reference which must be in a certain compliance
+                          state before the policy should be created.
                         oneOf:
                         - properties:
                             kind:
@@ -138,10 +145,11 @@ spec:
                                 pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                         properties:
                           apiVersion:
-                            description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                             type: string
                           compliance:
                             description: The ComplianceState (at path .status.compliant)
@@ -152,10 +160,12 @@ spec:
                             - NonCompliant
                             type: string
                           kind:
-                            description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
                             description: The name of the object to be checked
@@ -279,9 +289,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: policyautomations.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io
@@ -24,14 +22,19 @@ spec:
         description: PolicyAutomation is the Schema for the policyautomations API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -56,15 +59,16 @@ spec:
                     minLength: 1
                     type: string
                   policyViolationsLimit:
-                    description: The maximum number of violating cluster contexts
-                      that will be provided to the Ansible job as extra variables.
-                      When policyViolationsLimit is set to 0, it means no limit. The
-                      default value is 1000.
+                    description: |-
+                      The maximum number of violating cluster contexts that will be provided to the Ansible job as extra variables.
+                      When policyViolationsLimit is set to 0, it means no limit.
+                      The default value is 1000.
                     minimum: 0
                     type: integer
                   secret:
-                    description: TowerSecret is the name of the secret that contains
-                      the Ansible Automation Platform credential.
+                    description: |-
+                      TowerSecret is the name of the secret that contains the Ansible Automation Platform
+                      credential.
                     minLength: 1
                     type: string
                   type:
@@ -75,9 +79,10 @@ spec:
                 - secret
                 type: object
               delayAfterRunSeconds:
-                description: DelayAfterRunSeconds sets the minimum number of seconds
-                  before an automation can run again due to a new violation on the
-                  same managed cluster. This only applies to the EveryEvent Mode.  The
+                description: |-
+                  DelayAfterRunSeconds sets the minimum number of seconds before
+                  an automation can run again due to a new violation on the same
+                  managed cluster. This only applies to the EveryEvent Mode.  The
                   default value is 0.
                 minimum: 0
                 type: integer
@@ -94,8 +99,9 @@ spec:
                 - disabled
                 type: string
               policyRef:
-                description: PolicyRef is the name of the policy that this automation
-                  resource is bound to.
+                description: |-
+                  PolicyRef is the name of the policy that this automation resource
+                  is bound to.
                 type: string
               rescanAfter:
                 description: RescanAfter is reserved for future use.
@@ -132,9 +138,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policysets.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policysets.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: policysets.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io
@@ -31,20 +29,26 @@ spec:
         description: PolicySet is the Schema for the policysets API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: PolicySetSpec describes a group of policies that are related
-              and can be placed on the same managed clusters.
+            description: |-
+              PolicySetSpec describes a group of policies that are related and
+              can be placed on the same managed clusters.
             properties:
               description:
                 description: Description of this PolicySet.
@@ -86,9 +90,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
There will be skew between the hub and managed clusters since the managed cluster CRDs are being built with controller-gen v0.6.1, but it shouldn't cause issues since the differences are in the multiline `description` strings.

ref: https://issues.redhat.com/browse/ACM-9975

/cc @mprahl @JustinKuli @yiraeChristineKim @gparvin 