### PR TITLE
Controller runtime tool versioning fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
the controller runtime setup-envtest tool is not versioned the same way that controller-runtime itself is, and the contributors updated its @latest tag to require go1.22. The Makefile has been updated to grab a specific release branch instead to avoid this issue.

Here is a reference issue on the controller-runtime repo that suggests this workaround until they can version that tool separately: https://github.com/kubernetes-sigs/kubebuilder/issues/2480#issuecomment-1825529490