### PR TITLE
remove repository option and use capacity for PVC and RDest

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-destination.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-destination.yaml
@@ -92,11 +92,12 @@ spec:
                   {{ `{{- /* If the hub-pvc-backup-pvc-ns-pvcname ConfigMap exists, use it instead of the global  hub-pvc-backup ConfigMap  */ -}}` }}
                   {{ `{{ $volsync_map = $pvc_config_name }}` }}
                 {{ `{{- end }}` }}
-                {{ `{{- $secret_name := fromConfigMap $ns $volsync_map "repository" }}` }}
+                {{ `{{- /* restic_secret_suffix is the suffix used for the secret when copied over to the PVC ns  */ -}}` }}
+                {{ `{{- $restic_secret_suffix := "restic-secret" }}` }}
 
                 {{ `{{ if eq ( lookup "v1" "ConfigMap" $pvc_namespace  $pvc_config_info_name ).metadata.name  $pvc_config_info_name }}` }}
 
-                {{ `{{- $secretName := ( (cat $pvc_name "-"  (fromConfigMap $ns $volsync_map "repository") ) | replace " " "" ) }}` }}
+                {{ `{{- $secretName := ( (cat $pvc_name "-"  $restic_secret_suffix ) | replace " " "" ) }}` }}
                 {{ `{{- /* truncate from the front, the Dest name, if the string is longer than 50 chars ; a job batch starting with volsync-dst- is generated from this name and it must be less than 63 chars */ -}}` }}
                 {{ `{{- $rd_name :=  trunc -50 (cat $pvc_name $restore_timestamp_trim | replace " " "") }}` }}
 
@@ -161,9 +162,11 @@ spec:
                         {{ `{{- if not (eq $storageClassName "" ) }}` }}
                         storageClassName: {{ `{{ $storageClassName }}` }}
                         {{ `{{- end }}` }}
+                        {{ `{{- if not (eq $capacity "" ) }}` }}
                         resources:
                           requests:
-                            storage: '{{ `{{ fromConfigMap $pvc_namespace $pvc_config_info_name "resources.requests.storage" }}` }}'
+                            storage: '{{ `{{ $capacity }}` }}'
+                        {{ `{{- end }}` }}                        
                         volumeMode: '{{ `{{ fromConfigMap $pvc_namespace $pvc_config_info_name "volumeMode" }}` }}'    
                         {{ `{{ $accessModes := trimAll " " (fromConfigMap $pvc_namespace $pvc_config_info_name "resources.accessModes") }}` }}                  
                         {{ `{{- if not (eq $accessModes "" ) }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-destination.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-destination.yaml
@@ -93,7 +93,7 @@ spec:
                   {{ `{{ $volsync_map = $pvc_config_name }}` }}
                 {{ `{{- end }}` }}
                 {{ `{{- /* restic_secret_suffix is the suffix used for the secret when copied over to the PVC ns  */ -}}` }}
-                {{ `{{- $restic_secret_suffix := "restic-secret" }}` }}
+                {{ `{{- $restic_secret_suffix := "acm-pvc-restic" }}` }}
 
                 {{ `{{ if eq ( lookup "v1" "ConfigMap" $pvc_namespace  $pvc_config_info_name ).metadata.name  $pvc_config_info_name }}` }}
 

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
@@ -46,6 +46,8 @@ spec:
             {{ `{{- $pv_claim_cond := gt (len ( lookup "v1" "PersistentVolumeClaim" "" "" $volsync_label).items ) 0 }}` }}
             {{ `{{- $volsync_backup_cond := gt (len ( lookup $velero_api $kind_schedule $ns "" $schedule_label).items ) 0  }}` }}
             {{ `{{- $volsync_pvcs := "hub-pvc-backup-pvcs" }}` }}
+            {{ `{{- /* restic_secret_suffix is the suffix used for the secret when copied over to the PVC ns  */ -}}` }}
+            {{ `{{- $restic_secret_suffix := "restic-secret" }}` }}
 
             {{ `{{- /* Create the volsync ReplicationSource and secret - if BackupSchedule exists ; delete ReplicationSource otherwise */ -}}` }}
             {{ `{{ if $volsync_backup_cond }}` }}
@@ -116,7 +118,7 @@ spec:
 
                   {{ `{{- $volsync_pvcs_str = ( (cat $volsync_pvcs_str "##" $pvc.metadata.namespace "#" $pvc.metadata.name ) | replace " " "" ) }}` }}
                   {{ `{{- $common_restic_repo := ( lookup "v1" "Secret" $ns $volsync_secret ).data.RESTIC_REPOSITORY | base64dec }}` }}
-                  {{ `{{- $secretName := ( (cat $pvc.metadata.name "-"  (fromConfigMap $ns $volsync_map "repository") ) | replace " " "" ) }}` }}                 
+                  {{ `{{- $secretName := ( (cat $pvc.metadata.name "-"  $restic_secret_suffix ) | replace " " "" ) }}` }}                 
                   - complianceType: musthave
                     objectDefinition:
                       apiVersion: v1

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
@@ -47,7 +47,7 @@ spec:
             {{ `{{- $volsync_backup_cond := gt (len ( lookup $velero_api $kind_schedule $ns "" $schedule_label).items ) 0  }}` }}
             {{ `{{- $volsync_pvcs := "hub-pvc-backup-pvcs" }}` }}
             {{ `{{- /* restic_secret_suffix is the suffix used for the secret when copied over to the PVC ns  */ -}}` }}
-            {{ `{{- $restic_secret_suffix := "restic-secret" }}` }}
+            {{ `{{- $restic_secret_suffix := "acm-pvc-restic" }}` }}
 
             {{ `{{- /* Create the volsync ReplicationSource and secret - if BackupSchedule exists ; delete ReplicationSource otherwise */ -}}` }}
             {{ `{{ if $volsync_backup_cond }}` }}


### PR DESCRIPTION
# Description
remove repository option and use capacity for PVC and RDest

## Related Issue

https://issues.redhat.com/browse/ACM-10763

## Changes Made

- Removed the repository option from the hub-pvc-backup ConfigMap. This option was used to allow the user setting the name of the restic secret when copied over to the PVC ns ( backup or restore scenario ). The name of this secret is now defaulted to pvc_name-acm-pvc-restic.
- Used capacity for both PVC and RDest on restore. This is a property defined by the user with the optional hub-pvc-restore ConfigMap. If defined, it will overwrite the PVC resources.requests.storage property set on the original PVC and stored by the hub-pvc-backup-pvc_name / pvc_ns ConfigMap

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
