### PR TITLE
policy to install oadp

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -92,7 +92,7 @@ spec:
                     resources: {}
                 {{- with .Values.hubconfig.nodeSelector }}
                     nodeSelector:
-                {{ toYaml . | indent 24 }}
+                {{ toYaml . | indent 22 }}
                 {{- end }}
                 {{- with .Values.hubconfig.tolerations }}
                     tolerations:

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -69,54 +69,54 @@ spec:
               {{` {{- /* Creates the OADP Operator namespace group  */ -}}` }}
               {{` {{- /* All operator resources will be installed under the open-cluster-management-backup namespace  */ -}}` }}
 
-              - complianceType: musthave
-                objectDefinition:
-                  apiVersion: operators.coreos.com/v1
-                  kind: OperatorGroup
-                  metadata:
-                    namespace: open-cluster-management-backup
-                    name: redhat-oadp-operator-group
-                  spec:
-                    targetNamespaces:
-                    - open-cluster-management-backup
-              - complianceType: mustonlyhave
-                objectDefinition:
-                  apiVersion: operators.coreos.com/v1alpha1
-                  kind: Subscription
-                  metadata:
-                    namespace: open-cluster-management-backup
-                    name: redhat-oadp-operator-subscription
-                  spec:
-                    channel: {{ .Values.global.channel }}
-                    config:
-                      resources: {}
-                  {{- with .Values.hubconfig.nodeSelector }}
-                      nodeSelector:
-                  {{ toYaml . | indent 24 }}
-                  {{- end }}
-                  {{- with .Values.hubconfig.tolerations }}
-                      tolerations:
-                      {{- range . }}
-                      - {{ if .Key }} key: {{ .Key }} {{- end }}
-                        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
-                        {{ if .Value }} value: {{ .Value }} {{- end }}
-                        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
-                        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
-                        {{- end }}
-                  {{- end }}
-                      {{- if .Values.hubconfig.proxyConfigs }}
-                      env:
-                      - name: HTTP_PROXY
-                        value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
-                      - name: HTTPS_PROXY
-                        value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
-                      - name: NO_PROXY
-                        value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  namespace: open-cluster-management-backup
+                  name: redhat-oadp-operator-group
+                spec:
+                  targetNamespaces:
+                  - open-cluster-management-backup
+            - complianceType: mustonlyhave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  namespace: open-cluster-management-backup
+                  name: redhat-oadp-operator-subscription
+                spec:
+                  channel: {{ .Values.global.channel }}
+                  config:
+                    resources: {}
+                {{- with .Values.hubconfig.nodeSelector }}
+                    nodeSelector:
+                {{ toYaml . | indent 24 }}
+                {{- end }}
+                {{- with .Values.hubconfig.tolerations }}
+                    tolerations:
+                    {{- range . }}
+                    - {{ if .Key }} key: {{ .Key }} {{- end }}
+                      {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+                      {{ if .Value }} value: {{ .Value }} {{- end }}
+                      {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+                      {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
                       {{- end }}
-                    installPlanApproval: {{ .Values.global.installPlanApproval}}
-                    name: {{ .Values.global.name }}
-                    source: {{ .Values.global.source }}
-                    sourceNamespace: {{ .Values.global.sourceNamespace }} 
-              {{` {{- end }}` }}             
+                {{- end }}
+                    {{- if .Values.hubconfig.proxyConfigs }}
+                    env:
+                    - name: HTTP_PROXY
+                      value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+                    - name: HTTPS_PROXY
+                      value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+                    - name: NO_PROXY
+                      value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+                    {{- end }}
+                  installPlanApproval: {{ .Values.global.installPlanApproval}}
+                  name: {{ .Values.global.name }}
+                  source: {{ .Values.global.source }}
+                  sourceNamespace: {{ .Values.global.sourceNamespace }} 
+            {{` {{- end }}` }}             
           remediationAction: enforce
           severity: high

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -92,7 +92,7 @@ spec:
                       resources: {}
                   {{- with .Values.hubconfig.nodeSelector }}
                       nodeSelector:
-                  {{ toYaml . | indent 6 }}
+                  {{ toYaml . | indent 24 }}
                   {{- end }}
                   {{- with .Values.hubconfig.tolerations }}
                       tolerations:

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -69,54 +69,54 @@ spec:
               {{` {{- /* Creates the OADP Operator namespace group  */ -}}` }}
               {{` {{- /* All operator resources will be installed under the open-cluster-management-backup namespace  */ -}}` }}
 
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: operators.coreos.com/v1
-                kind: OperatorGroup
-                metadata:
-                  namespace: open-cluster-management-backup
-                  name: redhat-oadp-operator-group
-                spec:
-                  targetNamespaces:
-                  - open-cluster-management-backup
-            - complianceType: mustonlyhave
-              objectDefinition:
-                apiVersion: operators.coreos.com/v1alpha1
-                kind: Subscription
-                metadata:
-                  namespace: open-cluster-management-backup
-                  name: redhat-oadp-operator-subscription
-                spec:
-                  channel: {{ .Values.global.channel }}
-                  config:
-                    resources: {}
-                {{- with .Values.hubconfig.nodeSelector }}
-                    nodeSelector:
-                {{ toYaml . | indent 22 }}
-                {{- end }}
-                {{- with .Values.hubconfig.tolerations }}
-                    tolerations:
-                    {{- range . }}
-                    - {{ if .Key }} key: {{ .Key }} {{- end }}
-                      {{ if .Operator }} operator: {{ .Operator }} {{- end }}
-                      {{ if .Value }} value: {{ .Value }} {{- end }}
-                      {{ if .Effect }} effect: {{ .Effect }} {{- end }}
-                      {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: operators.coreos.com/v1
+                  kind: OperatorGroup
+                  metadata:
+                    namespace: open-cluster-management-backup
+                    name: redhat-oadp-operator-group
+                  spec:
+                    targetNamespaces:
+                    - open-cluster-management-backup
+              - complianceType: mustonlyhave
+                objectDefinition:
+                  apiVersion: operators.coreos.com/v1alpha1
+                  kind: Subscription
+                  metadata:
+                    namespace: open-cluster-management-backup
+                    name: redhat-oadp-operator-subscription
+                  spec:
+                    channel: {{ .Values.global.channel }}
+                    config:
+                      resources: {}
+                  {{- with .Values.hubconfig.nodeSelector }}
+                      nodeSelector:
+                  {{ toYaml . | indent 24 }}
+                  {{- end }}
+                  {{- with .Values.hubconfig.tolerations }}
+                      tolerations:
+                      {{- range . }}
+                      - {{ if .Key }} key: {{ .Key }} {{- end }}
+                        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+                        {{ if .Value }} value: {{ .Value }} {{- end }}
+                        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+                        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+                        {{- end }}
+                  {{- end }}
+                      {{- if .Values.hubconfig.proxyConfigs }}
+                      env:
+                      - name: HTTP_PROXY
+                        value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+                      - name: HTTPS_PROXY
+                        value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+                      - name: NO_PROXY
+                        value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
                       {{- end }}
-                {{- end }}
-                    {{- if .Values.hubconfig.proxyConfigs }}
-                    env:
-                    - name: HTTP_PROXY
-                      value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
-                    - name: HTTPS_PROXY
-                      value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
-                    - name: NO_PROXY
-                      value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
-                    {{- end }}
-                  installPlanApproval: {{ .Values.global.installPlanApproval}}
-                  name: {{ .Values.global.name }}
-                  source: {{ .Values.global.source }}
-                  sourceNamespace: {{ .Values.global.sourceNamespace }} 
-            {{` {{- end }}` }}             
+                    installPlanApproval: {{ .Values.global.installPlanApproval}}
+                    name: {{ .Values.global.name }}
+                    source: {{ .Values.global.source }}
+                    sourceNamespace: {{ .Values.global.sourceNamespace }} 
+              {{` {{- end }}` }}             
           remediationAction: enforce
           severity: high

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -1,0 +1,123 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: backup-restore-oadp
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+    release: cluster-backup-chart
+    heritage: Helm
+    app.kubernetes.io/instance: cluster-backup-chart
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cluster-backup-chart
+    helm.sh/chart: cluster-backup-chart
+    velero.io/exclude-from-backup: "true"
+    component: policy
+  annotations:
+    policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
+    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/source: system
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: install-oadp
+        spec:
+          object-templates-raw: |
+
+            {{` {{- /* Check cluster platform  */ -}}` }}
+            {{` {{- $platformType := ""}}` }}
+            {{` {{- range $infra := (lookup "config.openshift.io/v1" "Infrastructure" "" "" "").items }}` }}
+              {{` {{ if eq $infra.metadata.name "cluster" }}` }}
+                {{` {{- $platformType = $infra.status.platform }}` }}
+              {{` {{- end }}` }}
+            {{` {{- end }}` }}
+
+            {{` {{- /* Get credentials mode value  */ -}}` }}
+            {{` {{- $credentialsMode := ""}}` }}
+            {{` {{- range $cloud_cred := (lookup "operator.openshift.io/v1" "CloudCredential" "" "" "").items }}` }}
+              {{` {{ if eq $cloud_cred.metadata.name "cluster" }}` }}
+                {{` {{- $credentialsMode = $cloud_cred.spec.credentialsMode }}` }}
+              {{` {{- end }}` }}
+            {{` {{- end }}` }}
+            
+            {{` {{- /* Check cluster serviceAccountIssuer value  */ -}}` }}
+            {{` {{- $serviceAccountIssuer := ""}}` }}
+            {{` {{- range $auth := (lookup "config.openshift.io/v1" "Authentication" "" "" "").items }}` }}
+              {{` {{ if eq $auth.metadata.name "cluster" }}` }}
+                {{` {{- $serviceAccountIssuer = $auth.spec.serviceAccountIssuer }}` }}
+              {{` {{- end }}` }}
+            {{` {{- end }}` }}
+
+            {{` {{- /* Check oadp-manual option set on on cluster  */ -}}` }}
+            {{` {{- $manualInstall := ""}}` }}
+            {{` {{- range $cclaim := (lookup "cluster.open-cluster-management.io/v1alpha1" "ClusterClaim" "" "" "").items }}` }}
+              {{` {{ if eq $cclaim.metadata.name "oadp-manual" }}` }}
+                {{` {{- $manualInstall = $cclaim.spec.value }}` }}
+              {{` {{- end }}` }}
+            {{` {{- end }}` }}           
+
+            {{` {{- $isSTSEnabledCluster := and (eq $credentialsMode "Manual")  (not (eq $serviceAccountIssuer "")) (eq (lower $platformType) "aws")}}` }}
+            {{` {{- $isManualInstall :=  eq (lower $manualInstall) "true" }}` }}
+
+            {{` {{ if not (or $isManualInstall  $isSTSEnabledCluster) }}` }}
+              {{` {{- /* This is not an STS enabled cluster and the user did not set the manual install label - can install OADP  */ -}}` }}
+              {{` {{- /* Creates the OADP Operator namespace group  */ -}}` }}
+              {{` {{- /* All operator resources will be installed under the open-cluster-management-backup namespace  */ -}}` }}
+
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: operators.coreos.com/v1
+                  kind: OperatorGroup
+                  metadata:
+                    namespace: open-cluster-management-backup
+                    name: redhat-oadp-operator-group
+                  spec:
+                    targetNamespaces:
+                    - open-cluster-management-backup
+              - complianceType: mustonlyhave
+                objectDefinition:
+                  apiVersion: operators.coreos.com/v1alpha1
+                  kind: Subscription
+                  metadata:
+                    namespace: open-cluster-management-backup
+                    name: redhat-oadp-operator-subscription
+                  spec:
+                    channel: {{ .Values.global.channel }}
+                    config:
+                      resources: {}
+                  {{- with .Values.hubconfig.nodeSelector }}
+                      nodeSelector:
+                  {{ toYaml . | indent 6 }}
+                  {{- end }}
+                  {{- with .Values.hubconfig.tolerations }}
+                      tolerations:
+                      {{- range . }}
+                      - {{ if .Key }} key: {{ .Key }} {{- end }}
+                        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+                        {{ if .Value }} value: {{ .Value }} {{- end }}
+                        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+                        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+                        {{- end }}
+                  {{- end }}
+                      {{- if .Values.hubconfig.proxyConfigs }}
+                      env:
+                      - name: HTTP_PROXY
+                        value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+                      - name: HTTPS_PROXY
+                        value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+                      - name: NO_PROXY
+                        value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+                      {{- end }}
+                    installPlanApproval: {{ .Values.global.installPlanApproval}}
+                    name: {{ .Values.global.name }}
+                    source: {{ .Values.global.source }}
+                    sourceNamespace: {{ .Values.global.sourceNamespace }} 
+              {{` {{- end }}` }}             
+          remediationAction: enforce
+          severity: high

--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -20,7 +20,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/source: system
 spec:
-  disabled: false
+  disabled: true
   policy-templates:
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -29,7 +29,6 @@ spec:
           name: install-oadp
         spec:
           object-templates-raw: |
-
             {{` {{- /* Check cluster platform  */ -}}` }}
             {{` {{- $platformType := ""}}` }}
             {{` {{- range $infra := (lookup "config.openshift.io/v1" "Infrastructure" "" "" "").items }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-policy-set.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-policy-set.yaml
@@ -14,3 +14,4 @@ spec:
     - backup-pvc-config
     - backup-pvc-source
     - backup-pvc-destination
+    - backup-restore-oadp

--- a/pkg/templates/charts/toggle/cluster-backup/templates/managed-hub-policy-set.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/managed-hub-policy-set.yaml
@@ -14,3 +14,4 @@ spec:
     - backup-pvc-config
     - backup-pvc-source
     - backup-pvc-destination
+    - backup-restore-oadp


### PR DESCRIPTION
# Description

Create a policy to wrap up the installation of the oadp operator

## Related Issue

https://issues.redhat.com/browse/ACM-10890

## Changes Made

Created a new Policy which can be used to install OADP.
The policy does not install  OADP if 
- this is an STS enabled cluster
- the user sets oadp-manual=true label on the local-cluster hub resource

In the screen cap below, the  oadp-manual=true label is set on the local-cluster hub resource so the policy doesn't try to create the operator

The policy is disabled for now and I am keeping the chart resources used to install the OADP operator; once I can test the policy being packaged with the chart I will enable it and replace the chart resources

## Screenshots (if applicable)
<img width="1403" alt="Screenshot 2024-04-16 at 4 09 53 PM" src="https://github.com/stolostron/multiclusterhub-operator/assets/43010150/679bb91c-1060-4a71-b880-f238b612e2a2">

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
