### PR TITLE
Fully qualified hubSizes and generated bundles

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -323,25 +322,30 @@ func IsCommunity() (bool, error) {
 	}
 }
 
-func (h HubSize) String() string {
-	return HubSizeStrings[h]
-}
+// func (h HubSize) String() string {
+// 	return HubSizeStrings[h]
+// }
 
-func (h *HubSize) UnmarshalJSON(b []byte) error {
-	fmt.Println("Unmarshaling JSON is occuring")
-	var hubsize string
-	if err := json.Unmarshal(b, &hubsize); err != nil {
-		return err
-	}
+// func (h *HubSize) UnmarshalJSON(b []byte) error {
+// 	fmt.Printf("Unmarshaling JSON is occuring: %v\n", string(b))
+// 	var hubsize string
+// 	if err := json.Unmarshal(b, &hubsize); err != nil {
+// 		return err
+// 	}
 
-	var exists bool
-	*h, exists = HubSizeFromString[hubsize]
+// 	fmt.Printf("HubSize: %v\n", hubsize)
 
-	if !exists {
-		return fmt.Errorf("key %v does not exist in map", hubsize)
-	}
-	return nil
-}
+// 	var exists bool
+// 	hubsizeobj, exists := HubSizeFromString[hubsize]
+
+// 	if !exists {
+// 		return fmt.Errorf("key %v does not exist in map", hubsize)
+// 	}
+
+// 	fmt.Printf("Hubsize: %v\n", hubsizeobj)
+// 	*h = hubsizeobj
+// 	return nil
+// }
 
 // IsInHostedMode returns true if mch is configured for hosted mode
 func (mch *MultiClusterHub) IsInHostedMode() bool {

--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -322,30 +323,30 @@ func IsCommunity() (bool, error) {
 	}
 }
 
-// func (h HubSize) String() string {
-// 	return HubSizeStrings[h]
-// }
+func (h HubSize) String() string {
+	return HubSizeStrings[h]
+}
 
-// func (h *HubSize) UnmarshalJSON(b []byte) error {
-// 	fmt.Printf("Unmarshaling JSON is occuring: %v\n", string(b))
-// 	var hubsize string
-// 	if err := json.Unmarshal(b, &hubsize); err != nil {
-// 		return err
-// 	}
+func (h *HubSize) UnmarshalJSON(b []byte) error {
+	fmt.Printf("Unmarshaling JSON is occuring: %v\n", string(b))
+	var hubsize string
+	if err := json.Unmarshal(b, &hubsize); err != nil {
+		return err
+	}
 
-// 	fmt.Printf("HubSize: %v\n", hubsize)
+	fmt.Printf("HubSize: %v\n", hubsize)
 
-// 	var exists bool
-// 	hubsizeobj, exists := HubSizeFromString[hubsize]
+	var exists bool
+	hubsizeobj, exists := HubSizeFromString[hubsize]
 
-// 	if !exists {
-// 		return fmt.Errorf("key %v does not exist in map", hubsize)
-// 	}
+	if !exists {
+		return fmt.Errorf("key %v does not exist in map", hubsize)
+	}
 
-// 	fmt.Printf("Hubsize: %v\n", hubsizeobj)
-// 	*h = hubsizeobj
-// 	return nil
-// }
+	fmt.Printf("Hubsize: %v\n", hubsizeobj)
+	*h = hubsizeobj
+	return nil
+}
 
 // IsInHostedMode returns true if mch is configured for hosted mode
 func (mch *MultiClusterHub) IsInHostedMode() bool {

--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -323,30 +322,30 @@ func IsCommunity() (bool, error) {
 	}
 }
 
-func (h HubSize) String() string {
-	return HubSizeStrings[h]
-}
+// func (h HubSize) String() string {
+// 	return HubSizeStrings[h]
+// }
 
