### PR TITLE
Fix policy template unknown API issue when ManagedServiceAccount is not enabled

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-auto-import.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-auto-import.yaml
@@ -55,16 +55,22 @@ spec:
           remediationAction: inform
           severity: medium
           object-templates-raw: |
-            {{ `{{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}` }}
-            {{ `{{- $ms := (lookup "authentication.open-cluster-management.io/v1alpha1" "ManagedServiceAccount" $ns.metadata.name "auto-import-account") }}` }} 
-              {{ `{{- if $ms }}` }}   
+            {{ `{{- range $mce := (lookup "multicluster.openshift.io/v1" "MultiClusterEngine" "" "").items }}` }}
+              {{ `{{- range $cmp := $mce.spec.overrides.components }}` }}
+                {{ `{{- if and (or (eq $cmp.name "managedserviceaccount-preview") (eq $cmp.name "managedserviceaccount")) (eq $cmp.enabled true) }}` }}
+                  {{ `{{- range $ns := (lookup "v1" "Namespace" "" "" "cluster.open-cluster-management.io/managedCluster, cluster.open-cluster-management.io/managedCluster notin (local-cluster)").items }}` }}
+                    {{ `{{- range $ms := (lookup "authentication.open-cluster-management.io/v1alpha1" "ManagedServiceAccount" $ns.metadata.name "").items }}` }} 
+                      {{ `{{- if or (eq $ms.metadata.name "auto-import-account") (eq $ms.metadata.name "auto-import-account-pair") }}` }}   
             - complianceType: musthave
               objectDefinition:
                 kind: Secret
                 apiVersion: v1
                 metadata:
-                  name: "auto-import-account"
+                  name: {{ `{{ $ms.metadata.name }}` }}
                   namespace: {{ `{{ $ns.metadata.name }}` }}
+                      {{ `{{- end }}` }}
+                    {{ `{{- end }}` }}
+                  {{ `{{- end }}` }}
+                {{ `{{- end }}` }}
               {{ `{{- end }}` }}
             {{ `{{- end }}` }}
-


### PR DESCRIPTION
# Description

When ManagedServiceAccount feature is not enabled on MultiClusterEngine, the policy template encounters error calling lookup: one or more API resources are not installed on the API server.

## Related Issue

https://issues.redhat.com/browse/ACM-10214

## Changes Made

Before looping through ManagedServiceAccount instances, get the MultiClusterEngine cluster scoped instance and check whether managedserviceaccount component is enabled

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
