### PR TITLE
[ACM-11364] Removed hubSize reference from CRD

### DIFF
--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -79,12 +79,6 @@ spec:
         path: hive
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: The resource allocation bucket for this hub to use. [Small, Medium,
-          Large, ExtraLarge]. Defaults to Small if not specified.
-        displayName: Hub Size
-        path: hubSize
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Override pull secret for accessing MultiClusterHub operand and
           endpoint images
         displayName: Image Pull Secret

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -193,16 +193,6 @@ spec:
                 required:
                 - failedProvisionConfig
                 type: object
-              hubSize:
-                default: Small
-                description: The resource allocation bucket for this hub to use. [Small,
-                  Medium, Large, ExtraLarge]. Defaults to Small if not specified.
-                enum:
-                - Small
-                - Medium
-                - Large
-                - ExtraLarge
-                type: string
               imagePullSecret:
                 description: Override pull secret for accessing MultiClusterHub operand
                   and endpoint images

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -8,6 +8,7 @@ import coloredlogs
 import os
 import logging
 import shutil
+import sys
 import time
 
 from git import Repo, exc
@@ -26,7 +27,10 @@ def clone_repository(repo_url, repo_path, branch='main'):
 
 def prepare_operation(script_dir, operation_script, operation_args):
     shutil.copy(os.path.join(os.path.dirname(os.path.realpath(__file__)), f"{script_dir}/{operation_script}"), os.path.join(os.path.dirname(os.path.realpath(__file__)), operation_script))
-    os.system("python3 " + os.path.dirname(os.path.realpath(__file__)) +  f"/{operation_script} {operation_args}")
+    exit_code = os.system("python3 " + os.path.dirname(os.path.realpath(__file__)) +  f"/{operation_script} {operation_args}")
+    if exit_code != 0:
+        sys.exit(1)
+
     os.remove(os.path.join(os.path.dirname(os.path.realpath(__file__)), f"{operation_script}"))
 
 def main(args):


### PR DESCRIPTION
# Description

For this release, we migrated the usage of the hubSize field to an annotation; therefore, we don't need to display it within the CRD spec field.

## Related Issue

https://issues.redhat.com/browse/ACM-11364

## Changes Made

Removed `HubSize` from MCH CRD.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