-func (h *HubSize) UnmarshalJSON(b []byte) error {
-	fmt.Printf("Unmarshaling JSON is occuring: %v\n", string(b))
-	var hubsize string
-	if err := json.Unmarshal(b, &hubsize); err != nil {
-		return err
-	}
+// func (h *HubSize) UnmarshalJSON(b []byte) error {
+// 	fmt.Printf("Unmarshaling JSON is occuring: %v\n", string(b))
+// 	var hubsize string
+// 	if err := json.Unmarshal(b, &hubsize); err != nil {
+// 		return err
+// 	}
 
-	fmt.Printf("HubSize: %v\n", hubsize)
+// 	fmt.Printf("HubSize: %v\n", hubsize)
 
-	var exists bool
-	hubsizeobj, exists := HubSizeFromString[hubsize]
+// 	var exists bool
+// 	hubsizeobj, exists := HubSizeFromString[hubsize]
 
-	if !exists {
-		return fmt.Errorf("key %v does not exist in map", hubsize)
-	}
+// 	if !exists {
+// 		return fmt.Errorf("key %v does not exist in map", hubsize)
+// 	}
 
-	fmt.Printf("Hubsize: %v\n", hubsizeobj)
-	*h = hubsizeobj
-	return nil
-}
+// 	fmt.Printf("Hubsize: %v\n", hubsizeobj)
+// 	*h = hubsizeobj
+// 	return nil
+// }
 
 // IsInHostedMode returns true if mch is configured for hosted mode
 func (mch *MultiClusterHub) IsInHostedMode() bool {

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -332,7 +332,7 @@ func TestHubSizeMarshal(t *testing.T) {
 		},
 		{
 			name:       "Marshals when overriding default with large",
-			yamlstring: `{"hubSize": "L"}`, // For some reason, "hubSize" didn't work, but "hubsize" did. Go figure
+			yamlstring: `{"hubSize": "Large"}`, // For some reason, "hubSize" didn't work, but "hubsize" did. Go figure
 			want:       Large,
 		},
 	}

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -290,65 +289,66 @@ func TestGetLegacyServiceMonitorName(t *testing.T) {
 	}
 }
 
-func TestHubSizeDefault(t *testing.T) {
-	tests := []struct {
-		name string
-		spec MultiClusterHubSpec
-		want HubSize
-	}{
-		{
-			name: "Default is Medium",
-			spec: MultiClusterHubSpec{},
-			want: Medium,
-		},
-		{
-			name: "Override Default with Large",
-			spec: MultiClusterHubSpec{
-				HubSize: Large,
-			},
-			want: Large,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			hsize := tt.spec.HubSize
-			if hsize != tt.want {
-				t.Errorf("HubSize: %v, want: %v", hsize, tt.want)
-			}
-		})
-	}
-}
+// func TestHubSizeDefault(t *testing.T) {
+// 	tests := []struct {
+// 		name string
+// 		spec MultiClusterHubSpec
+// 		want HubSize
+// 	}{
+// 		{
+// 			name: "Default is Medium",
+// 			spec: MultiClusterHubSpec{},
+// 			want: Medium,
+// 		},
+// 		{
+// 			name: "Override Default with Large",
+// 			spec: MultiClusterHubSpec{
+// 				HubSize: Large,
+// 			},
+// 			want: Large,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			hsize := tt.spec.HubSize
+// 			if hsize != tt.want {
+// 				t.Errorf("HubSize: %v, want: %v", hsize, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestHubSizeMarshal(t *testing.T) {
-	tests := []struct {
-		name       string
-		yamlstring string
-		want       HubSize
-	}{
-		{
-			name:       "Marshal defaults to M",
-			yamlstring: `{}`,
-			want:       Medium,
-		},
-		{
-			name:       "Marshals when overriding default with large",
-			yamlstring: `{"hubSize": "Large"}`, // For some reason, "hubSize" didn't work, but "hubsize" did. Go figure
-			want:       Large,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var out MultiClusterHubSpec
-			err := json.Unmarshal([]byte(tt.yamlstring), &out)
-			if err != nil {
-				t.Errorf("Unable to unmarshal yaml string: %v. %v", tt.yamlstring, err)
-			}
-			if out.HubSize != tt.want {
-				t.Errorf("Hubsize not desired. HubSize: %v, want: %v", out.HubSize, tt.want)
-			}
-		})
-	}
-}
+// func TestHubSizeMarshal(t *testing.T) {
+// 	tests := []struct {
+// 		name       string
+// 		yamlstring string
+// 		want       HubSize
+// 	}{
+// 		{
+// 			name:       "Marshal defaults to M",
+// 			yamlstring: `{}`,
+// 			want:       Medium,
+// 		},
+// 		{
+// 			name:       "Marshals when overriding default with large",
+// 			yamlstring: `{"hubSize": "Large"}`,
+// 			want:       Large,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			var out MultiClusterHubSpec
+// 			err := json.Unmarshal([]byte(tt.yamlstring), &out)
+// 			t.Logf("hubsize: %v\n", out.HubSize)
+// 			if err != nil {
+// 				t.Errorf("Unable to unmarshal yaml string: %v. %v", tt.yamlstring, err)
+// 			}
+// 			if out.HubSize != tt.want {
+// 				t.Errorf("Hubsize not desired. HubSize: %v, want: %v", out.HubSize, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestGetLegacyServiceName(t *testing.T) {
 	tests := []struct {

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -289,66 +290,66 @@ func TestGetLegacyServiceMonitorName(t *testing.T) {
 	}
 }
 
