### PR TITLE
[ACM-10819] Updated Makefiles to support podman configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,12 @@ docker-build: ## test ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
+podman-build: ## test ## Build podman image with the manager.
+	podman build --no-cache -t ${IMG} .
+
+podman-push: ## Push podman image with the manager.
+	podman push ${IMG}
+
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
@@ -175,6 +181,14 @@ bundle-build: ## Build the bundle image.
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
+.PHONY: podman-bundle-build
+podman-bundle-build: ## Build the bundle image.
+	podman build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+.PHONY: podman-bundle-push
+podman-bundle-push: ## Push the bundle image.
+	$(MAKE) podman-push IMG=$(BUNDLE_IMG)
+
 .PHONY: opm
 OPM = ./bin/opm
 opm: ## Download opm locally if necessary.
@@ -215,6 +229,11 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+# Push the catalog image.
+.PHONY: podman-catalog-push
+catalog-push: ## Push a catalog image.
+	$(MAKE) podman-push IMG=$(CATALOG_IMG)
 
 
 -include Makefile.dev

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -41,6 +41,9 @@ copy-charts: ## Regenerates the operator bundles
 # different from `in-cluster-install` (call no secrets, no observability-crd)
 mock-install: prereqs subscriptions docker-build docker-push deploy
 
+# different from `in-cluster-install` (call no secrets, no observability-crd)
+podman-mock-install: prereqs subscriptions podman-build podman-push deploy
+
 cr: 
 	oc apply -k config/samples
 
@@ -49,6 +52,8 @@ cr:
 full-catalog-install: manifests generate bundle bundle-build bundle-push catalog-build catalog-push prereqs subscriptions catalog
 
 full-dev-install: prereqs manifests generate update-manifest subscriptions docker-build docker-push deploy
+
+podman-full-dev-install: prereqs manifests generate update-manifest subscriptions podman-build podman-push deploy
 
 add-images: ## Retrieves latest manifest and injects image definitions directly into the deployment template
 	pip3 install -r ./hack/bundle-automation/requirements.txt

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -32,7 +32,7 @@ regenerate-operator-bundles: ## Regenerates the operator bundles
 
 regenerate-charts: ## Regenerates the charts 
 	pip install -r hack/bundle-automation/chart-requirements.txt
-	python ./hack/bundle-automation/generate-charts.py --destination pkg/templates/
+	python3 ./hack/bundle-automation/generate-charts.py --destination pkg/templates/
 
 copy-charts: ## Regenerates the operator bundles
 	pip install -r hack/bundle-automation/requirements.txt

--- a/test/function_tests/Makefile
+++ b/test/function_tests/Makefile
@@ -46,6 +46,46 @@ ft-downstream-update:
 		--volume ~/.kube/config:/opt/.kube/config \
 		$(REGISTRY)/$(IMG)-tests:$(VERSION)
 
+## Run the installer downstream functional tests
+podman-ft-downstream-install:
+	podman run --network host \
+		--env pullSecret=$(PULL_SECRET_NAME) \
+		--env source=$(SOURCE_NAME) \
+		--env channel=$(CHANNEL) \
+		--env sourceNamespace=$(SOURCE_NAMESPACE) \
+		--env name=$(SUBSCRIPTION_NAME) \
+		--env TEST_MODE="install" \
+		--env full_test_suite="false" \
+		--volume ~/.kube/config:/opt/.kube/config \
+		$(REGISTRY)/$(IMG)-tests:$(VERSION)
+
+## Run the uninstall functional tests
+podman-ft-downstream-uninstall:
+	podman run --network host \
+		--env pullSecret=$(PULL_SECRET_NAME) \
+		--env source=$(SOURCE_NAME) \
+		--env channel=$(CHANNEL) \
+		--env sourceNamespace=$(SOURCE_NAMESPACE) \
+		--env name=$(SUBSCRIPTION_NAME) \
+		--env TEST_MODE="uninstall" \
+		--env skipSubscription="true" \
+		--volume ~/.kube/config:/opt/.kube/config \
+		$(REGISTRY)/$(IMG)-tests:$(VERSION)
+
+## Run the uninstall functional tests
+podman-ft-downstream-update:
+	podman run --network host \
+		--env pullSecret=$(PULL_SECRET_NAME) \
+		--env source=$(SOURCE_NAME) \
+		--env channel=$(CHANNEL) \
+		--env sourceNamespace=$(SOURCE_NAMESPACE) \
+		--env name=$(SUBSCRIPTION_NAME) \
+		--env TEST_MODE="update" \
+		--env startVersion="2.1.0" \
+		--env updateVersion="2.7.0" \
+		--volume ~/.kube/config:/opt/.kube/config \
+		$(REGISTRY)/$(IMG)-tests:$(VERSION)
+
 ## Run the install functional tests directly
 ft-install: 
 	export skipSubscription="true";	ginkgo -tags functional -v --slow-spec-threshold=150s test/function_tests/multiclusterhub_install_test
@@ -70,6 +110,13 @@ test-image: deps
 	go mod vendor
 	@echo "Building $(REGISTRY)/multiclusterhub-operator-tests:$(VERSION)"
 	docker build . -f build/Dockerfile.test.prow -t $(REGISTRY)/multiclusterhub-operator-tests:$(VERSION)
+	rm -rf vendor
+
+## Build the MCH functional test image
+podman-test-image: deps
+	go mod vendor
+	@echo "Building $(REGISTRY)/multiclusterhub-operator-tests:$(VERSION)"
+	podman build . -f build/Dockerfile.test.prow -t $(REGISTRY)/multiclusterhub-operator-tests:$(VERSION)
 	rm -rf vendor
 
 # Pass downstream bundle image snapshots for beginning version and the desired version to upgrade to 


### PR DESCRIPTION
# Description

For Red Hat, there was an announcement made for us to use `podman` instead of `docker`; therefore, this PR will add the support for `podman` and keep the `docker` compatibility if it is still needed.

## Related Issue

https://issues.redhat.com/browse/ACM-10819

## Changes Made

Added supported `podman` configs in the Makefiles.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
