### PR TITLE
[ACM-10802] Updated MCH annotations naming convention

### DIFF
--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -22,33 +22,33 @@ var (
 		AnnotationIgnoreOCPVersion is an annotation used to indicate the operator should not check the OpenShift
 		Container Platform (OCP) version before proceeding when set.
 	*/
-	AnnotationIgnoreOCPVersion           = "operator.open-cluster-management.io/ignore-ocp-version"
+	AnnotationIgnoreOCPVersion           = "installer.open-cluster-management.io/ignore-ocp-version"
 	DeprecatedAnnotationIgnoreOCPVersion = "ignoreOCPVersion"
 
 	/*
 		AnnotationImageOverridesCM is an annotation used in multiclusterhub to specify a custom ConfigMap containing
 		image overrides.
 	*/
-	AnnotationImageOverridesCM           = "operator.open-cluster-management.io/image-overrides-configmap"
+	AnnotationImageOverridesCM           = "installer.open-cluster-management.io/image-overrides-configmap"
 	DeprecatedAnnotationImageOverridesCM = "mch-imageOverridesCM"
 
 	/*
 		AnnotationImageRepo is an annotation used in multiclusterhub to specify a custom image repository to use.
 	*/
-	AnnotationImageRepo           = "operator.open-cluster-management.io/image-repository"
+	AnnotationImageRepo           = "installer.open-cluster-management.io/image-repository"
 	DeprecatedAnnotationImageRepo = "mch-imageRepository"
 
 	/*
 		AnnotationKubeconfig is an annotation used to specify the secret name residing in target containing the
 		kubeconfig to access the remote cluster.
 	*/
-	AnnotationKubeconfig           = "operator.open-cluster-management.io/kubeconfig"
+	AnnotationKubeconfig           = "installer.open-cluster-management.io/kubeconfig"
 	DeprecatedAnnotationKubeconfig = "mch-kubeconfig"
 
 	/*
 		AnnotationMCHPause is an annotation used in multiclusterhub to identify if the multiclusterhub is paused or not.
 	*/
-	AnnotationMCHPause           = "operator.open-cluster-management.io/pause"
+	AnnotationMCHPause           = "installer.open-cluster-management.io/pause"
 	DeprecatedAnnotationMCHPause = "mch-pause"
 
 	/*
@@ -72,7 +72,7 @@ var (
 		AnnotationTemplateOverridesCM is an annotation used in multiclusterhub to specify a custom ConfigMap
 		containing resource template overrides.
 	*/
-	AnnotationTemplateOverridesCM = "operator.multicluster.openshift.io/template-override-cm"
+	AnnotationTemplateOverridesCM = "installer.open-cluster-management.io/template-override-configmap"
 )
 
 /*


### PR DESCRIPTION
# Description

Updated MCH annotations to use `installer.<annotation>` pattern, instead of `operator.<annotation>` pattern.

## Related Issue

https://issues.redhat.com/browse/ACM-10802

## Changes Made

Updated MCH annotations names.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
