### PR TITLE
Enable template overrides for multicluster-o11y-operator resources

### DIFF
--- a/pkg/templates/charts/toggle/multicluster-observability-operator/templates/multicluster-observability-operator.yaml
+++ b/pkg/templates/charts/toggle/multicluster-observability-operator/templates/multicluster-observability-operator.yaml
@@ -99,11 +99,27 @@ spec:
           periodSeconds: 10
         resources:
           limits:
+          {{- if hasKey .Values.global.templateOverrides "multicluster_obs_operator_cpu_limit" }}
+            cpu: {{ .Values.global.templateOverrides.multicluster_obs_operator_cpu_limit | quote }}
+          {{- else }}
             cpu: 600m
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "multicluster_obs_operator_memory_limit" }}
+            memory: {{ .Values.global.templateOverrides.multicluster_obs_operator_memory_limit | quote }}
+          {{- else }}
             memory: 1Gi
+          {{- end }}
           requests:
+          {{- if hasKey .Values.global.templateOverrides "multicluster_obs_operator_cpu_request" }}
+            cpu: {{ .Values.global.templateOverrides.multicluster_obs_operator_cpu_request | quote }}
+          {{- else }}
             cpu: 100m
+          {{- end }}
+          {{- if hasKey .Values.global.templateOverrides "multicluster_obs_operator_memory_request" }}
+            memory: {{ .Values.global.templateOverrides.multicluster_obs_operator_memory_request | quote }}
+          {{- else }}
             memory: 128Mi
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/templates/charts/toggle/multicluster-observability-operator/values.yaml
+++ b/pkg/templates/charts/toggle/multicluster-observability-operator/values.yaml
@@ -5,6 +5,11 @@ global:
   namespace: default
   pullSecret: null
   templateOverrides: {}
+    # Available template overrides:
+    # multicluster_obs_operator_memory_request: <memory-value>
+    # multicluster_obs_operator_memory_limit: <memory-value>
+    # multicluster_obs_operator_cpu_request: <cpu-value>
+    # multicluster_obs_operator_cpu_limit: <cpu-value>
 hubconfig:
   nodeSelector: null
   ocpVersion: 4.12.0


### PR DESCRIPTION
# Description

Enables template overrides for overriding resources for the multicluster-observability-operator
```
multicluster_obs_operator_memory_request: <memory-value>
multicluster_obs_operator_memory_limit: <memory-value>
multicluster_obs_operator_cpu_request: <cpu-value>
multicluster_obs_operator_cpu_limit: <cpu-value>
```

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @philipgough @subbarao-meduri 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