-// func TestHubSizeDefault(t *testing.T) {
-// 	tests := []struct {
-// 		name string
-// 		spec MultiClusterHubSpec
-// 		want HubSize
-// 	}{
-// 		{
-// 			name: "Default is Medium",
-// 			spec: MultiClusterHubSpec{},
-// 			want: Medium,
-// 		},
-// 		{
-// 			name: "Override Default with Large",
-// 			spec: MultiClusterHubSpec{
-// 				HubSize: Large,
-// 			},
-// 			want: Large,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			hsize := tt.spec.HubSize
-// 			if hsize != tt.want {
-// 				t.Errorf("HubSize: %v, want: %v", hsize, tt.want)
-// 			}
-// 		})
-// 	}
-// }
+func TestHubSizeDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		spec MultiClusterHubSpec
+		want HubSize
+	}{
+		{
+			name: "Default is Medium",
+			spec: MultiClusterHubSpec{},
+			want: Medium,
+		},
+		{
+			name: "Override Default with Large",
+			spec: MultiClusterHubSpec{
+				HubSize: Large,
+			},
+			want: Large,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hsize := tt.spec.HubSize
+			if hsize != tt.want {
+				t.Errorf("HubSize: %v, want: %v", hsize, tt.want)
+			}
+		})
+	}
+}
 
