### PR TITLE
Volsync-addon-controller update clusterrole https://issues.redhat.com/browse/ACM-10539

### DIFF
--- a/pkg/templates/charts/toggle/volsync-controller/templates/volsync-addon-controller-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/volsync-controller/templates/volsync-addon-controller-clusterrole.yaml
@@ -48,7 +48,7 @@ rules:
     verbs: ["update"]
   - apiGroups: ["addon.open-cluster-management.io"]
     resources: ["clustermanagementaddons"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "patch"]
   - apiGroups: ["addon.open-cluster-management.io"]
     resources: ["addondeploymentconfigs"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
# Description

Required for addon-framework updates


## Related Issue

For: https://issues.redhat.com/browse/ACM-10539


## Changes Made

Volsync-addon-controller update clusterrole to allow "patch" for clustermanagementaddon resources.  The addon-framework now does a patch to the clustermanagementaddon to update an annotation.

Note this should also go into release-2.10 as this change in the addon-framework was made back in v0.8.1 which is used in release-2.10.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

