### PR TITLE
update configmap with optional properties

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
@@ -133,7 +133,7 @@ spec:
                         RESTIC_REPOSITORY: {{ `{{ ( ( (cat $common_restic_repo "/" $pvc.metadata.namespace "-" $pvc.metadata.name ) | replace " " "" ) | base64enc ) }}` }}                      
                       type: Opaque
                       
-                  - complianceType: musthave
+                  - complianceType: mustonlyhave
                     objectDefinition:
                       kind: ReplicationSource
                       apiVersion: volsync.backube/v1alpha1
@@ -185,6 +185,48 @@ spec:
                           {{ `{{- end }}` }}
                           {{ `{{- if not (eq $retain_last "" ) }}` }}
                             last: '{{ `{{ $retain_last }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{ $customCA_secretName := trimAll " " (fromConfigMap $ns $volsync_map "customCA_secretName") }}` }}
+                          {{ `{{ $customCA_configMapName := trimAll " " (fromConfigMap $ns $volsync_map "customCA_configMapName") }}` }}
+                          {{ `{{ $customCA_key := trimAll " " (fromConfigMap $ns $volsync_map "customCA_key") }}` }}
+                          {{ `{{- /* if any of the customCA options are set, create the customCA section */ -}}` }}
+                          {{ `{{- if or (not (eq $customCA_secretName "" )) (not (eq $customCA_configMapName "" )) (not (eq $customCA_key "" )) }}` }}
+                          customCA:
+                          {{ `{{- end }}` }}
+                          {{ `{{- if not (eq $customCA_key "" ) }}` }}
+                            key: '{{ `{{ $customCA_key }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{- if not (eq $customCA_secretName "" ) }}` }}
+                            secretName: '{{ `{{ $customCA_secretName }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{- if not (eq $customCA_configMapName "" ) }}` }}
+                            configMapName: '{{ `{{ $customCA_configMapName }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{ $volumeSnapshotClassName := trimAll " " (fromConfigMap $ns $volsync_map "volumeSnapshotClassName") }}` }}
+                          {{ `{{- if not (eq $volumeSnapshotClassName "" ) }}` }}
+                          volumeSnapshotClassName: '{{ `{{ $volumeSnapshotClassName }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{ $storageClassName := trimAll " " (fromConfigMap $ns $volsync_map "storageClassName") }}` }}
+                          {{ `{{- if not (eq $storageClassName "" ) }}` }}
+                          storageClassName: '{{ `{{ $storageClassName }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{ $cacheStorageClassName := trimAll " " (fromConfigMap $ns $volsync_map "cacheStorageClassName") }}` }}
+                          {{ `{{- if not (eq $cacheStorageClassName "" ) }}` }}
+                          cacheStorageClassName: '{{ `{{ $cacheStorageClassName }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{ $capacity := trimAll " " (fromConfigMap $ns $volsync_map "capacity") }}` }}
+                          {{ `{{- if not (eq $capacity "" ) }}` }}
+                          capacity: '{{ `{{ $capacity }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{ $accessModes := trimAll " " (fromConfigMap $ns $volsync_map "accessModes") }}` }}
+                          {{ `{{- if not (eq $accessModes "" ) }}` }}
+                          accessModes: 
+                            - '{{ `{{ $accessModes }}` }}'
+                          {{ `{{- end }}` }}
+                          {{ `{{ $cacheAccessModes := trimAll " " (fromConfigMap $ns $volsync_map "cacheAccessModes") }}` }}
+                          {{ `{{- if not (eq $cacheAccessModes "" ) }}` }}
+                          cacheAccessModes: 
+                            - '{{ `{{ $cacheAccessModes }}` }}'
                           {{ `{{- end }}` }}
                         sourcePVC: {{ `{{ $pvc.metadata.name }}` }}
                         trigger:


### PR DESCRIPTION
# Description

Update ReplicationSource configmap properties to include all optional properties

## Related Issue

https://issues.redhat.com/browse/ACM-10837

## Changes Made

- Added these optional properties to the `hub-pvc-backup` ConfigMap

spec.restic.volumeSnapshotClassName
spec.restic.customCA
Missing but less important:

spec.restic.capacity
spec.restic.storageClassName
spec.restic.accessModes
spec.restic.cacheStorageClassName
spec.restic.cacheAccessModes

- updated the ReplicationSource template to use the `mustonlyhave` compliance type so that optional properties which are removed from the configMap are also removed from the ReplicationSource

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