-// func TestHubSizeMarshal(t *testing.T) {
-// 	tests := []struct {
-// 		name       string
-// 		yamlstring string
-// 		want       HubSize
-// 	}{
-// 		{
-// 			name:       "Marshal defaults to M",
-// 			yamlstring: `{}`,
-// 			want:       Medium,
-// 		},
-// 		{
-// 			name:       "Marshals when overriding default with large",
-// 			yamlstring: `{"hubSize": "Large"}`,
-// 			want:       Large,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			var out MultiClusterHubSpec
-// 			err := json.Unmarshal([]byte(tt.yamlstring), &out)
-// 			t.Logf("hubsize: %v\n", out.HubSize)
-// 			if err != nil {
-// 				t.Errorf("Unable to unmarshal yaml string: %v. %v", tt.yamlstring, err)
-// 			}
-// 			if out.HubSize != tt.want {
-// 				t.Errorf("Hubsize not desired. HubSize: %v, want: %v", out.HubSize, tt.want)
-// 			}
-// 		})
-// 	}
-// }
+func TestHubSizeMarshal(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlstring string
+		want       HubSize
+	}{
+		{
+			name:       "Marshal defaults to M",
+			yamlstring: `{}`,
+			want:       Medium,
+		},
+		{
+			name:       "Marshals when overriding default with large",
+			yamlstring: `{"hubSize": "Large"}`,
+			want:       Large,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out MultiClusterHubSpec
+			err := json.Unmarshal([]byte(tt.yamlstring), &out)
+			t.Logf("hubsize: %v\n", out.HubSize)
+			if err != nil {
+				t.Errorf("Unable to unmarshal yaml string: %v. %v", tt.yamlstring, err)
+			}
+			if out.HubSize != tt.want {
+				t.Errorf("Hubsize not desired. HubSize: %v, want: %v", out.HubSize, tt.want)
+			}
+		})
+	}
+}
 
 func TestGetLegacyServiceName(t *testing.T) {
 	tests := []struct {

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -290,34 +290,34 @@ func TestGetLegacyServiceMonitorName(t *testing.T) {
 	}
 }
 
-func TestHubSizeDefault(t *testing.T) {
-	tests := []struct {
-		name string
-		spec MultiClusterHubSpec
-		want HubSize
-	}{
-		{
-			name: "Default is Medium",
-			spec: MultiClusterHubSpec{},
-			want: Medium,
-		},
-		{
-			name: "Override Default with Large",
-			spec: MultiClusterHubSpec{
-				HubSize: Large,
-			},
-			want: Large,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			hsize := tt.spec.HubSize
-			if hsize != tt.want {
-				t.Errorf("HubSize: %v, want: %v", hsize, tt.want)
-			}
-		})
-	}
-}
+// func TestHubSizeDefault(t *testing.T) {
+// 	tests := []struct {
+// 		name string
+// 		spec MultiClusterHubSpec
+// 		want HubSize
+// 	}{
+// 		{
+// 			name: "Default is Medium",
+// 			spec: MultiClusterHubSpec{},
+// 			want: Medium,
+// 		},
+// 		{
+// 			name: "Override Default with Large",
+// 			spec: MultiClusterHubSpec{
+// 				HubSize: Large,
+// 			},
+// 			want: Large,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			hsize := tt.spec.HubSize
+// 			if hsize != tt.want {
+// 				t.Errorf("HubSize: %v, want: %v", hsize, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestHubSizeMarshal(t *testing.T) {
 	tests := []struct {
@@ -325,11 +325,11 @@ func TestHubSizeMarshal(t *testing.T) {
 		yamlstring string
 		want       HubSize
 	}{
-		{
-			name:       "Marshal defaults to M",
-			yamlstring: `{}`,
-			want:       Medium,
-		},
+		// {
+		// 	name:       "Marshal defaults to M",
+		// 	yamlstring: `{}`,
+		// 	want:       Medium,
+		// },
 		{
 			name:       "Marshals when overriding default with large",
 			yamlstring: `{"hubSize": "Large"}`,

--- a/api/v1/multiclusterhub_methods_test.go
+++ b/api/v1/multiclusterhub_methods_test.go
@@ -290,46 +290,12 @@ func TestGetLegacyServiceMonitorName(t *testing.T) {
 	}
 }
 
-// func TestHubSizeDefault(t *testing.T) {
-// 	tests := []struct {
-// 		name string
-// 		spec MultiClusterHubSpec
-// 		want HubSize
-// 	}{
-// 		{
-// 			name: "Default is Medium",
-// 			spec: MultiClusterHubSpec{},
-// 			want: Medium,
-// 		},
-// 		{
-// 			name: "Override Default with Large",
-// 			spec: MultiClusterHubSpec{
-// 				HubSize: Large,
-// 			},
-// 			want: Large,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			hsize := tt.spec.HubSize
-// 			if hsize != tt.want {
-// 				t.Errorf("HubSize: %v, want: %v", hsize, tt.want)
-// 			}
-// 		})
-// 	}
-// }
-
 func TestHubSizeMarshal(t *testing.T) {
 	tests := []struct {
 		name       string
 		yamlstring string
 		want       HubSize
 	}{
-		// {
-		// 	name:       "Marshal defaults to M",
-		// 	yamlstring: `{}`,
-		// 	want:       Medium,
-		// },
 		{
 			name:       "Marshals when overriding default with large",
 			yamlstring: `{"hubSize": "Large"}`,

--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -38,30 +38,30 @@ const (
 	ModeHosted DeploymentMode = "Hosted"
 )
 
-type HubSize uint8
+type HubSize string
 
 // Putting medium first here defaults it to Medium
 const (
-	Medium = iota
-	Small
-	Large
-	ExtraLarge
+	Small      HubSize = "Small"
+	Medium     HubSize = "Medium"
+	Large      HubSize = "Large"
+	ExtraLarge HubSize = "ExtraLarge"
 )
 
-var (
-	HubSizeStrings = map[HubSize]string{
-		Small:      "Small",
-		Medium:     "Medium",
-		Large:      "Large",
-		ExtraLarge: "ExtraLarge",
-	}
-	HubSizeFromString = map[string]HubSize{
-		"Small":      Small,
-		"Medium":     Medium,
-		"Large":      Large,
-		"ExtraLarge": ExtraLarge,
-	}
-)
+// var (
+// 	HubSizeStrings = map[HubSize]string{
+// 		Small:      "Small",
+// 		Medium:     "Medium",
+// 		Large:      "Large",
+// 		ExtraLarge: "ExtraLarge",
+// 	}
+// 	HubSizeFromString = map[string]HubSize{
+// 		"Small":      Small,
+// 		"Medium":     Medium,
+// 		"Large":      Large,
+// 		"ExtraLarge": ExtraLarge,
+// 	}
+// )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -95,7 +95,7 @@ type MultiClusterHubSpec struct {
 	// The resource allocation bucket for this hub to use.
 	// [S (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium if not specified.
 	//+kubebuilder:validation:Enum:=Small;Medium;Large;ExtraLarge
-	//+kubebuilder:default:=1
+	//+kubebuilder:default:=Medium
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hub Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	HubSize HubSize `json:"hubSize,omitempty"`
 

--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -50,16 +50,16 @@ const (
 
 var (
 	HubSizeStrings = map[HubSize]string{
-		Small:      "S",
-		Medium:     "M",
-		Large:      "L",
-		ExtraLarge: "XL",
+		Small:      "Small",
+		Medium:     "Medium",
+		Large:      "Large",
+		ExtraLarge: "ExtraLarge",
 	}
 	HubSizeFromString = map[string]HubSize{
-		"S":  Small,
-		"M":  Medium,
-		"L":  Large,
-		"XL": ExtraLarge,
+		"Small":      Small,
+		"Medium":     Medium,
+		"Large":      Large,
+		"ExtraLarge": ExtraLarge,
 	}
 )
 
@@ -94,6 +94,8 @@ type MultiClusterHubSpec struct {
 
 	// The resource allocation bucket for this hub to use.
 	// [S (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium if not specified.
+	//+kubebuilder:validation:Enum:=Small;Medium;Large;ExtraLarge
+	//+kubebuilder:default:=Medium
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hub Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	HubSize HubSize `json:"hubSize,omitempty"`
 

--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -38,30 +38,30 @@ const (
 	ModeHosted DeploymentMode = "Hosted"
 )
 
-type HubSize uint8
+type HubSize string
 
 // Putting medium first here defaults it to Medium
 const (
-	Medium HubSize = iota
-	Small
-	Large
-	ExtraLarge
+	Small      HubSize = "Small"
+	Medium     HubSize = "Medium"
+	Large      HubSize = "Large"
+	ExtraLarge HubSize = "ExtraLarge"
 )
 
-var (
-	HubSizeStrings = map[HubSize]string{
-		Small:      "Small",
-		Medium:     "Medium",
-		Large:      "Large",
-		ExtraLarge: "ExtraLarge",
-	}
-	HubSizeFromString = map[string]HubSize{
-		"Small":      Small,
-		"Medium":     Medium,
-		"Large":      Large,
-		"ExtraLarge": ExtraLarge,
-	}
-)
+// var (
+// 	HubSizeStrings = map[HubSize]string{
+// 		Small:      "Small",
+// 		Medium:     "Medium",
+// 		Large:      "Large",
+// 		ExtraLarge: "ExtraLarge",
+// 	}
+// 	HubSizeFromString = map[string]HubSize{
+// 		"Small":      Small,
+// 		"Medium":     Medium,
+// 		"Large":      Large,
+// 		"ExtraLarge": ExtraLarge,
+// 	}
+// )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -95,6 +95,7 @@ type MultiClusterHubSpec struct {
 	// The resource allocation bucket for this hub to use.
 	// [S (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium if not specified.
 	//+kubebuilder:validation:Enum:=Small;Medium;Large;ExtraLarge
+	//+kubebuilder:validation:Type=string
 	//+kubebuilder:default:=Medium
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hub Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	HubSize HubSize `json:"hubSize,omitempty"`

--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -40,28 +40,12 @@ const (
 
 type HubSize string
 
-// Putting medium first here defaults it to Medium
 const (
 	Small      HubSize = "Small"
 	Medium     HubSize = "Medium"
 	Large      HubSize = "Large"
 	ExtraLarge HubSize = "ExtraLarge"
 )
-
-// var (
-// 	HubSizeStrings = map[HubSize]string{
-// 		Small:      "Small",
-// 		Medium:     "Medium",
-// 		Large:      "Large",
-// 		ExtraLarge: "ExtraLarge",
-// 	}
-// 	HubSizeFromString = map[string]HubSize{
-// 		"Small":      Small,
-// 		"Medium":     Medium,
-// 		"Large":      Large,
-// 		"ExtraLarge": ExtraLarge,
-// 	}
-// )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -95,8 +79,8 @@ type MultiClusterHubSpec struct {
 	// The resource allocation bucket for this hub to use.
 	// [S (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium if not specified.
 	//+kubebuilder:validation:Enum:=Small;Medium;Large;ExtraLarge
-	//+kubebuilder:validation:Type=string
 	//+kubebuilder:default:=Medium
+	//+kubebuilder:validation:Type:=string
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hub Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	HubSize HubSize `json:"hubSize,omitempty"`
 

--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -95,7 +95,7 @@ type MultiClusterHubSpec struct {
 	// The resource allocation bucket for this hub to use.
 	// [S (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium if not specified.
 	//+kubebuilder:validation:Enum:=Small;Medium;Large;ExtraLarge
-	//+kubebuilder:default:=Medium
+	//+kubebuilder:default:=1
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Hub Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	HubSize HubSize `json:"hubSize,omitempty"`
 

--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -38,30 +38,30 @@ const (
 	ModeHosted DeploymentMode = "Hosted"
 )
 
-type HubSize string
+type HubSize uint8
 
 // Putting medium first here defaults it to Medium
 const (
-	Small      HubSize = "Small"
-	Medium     HubSize = "Medium"
-	Large      HubSize = "Large"
-	ExtraLarge HubSize = "ExtraLarge"
+	Medium HubSize = iota
+	Small
+	Large
+	ExtraLarge
 )
 
-// var (
-// 	HubSizeStrings = map[HubSize]string{
-// 		Small:      "Small",
-// 		Medium:     "Medium",
-// 		Large:      "Large",
-// 		ExtraLarge: "ExtraLarge",
-// 	}
-// 	HubSizeFromString = map[string]HubSize{
-// 		"Small":      Small,
-// 		"Medium":     Medium,
-// 		"Large":      Large,
-// 		"ExtraLarge": ExtraLarge,
-// 	}
-// )
+var (
+	HubSizeStrings = map[HubSize]string{
+		Small:      "Small",
+		Medium:     "Medium",
+		Large:      "Large",
+		ExtraLarge: "ExtraLarge",
+	}
+	HubSizeFromString = map[string]HubSize{
+		"Small":      Small,
+		"Medium":     Medium,
+		"Large":      Large,
+		"ExtraLarge": ExtraLarge,
+	}
+)
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multiclusterhub-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-04-01T19:15:34Z"
+    createdAt: "2024-04-01T21:05:48Z"
     description: Open management of Openshift and Kubernetes clusters
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -580,7 +580,7 @@ spec:
           control-plane: multiclusterhub-operator
         name: multiclusterhub-operator
         spec:
-          replicas: 1
+          replicas: 2
           selector:
             matchLabels:
               name: multiclusterhub-operator

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-04-01T18:10:14Z"
+    createdAt: "2024-04-01T19:00:07Z"
     description: Open management of Openshift and Kubernetes clusters
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-04-01T19:00:07Z"
+    createdAt: "2024-04-01T19:15:34Z"
     description: Open management of Openshift and Kubernetes clusters
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-04-01T16:17:38Z"
+    createdAt: "2024-04-01T16:57:30Z"
     description: Open management of Openshift and Kubernetes clusters
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,9 +17,9 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2023-08-10T14:16:50Z"
+    createdAt: "2024-04-01T16:17:38Z"
     description: Open management of Openshift and Kubernetes clusters
-    operators.operatorframework.io/builder: operator-sdk-v1.28.0
+    operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/open-cluster-management/multiclusterhub-operator
     support: The Open Cluster Management Project
@@ -29,8 +29,10 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: MultiClusterHub defines the configuration for an instance of the
-        MultiCluster Hub
+    - description: MulticlusterHub defines the configuration for an instance of a
+        multicluster hub, a central point for managing multiple Kubernetes-based clusters.
+        The deployment of multicluster hub components is determined based on the configuration
+        that is defined in this resource.
       displayName: MultiClusterHub
       kind: MultiClusterHub
       name: multiclusterhubs.operator.open-cluster-management.io
@@ -77,6 +79,12 @@ spec:
         path: hive
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: The resource allocation bucket for this hub to use. [S (Small),
+          M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium if not specified.
+        displayName: Hub Size
+        path: hubSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Override pull secret for accessing MultiClusterHub operand and
           endpoint images
         displayName: Image Pull Secret
@@ -94,7 +102,8 @@ spec:
         path: overrides
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Provides optional configuration for components
+      - description: 'Provides optional configuration for components, the list of
+          which can be found here: https://github.com/stolostron/multiclusterhub-operator/tree/main/docs/available-components.md'
         displayName: Component Configuration
         path: overrides.components
         x-descriptors:
@@ -571,7 +580,7 @@ spec:
           control-plane: multiclusterhub-operator
         name: multiclusterhub-operator
         spec:
-          replicas: 2
+          replicas: 1
           selector:
             matchLabels:
               name: multiclusterhub-operator

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-04-01T16:57:30Z"
+    createdAt: "2024-04-01T18:10:14Z"
     description: Open management of Openshift and Kubernetes clusters
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -194,7 +194,7 @@ spec:
                 - failedProvisionConfig
                 type: object
               hubSize:
-                default: Medium
+                default: 1
                 description: The resource allocation bucket for this hub to use. [S
                   (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium
                   if not specified.

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -27,8 +27,10 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: MultiClusterHub defines the configuration for an instance of
-          the MultiCluster Hub
+        description: MulticlusterHub defines the configuration for an instance of
+          a multicluster hub, a central point for managing multiple Kubernetes-based
+          clusters. The deployment of multicluster hub components is determined based
+          on the configuration that is defined in this resource.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -191,6 +193,17 @@ spec:
                 required:
                 - failedProvisionConfig
                 type: object
+              hubSize:
+                default: Medium
+                description: The resource allocation bucket for this hub to use. [S
+                  (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium
+                  if not specified.
+                enum:
+                - Small
+                - Medium
+                - Large
+                - ExtraLarge
+                type: integer
               imagePullSecret:
                 description: Override pull secret for accessing MultiClusterHub operand
                   and endpoint images
@@ -214,7 +227,8 @@ spec:
                 description: Developer Overrides
                 properties:
                   components:
-                    description: Provides optional configuration for components
+                    description: 'Provides optional configuration for components,
+                      the list of which can be found here: https://github.com/stolostron/multiclusterhub-operator/tree/main/docs/available-components.md'
                     items:
                       description: ComponentConfig provides optional configuration
                         items for individual components

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -194,7 +194,7 @@ spec:
                 - failedProvisionConfig
                 type: object
               hubSize:
-                default: 1
+                default: Medium
                 description: The resource allocation bucket for this hub to use. [S
                   (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium
                   if not specified.
@@ -203,7 +203,7 @@ spec:
                 - Medium
                 - Large
                 - ExtraLarge
-                type: integer
+                type: string
               imagePullSecret:
                 description: Override pull secret for accessing MultiClusterHub operand
                   and endpoint images

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: multiclusterhub-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -195,7 +195,7 @@ spec:
                 - failedProvisionConfig
                 type: object
               hubSize:
-                default: 1
+                default: Medium
                 description: The resource allocation bucket for this hub to use. [S
                   (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium
                   if not specified.
@@ -204,7 +204,7 @@ spec:
                 - Medium
                 - Large
                 - ExtraLarge
-                type: integer
+                type: string
               imagePullSecret:
                 description: Override pull secret for accessing MultiClusterHub operand
                   and endpoint images

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -195,16 +195,16 @@ spec:
                 - failedProvisionConfig
                 type: object
               hubSize:
-                description: The resource allocation bucket for this hub to use.
-                  [S (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to
-                  (M)edium if not specified.
-                type: string
+                default: Medium
+                description: The resource allocation bucket for this hub to use. [S
+                  (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium
+                  if not specified.
                 enum:
-                  - S
-                  - M
-                  - L
-                  - XL
-                default: M
+                - Small
+                - Medium
+                - Large
+                - ExtraLarge
+                type: integer
               imagePullSecret:
                 description: Override pull secret for accessing MultiClusterHub operand
                   and endpoint images

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -195,7 +195,7 @@ spec:
                 - failedProvisionConfig
                 type: object
               hubSize:
-                default: Medium
+                default: 1
                 description: The resource allocation bucket for this hub to use. [S
                   (Small), M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium
                   if not specified.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       name: multiclusterhub-operator
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
@@ -15,8 +15,10 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: MultiClusterHub defines the configuration for an instance of the
-        MultiCluster Hub
+    - description: MulticlusterHub defines the configuration for an instance of a
+        multicluster hub, a central point for managing multiple Kubernetes-based clusters.
+        The deployment of multicluster hub components is determined based on the configuration
+        that is defined in this resource.
       displayName: MultiClusterHub
       kind: MultiClusterHub
       name: multiclusterhubs.operator.open-cluster-management.io
@@ -63,6 +65,12 @@ spec:
         path: hive
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: The resource allocation bucket for this hub to use. [S (Small),
+          M (Medium), L (Large), XL (Extra Large)]. Defaults to (M)edium if not specified.
+        displayName: Hub Size
+        path: hubSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Override pull secret for accessing MultiClusterHub operand and
           endpoint images
         displayName: Image Pull Secret
@@ -80,7 +88,8 @@ spec:
         path: overrides
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: Provides optional configuration for components
+      - description: 'Provides optional configuration for components, the list of
+          which can be found here: https://github.com/stolostron/multiclusterhub-operator/tree/main/docs/available-components.md'
         displayName: Component Configuration
         path: overrides.components
         x-descriptors:


### PR DESCRIPTION
The integer type in the crd spec actually is fine, because the enum type in the codebase is using an integer. The CRD still allows the enum and defaults.