### PR TITLE
trigger oadp policy deletion when chart is uninstalled

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/backup-oadp-config.yaml
@@ -4,14 +4,6 @@ metadata:
   name: backup-restore-oadp
   namespace: open-cluster-management-backup
   labels:
-    app: cluster-backup-chart
-    chart: cluster-backup-chart
-    release: cluster-backup-chart
-    heritage: Helm
-    app.kubernetes.io/instance: cluster-backup-chart
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cluster-backup-chart
-    helm.sh/chart: cluster-backup-chart
     velero.io/exclude-from-backup: "true"
     component: policy
   annotations:
@@ -19,6 +11,9 @@ metadata:
     policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/source: system
+    "helm.sh/hook": pre-install, post-delete
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/resource-policy": delete
 spec:
   disabled: false
   policy-templates:


### PR DESCRIPTION
# Description

Trigger oadp policy deletion when chart is uninstalled. This should delete the OADP subscription resource so that a new version of OADP can be installed on upgrade

## Related Issue

https://issues.redhat.com/browse/ACM-11015

## Changes Made

Updated oadp-install policy and added 
```
    "helm.sh/hook": pre-install, post-delete
    "helm.sh/hook-weight": "-1"
    "helm.sh/resource-policy": delete
```

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
