### PR TITLE
support restore from a different location than the backup

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-destination.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-destination.yaml
@@ -41,7 +41,8 @@ spec:
             {{ `{{- $schedule_label := "cluster.open-cluster-management.io/backup-schedule-type, cluster.open-cluster-management.io/backup-schedule-type in (resources)"}}` }}
             {{ `{{- $kind_restore := "Restore" }}` }}
             {{ `{{- $ns := "open-cluster-management-backup" }}` }}   
-            {{ `{{- $volsync_secret := "acm-hub-pvc-backup-restic-secret" }}` }} 
+            {{ `{{- $volsync_secret := "acm-hub-pvc-backup-restic-secret" }}` }}
+            {{ `{{- $volsync_restore_secret := "acm-hub-pvc-restore-restic-secret" }}` }} 
             {{ `{{- $volsync_map := "hub-pvc-backup" }}` }}
 
             {{ `{{- $volsync_label := "cluster.open-cluster-management.io/backup-hub-pvc" }}` }}
@@ -51,7 +52,7 @@ spec:
             {{ `{{- $backup_name_prefix :=  "acm-credentials-schedule-" }}` }}
             {{ `{{- $volsync_pvcs := "hub-pvc-backup-pvcs" }}` }}
 
-            {{ `{{- /* Create the volsync ReplicationDestination and secret - if Restore exists, PVC is created by a Restore and no Backup is running */ -}}` }}
+            {{ `{{- /* Create the volsync ReplicationDestination and secret - only if Restore exists, PVC is created by a Restore and no Backup is running */ -}}` }}
             {{ `{{- /* Use the hub-pvc-backup-pvcs-pvcns-pvcname config instead of the default hub-pvc-backup-pvcs map, if such map exists under the $ns */ -}}` }}
 
             {{ `{{- /* hub-pvc-backup-pvcs map should exist and have a backup-name label */ -}}` }}
@@ -64,6 +65,12 @@ spec:
             {{ `{{- end }}` }}
               
             {{ `{{ if and ($backup_name) ( not $volsync_backup_cond ) ($volsync_restore_cond) }}` }}
+
+              {{ `{{ if eq ( lookup "v1" "Secret" $ns  $volsync_restore_secret ).metadata.name  $volsync_restore_secret }}` }}
+                {{ `{{- /* Optionally, a volsync_restore_secret is created by the user on the restore hub before the restore operation  */ -}}` }}
+                {{ `{{- /* If volsync_restore_secret is set, it is used instead of the volsync_secret secret, to get PVC snapshots  */ -}}` }}
+                {{ `{{- $volsync_secret =  $volsync_restore_secret }}` }}
+              {{ `{{- end }}` }}
 
               {{ `{{- $restore_name := (index $volsync_pvcs_map.metadata.labels "velero.io/restore-name") }}` }}
               {{ `{{- $restore_timestamp_trim := trimAll $backup_name_prefix $backup_name  }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-pvc-source.yaml
@@ -147,7 +147,7 @@ spec:
                           {{ `{{- if not (eq $cacheCapacity "" ) }}` }}
                           cacheCapacity: '{{ `{{ $cacheCapacity }}` }}'
                           {{ `{{- end }}` }}
-                          copyMethod: '{{ `{{ fromConfigMap $ns $volsync_map "copyMethod" }}` }}'
+                          copyMethod: Snapshot
                           {{ `{{ $pruneIntervalDays := trimAll " " (fromConfigMap $ns $volsync_map "pruneIntervalDays") }}` }}
                           {{ `{{- if not (eq $pruneIntervalDays "" ) }}` }}
                           pruneIntervalDays: '{{ `{{ $pruneIntervalDays | toInt }}` }}'


### PR DESCRIPTION
# Description

make restic secret configurable on restore

## Related Issue

https://issues.redhat.com/browse/ACM-11003

## Changes Made

- Update `backup-pvc-destination` to look for a `acm-hub-pvc-restore-restic-secret` Secret in the `open-cluster-management-backup`. If this secret exists, it will be used instead of the `acm-hub-pvc-backup-restic-secret` 
- Updated `backup-pvc-source` Policy to hardcode the ReplicationSource copyMethod to Snapshot

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
