### PR TITLE
GRC: Add missing permissions on the grc-policy-addon SA

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -42,6 +42,18 @@ rules:
   - update
 - apiGroups:
   - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - clustermanagementaddons/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
   resources:
   - managedclusteraddons
   verbs:


### PR DESCRIPTION
This will remove the log errors of:
controller failed to sync "governance-policy-framework", err: clustermanagementaddons.addon.open-cluster-management.io "governance-policy-framework" is forbidden: User "system:serviceaccount:open-cluster-management:grc-policy-addon-sa" cannot patch resource "clustermanagementaddons/status" in API group "addon.open-cluster-management.io" at the cluster scope