### PR TITLE
[ACM-11398] Updated MCH operator to remove GRC CMA after MCE deployed

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -114,8 +114,8 @@ var MCHLegacyServices = map[string]string{
 
 // ClusterManagementAddOns is a map that associates certain component names with their corresponding add-ons.
 var ClusterManagementAddOns = map[string]string{
-	SubmarinerAddon:     "submariner",
 	IamPolicyController: "iam-policy-controller",
+	SubmarinerAddon:     "submariner",
 	// Add other components here when ClusterManagementAddOns is required.
 }
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -773,7 +773,11 @@ func (r *MultiClusterHubReconciler) ensureNoClusterManagementAddOn(m *operatorv1
 		},
 	}
 
-	err = r.Client.Delete(context.TODO(), clusterMgmtAddon)
+	foreground := metav1.DeletePropagationForeground
+	err = r.Client.Delete(context.TODO(), clusterMgmtAddon, &client.DeleteOptions{
+		PropagationPolicy: &foreground,
+	})
+
 	if errors.IsNotFound(err) {
 		return ctrl.Result{}, nil
 	}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -331,12 +331,6 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	// iam-policy-controller was removed in 2.11
-	result, err = r.ensureNoClusterManagementAddOn(multiClusterHub, "iam-policy-controller")
-	if err != nil {
-		return result, err
-	}
-
 	// Deploy appsub operator component
 	if multiClusterHub.Enabled(operatorv1.Appsub) {
 		result, err = r.ensureComponent(ctx, multiClusterHub, operatorv1.Appsub, r.CacheSpec)
@@ -432,6 +426,12 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	result, err = r.waitForMCEReady(ctx)
 	if result != (ctrl.Result{}) {
+		return result, err
+	}
+
+	// iam-policy-controller was removed in 2.11
+	result, err = r.ensureNoClusterManagementAddOn(multiClusterHub, operatorv1.IamPolicyController)
+	if err != nil {
 		return result, err
 	}
 


### PR DESCRIPTION
# Description

When attempting to remove the CMA for GRC, we are removing it before MCE is ready and has deployed the CMA CRD. This is preventing the MCH operator from deploying fully.

## Related Issue

https://issues.redhat.com/browse/ACM-11398

## Changes Made

Updated removal order for GRC CMA.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
