### PR TITLE
enable oadp install policy

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -20,7 +20,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/source: system
 spec:
-  disabled: true
+  disabled: false
   policy-templates:
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -97,11 +97,11 @@ spec:
                   {{- with .Values.hubconfig.tolerations }}
                       tolerations:
                       {{- range . }}
-                      - {{ if .Key }} key: {{ .Key }} {{- end }}
-                        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
-                        {{ if .Value }} value: {{ .Value }} {{- end }}
-                        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
-                        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+                      - {{ if .Key }}key: {{ .Key }} {{- end }}
+                        {{ if .Operator }}operator: {{ .Operator }} {{- end }}
+                        {{ if .Value }}value: {{ .Value }} {{- end }}
+                        {{ if .Effect }}effect: {{ .Effect }} {{- end }}
+                        {{ if .TolerationSeconds }}tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
                         {{- end }}
                   {{- end }}
                       {{- if .Values.hubconfig.proxyConfigs }}


### PR DESCRIPTION
# Description

Enable the policy used to install OADP

## Related Issue

https://issues.redhat.com/browse/ACM-11015

## Changes Made

- Updated oadp-policy and enable it

```
spec:
  disabled: false
```
- Fixed extra spaces on the tolerations section which makes the policy engine throw a wrapping error

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
