### PR TITLE
Sync KlusterletAddonConfig before cma deleted

### DIFF
--- a/controllers/managedcluster.go
+++ b/controllers/managedcluster.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"reflect"
 
 	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	utils "github.com/stolostron/multiclusterhub-operator/pkg/utils"
@@ -27,7 +28,19 @@ const (
 	AnnotationNodeSelector = "open-cluster-management/nodeSelector"
 )
 
-func getKlusterletAddonConfig() *unstructured.Unstructured {
+func getKlusterletAddonConfig(m *operatorsv1.MultiClusterHub) *unstructured.Unstructured {
+	grcEnabled := true
+
+	if m.Spec.Overrides != nil {
+		for _, component := range m.Spec.Overrides.Components {
+			if component.Name == operatorsv1.GRC {
+				grcEnabled = component.Enabled
+
+				break
+			}
+		}
+	}
+
 	klusterletaddonconfig := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "agent.open-cluster-management.io/v1",
@@ -44,7 +57,7 @@ func getKlusterletAddonConfig() *unstructured.Unstructured {
 					"enabledGlobalView": false,
 				},
 				"policyController": map[string]interface{}{
-					"enabled": true,
+					"enabled": grcEnabled,
 				},
 				"prometheusIntegration": map[string]interface{}{
 					"enabled": true,
@@ -53,12 +66,32 @@ func getKlusterletAddonConfig() *unstructured.Unstructured {
 					"enabled": false,
 				},
 				"certPolicyController": map[string]interface{}{
-					"enabled": true,
+					"enabled": grcEnabled,
 				},
 			},
 		},
 	}
 	return klusterletaddonconfig
+}
+
+func equivalentKlusterletAddonConfig(desiredKlusterletaddonconfig, klusterletaddonconfig *unstructured.Unstructured,
+	m *operatorsv1.MultiClusterHub,
+) (bool, map[string]interface{}, error) {
+	newSpec, _, err := unstructured.NestedMap(desiredKlusterletaddonconfig.Object, "spec")
+	if err != nil {
+		return false, nil, err
+	}
+
+	currentSpec, _, err := unstructured.NestedMap(klusterletaddonconfig.Object, "spec")
+	if err != nil {
+		return false, nil, err
+	}
+
+	labels := klusterletaddonconfig.GetLabels()
+
+	hasLabels := labels["installer.name"] == m.Name && labels["installer.namespace"] == m.Namespace
+
+	return reflect.DeepEqual(newSpec, currentSpec) && hasLabels, newSpec, nil
 }
 
 func (r *MultiClusterHubReconciler) ensureKlusterletAddonConfig(m *operatorsv1.MultiClusterHub) (ctrl.Result, error) {
@@ -75,34 +108,58 @@ func (r *MultiClusterHubReconciler) ensureKlusterletAddonConfig(m *operatorsv1.M
 		return ctrl.Result{}, err
 	}
 
-	klusterletaddonconfig := getKlusterletAddonConfig()
+	desiredKlusterletaddonconfig := getKlusterletAddonConfig(m)
+	klusterletaddonconfig := desiredKlusterletaddonconfig.DeepCopy()
 	nsn := types.NamespacedName{
 		Name:      KlusterletAddonConfigName,
 		Namespace: ManagedClusterName,
 	}
-	err = r.Client.Get(ctx, nsn, klusterletaddonconfig)
-	if err != nil && errors.IsNotFound(err) {
-		// Creating new klusterletAddonConfig
-		newKlusterletaddonconfig := getKlusterletAddonConfig()
-		utils.AddInstallerLabel(newKlusterletaddonconfig, m.GetName(), m.GetNamespace())
 
-		err = r.Client.Create(ctx, newKlusterletaddonconfig)
-		if err != nil {
-			r.Log.Error(err, "Failed to create klusterletaddonconfig resource")
-			return ctrl.Result{}, err
+	err = r.Client.Get(ctx, nsn, klusterletaddonconfig)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Creating new klusterletAddonConfig
+			utils.AddInstallerLabel(desiredKlusterletaddonconfig, m.GetName(), m.GetNamespace())
+
+			err = r.Client.Create(ctx, desiredKlusterletaddonconfig)
+			if err != nil {
+				r.Log.Error(err, "Failed to create klusterletaddonconfig resource")
+				return ctrl.Result{}, err
+			}
+			// KlusterletAddonConfig was successful
+			r.Log.Info("Created a new KlusterletAddonConfig")
+			return ctrl.Result{}, nil
 		}
-		// KlusterletAddonConfig was successful
-		r.Log.Info("Created a new KlusterletAddonConfig")
+
+		r.Log.Error(err, "Failed to get klusterletaddonconfig resource")
+		return ctrl.Result{}, err
+	}
+
+	isEquivalent, newSpec, err := equivalentKlusterletAddonConfig(desiredKlusterletaddonconfig, klusterletaddonconfig, m)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Don't need to update klusterletaddonconfig when isEquivalent is true
+	if isEquivalent {
 		return ctrl.Result{}, nil
 	}
 
 	utils.AddInstallerLabel(klusterletaddonconfig, m.GetName(), m.GetNamespace())
+
+	err = unstructured.SetNestedMap(klusterletaddonconfig.Object, newSpec, "spec")
+	if err != nil {
+		r.Log.Error(err, "Failed to set the spec of the KlusterletAddonConfig")
+		return ctrl.Result{}, err
+	}
 
 	err = r.Client.Update(ctx, klusterletaddonconfig)
 	if err != nil {
 		r.Log.Error(err, "Failed to update klusterletaddonconfig resource")
 		return ctrl.Result{}, err
 	}
+
+	r.Log.Info("Updated the KlusterletAddonConfig")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -449,6 +449,12 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
+	if !multiClusterHub.Spec.DisableHubSelfManagement {
+		result, err = r.ensureKlusterletAddonConfig(multiClusterHub)
+		if result != (ctrl.Result{}) || err != nil {
+			return result, err
+		}
+	}
 	// iam-policy-controller was removed in 2.11
 	result, err = r.ensureNoClusterManagementAddOn(multiClusterHub, operatorv1.IamPolicyController)
 	if err != nil {
@@ -459,13 +465,6 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	for _, c := range operatorv1.MCHComponents {
 		result, err = r.ensureComponentOrNoComponent(ctx, multiClusterHub, c, r.CacheSpec, ocpConsole, stsEnabled)
 		if result != (ctrl.Result{}) {
-			return result, err
-		}
-	}
-
-	if !multiClusterHub.Spec.DisableHubSelfManagement {
-		result, err = r.ensureKlusterletAddonConfig(multiClusterHub)
-		if result != (ctrl.Result{}) || err != nil {
 			return result, err
 		}
 	}
@@ -550,7 +549,8 @@ func (r *MultiClusterHubReconciler) ensureInfrastructureAWS(ctx context.Context)
 ensureObjectExistsAndNotDeleted ensures the existence of the specified object and that it has not been deleted.
 */
 func (r *MultiClusterHubReconciler) ensureObjectExistsAndNotDeleted(ctx context.Context, obj client.Object,
-	name string) (bool, error) {
+	name string,
+) (bool, error) {
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: name}, obj); err != nil {
 		if errors.IsNotFound(err) {
 			r.Log.Info(
@@ -594,7 +594,6 @@ func (r *MultiClusterHubReconciler) isSTSEnabled(ctx context.Context) (bool, err
 
 		if stsEnabledStatus {
 			r.Log.Info("STS is enabled.")
-
 		} else {
 			r.Log.Info("STS is not enabled.")
 		}
@@ -803,7 +802,8 @@ func (r *MultiClusterHubReconciler) fetchChartLocation(ctx context.Context, comp
 }
 
 func (r *MultiClusterHubReconciler) ensureComponentOrNoComponent(ctx context.Context, m *operatorv1.MultiClusterHub,
-	component string, cachespec CacheSpec, ocpConsole, isSTSEnabled bool) (ctrl.Result, error) {
+	component string, cachespec CacheSpec, ocpConsole, isSTSEnabled bool,
+) (ctrl.Result, error) {
 	var result ctrl.Result
 	var err error
 
@@ -854,7 +854,8 @@ func (r *MultiClusterHubReconciler) ensureNamespaceAndPullSecret(m *operatorv1.M
 }
 
 func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *operatorv1.MultiClusterHub, component string,
-	cachespec CacheSpec, isSTSEnabled bool) (ctrl.Result, error) {
+	cachespec CacheSpec, isSTSEnabled bool,
+) (ctrl.Result, error) {
 	/*
 	   If the component is detected to be MCH, we can simply return successfully. MCH is only listed in the components
 	   list for cleanup purposes.
@@ -903,7 +904,8 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 }
 
 func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *operatorv1.MultiClusterHub,
-	component string, cachespec CacheSpec, isSTSEnabled bool) (result ctrl.Result, err error) {
+	component string, cachespec CacheSpec, isSTSEnabled bool,
+) (result ctrl.Result, err error) {
 	/*
 	   If the component is detected to be MCH, we can simply return successfully. MCH is only listed in the components
 	   list for cleanup purposes. If the component is detected to be MCE, we can simply return successfully.
@@ -973,7 +975,8 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 }
 
 func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Context, m *operatorv1.MultiClusterHub) (
-	ctrl.Result, error) {
+	ctrl.Result, error,
+) {
 	existingNs := &corev1.Namespace{}
 
 	err := r.Client.Get(ctx, types.NamespacedName{Name: m.GetNamespace()}, existingNs)
@@ -1003,7 +1006,8 @@ func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Co
 }
 
 func (r *MultiClusterHubReconciler) deleteTemplate(ctx context.Context, m *operatorv1.MultiClusterHub,
-	template *unstructured.Unstructured) (ctrl.Result, error) {
+	template *unstructured.Unstructured,
+) (ctrl.Result, error) {
 	err := r.Client.Get(ctx, types.NamespacedName{Name: template.GetName(), Namespace: template.GetNamespace()}, template)
 
 	if err != nil && (errors.IsNotFound(err) || apimeta.IsNoMatchError(err)) {
@@ -1028,8 +1032,8 @@ func (r *MultiClusterHubReconciler) deleteTemplate(ctx context.Context, m *opera
 // createCAconfigmap creates a configmap that will be injected with the
 // trusted CA bundle for use with the OCP cluster wide proxy
 func (r *MultiClusterHubReconciler) createTrustBundleConfigmap(ctx context.Context, mch *operatorv1.MultiClusterHub) (
-	ctrl.Result, error) {
-
+	ctrl.Result, error,
+) {
 	// Get Trusted Bundle configmap name
 	trustBundleName := defaultTrustBundleName
 	trustBundleNamespace := mch.Namespace
@@ -1083,7 +1087,8 @@ func (r *MultiClusterHubReconciler) createTrustBundleConfigmap(ctx context.Conte
 }
 
 func (r *MultiClusterHubReconciler) createMetricsService(ctx context.Context, m *operatorv1.MultiClusterHub) (
-	ctrl.Result, error) {
+	ctrl.Result, error,
+) {
 	const Port = 8383
 
 	sName := utils.MCHOperatorMetricsServiceName
@@ -1145,7 +1150,8 @@ func (r *MultiClusterHubReconciler) createMetricsService(ctx context.Context, m 
 }
 
 func (r *MultiClusterHubReconciler) createMetricsServiceMonitor(ctx context.Context, m *operatorv1.MultiClusterHub) (
-	ctrl.Result, error) {
+	ctrl.Result, error,
+) {
 	smName := utils.MCHOperatorMetricsServiceMonitorName
 	smNamespace := m.GetNamespace()
 
@@ -1238,7 +1244,8 @@ func (r *MultiClusterHubReconciler) ingressDomain(m *operatorv1.MultiClusterHub)
 }
 
 func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operatorv1.MultiClusterHub, ocpConsole,
-	isSTSEnabled bool) error {
+	isSTSEnabled bool,
+) error {
 	if err := r.cleanupAppSubscriptions(reqLogger, m); err != nil {
 		return err
 	}

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -17,6 +17,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
+	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
@@ -61,9 +62,7 @@ const (
 	mchNamespace = "open-cluster-management"
 )
 
-var (
-	recon = MultiClusterHubReconciler{Client: fake.NewClientBuilder().Build()}
-)
+var recon = MultiClusterHubReconciler{Client: fake.NewClientBuilder().Build()}
 
 func ApplyPrereqs(k8sClient client.Client) {
 	By("Applying Namespace")
@@ -94,6 +93,8 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 
 	By("By creating a new Multiclusterhub")
 	mch := resources.EmptyMCH()
+	// To skip ensureKlusterletAddonConfig
+	mch.Spec.DisableHubSelfManagement = true
 	Expect(k8sClient.Create(ctx, &mch)).Should(Succeed())
 	Expect(k8sClient.Create(ctx, mchoDeployment)).Should(Succeed())
 
@@ -172,7 +173,6 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 		ns := LocalClusterNamespace()
 		_, err := reconciler.ensureNamespace(createdMCH, ns)
 		return err == nil
-
 	}, timeout, interval).Should(BeTrue())
 
 	By("Waiting for MCH to be in the running state")
@@ -234,6 +234,8 @@ func PreexistingMCE(k8sClient client.Client, reconciler *MultiClusterHubReconcil
 	}
 	Expect(k8sClient.Create(context.TODO(), testsecret)).Should(Succeed())
 	mch := resources.EmptyMCH()
+	// To skip ensureKlusterletAddonConfig
+	mch.Spec.DisableHubSelfManagement = true
 	mch.Spec.ImagePullSecret = "testsecret"
 	Expect(k8sClient.Create(ctx, &mch)).Should(Succeed())
 	Expect(k8sClient.Create(ctx, mchoDeployment)).Should(Succeed())
@@ -405,7 +407,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 			// 	ImageOverrides: map[string]string{},
 			// },
 		}
-		//Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
+		// Expect(reconciler.SetupWithManager(k8sManager)).Should(Succeed())
 		success, err := reconciler.SetupWithManager(k8sManager)
 		Expect(success).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())
@@ -492,7 +494,6 @@ var _ = Describe("MultiClusterHub controller", func() {
 			os.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
 			defer os.Unsetenv("OPERATOR_PACKAGE")
 			PreexistingMCE(k8sClient, reconciler, mchoDeployment)
-
 		})
 
 		It("Should get to a running state in Community Mode", func() {
@@ -511,7 +512,6 @@ var _ = Describe("MultiClusterHub controller", func() {
 			os.Setenv("OPERATOR_PACKAGE", "stolostron")
 			defer os.Unsetenv("OPERATOR_PACKAGE")
 			PreexistingMCE(k8sClient, reconciler, mchoDeployment)
-
 		})
 
 		It("Should allow MCH components to be optional", func() {
@@ -525,12 +525,15 @@ var _ = Describe("MultiClusterHub controller", func() {
 
 			By("Creating a new Multiclusterhub with components disabled")
 			mch := resources.NoComponentMCH()
+			// To skip ensureKlusterletAddonConfig
+			mch.Spec.DisableHubSelfManagement = true
 			mch.Disable(operatorv1.Appsub)
 			Expect(k8sClient.Create(ctx, &mch)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, mchoDeployment)).Should(Succeed())
 
 			By("Ensuring MCH is created")
 			createdMCH := &operatorv1.MultiClusterHub{}
+
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, resources.MCHLookupKey, createdMCH)
 				return err == nil
@@ -539,6 +542,9 @@ var _ = Describe("MultiClusterHub controller", func() {
 			By("Waiting for MCH to be in the running state")
 			Eventually(func() bool {
 				mch := &operatorv1.MultiClusterHub{}
+				// To skip ensureKlusterletAddonConfig
+				createdMCH.Spec.DisableHubSelfManagement = true
+
 				err := k8sClient.Get(ctx, resources.MCHLookupKey, mch)
 				if err == nil {
 					return mch.Status.Phase == operatorv1.HubRunning
@@ -1207,4 +1213,119 @@ func Test_ensureInfrastructureAWS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_equivalentKlusterletAddonConfig(t *testing.T) {
+	grcEnabled := true
+
+	match := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "agent.open-cluster-management.io/v1",
+			"kind":       "KlusterletAddonConfig",
+			"metadata": map[string]interface{}{
+				"name":      KlusterletAddonConfigName,
+				"namespace": ManagedClusterName,
+			},
+			"spec": map[string]interface{}{
+				"applicationManager": map[string]interface{}{
+					"enabled": true,
+				},
+				"connectionManager": map[string]interface{}{
+					"enabledGlobalView": false,
+				},
+				"policyController": map[string]interface{}{
+					"enabled": grcEnabled,
+				},
+				"prometheusIntegration": map[string]interface{}{
+					"enabled": true,
+				},
+				"searchCollector": map[string]interface{}{
+					"enabled": false,
+				},
+				"certPolicyController": map[string]interface{}{
+					"enabled": grcEnabled,
+				},
+			},
+		},
+	}
+
+	notMatch := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "agent.open-cluster-management.io/v1",
+			"kind":       "KlusterletAddonConfig",
+			"metadata": map[string]interface{}{
+				"name":      KlusterletAddonConfigName,
+				"namespace": ManagedClusterName,
+			},
+			"spec": map[string]interface{}{
+				"applicationManager": map[string]interface{}{
+					"enabled": true,
+				},
+				"connectionManager": map[string]interface{}{
+					"enabledGlobalView": true,
+				},
+				"policyController": map[string]interface{}{
+					"enabled": true,
+				},
+				"prometheusIntegration": map[string]interface{}{
+					"enabled": true,
+				},
+				"searchCollector": map[string]interface{}{
+					"enabled": true,
+				},
+				"certPolicyController": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+		},
+	}
+
+	mch := &operatorv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "mch", Namespace: "test-ns-1"},
+		Spec: operatorv1.MultiClusterHubSpec{
+			Overrides: &operatorv1.Overrides{
+				Components: []operatorv1.ComponentConfig{
+					{
+						Name:    operatorsv1.GRC,
+						Enabled: true,
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("Should return isUpdate false when label does not exist", func(t *testing.T) {
+		isEquivalent, _, err := equivalentKlusterletAddonConfig(getKlusterletAddonConfig(mch), match, mch)
+		if err != nil {
+			t.Errorf("equivalentKlusterletAddonConfig has error: %v", err)
+		}
+
+		if isEquivalent {
+			t.Errorf("isEquivalent should be false")
+		}
+	})
+
+	t.Run("Should return isUpdate true when label exists", func(t *testing.T) {
+		utils.AddInstallerLabel(match, mch.GetName(), mch.GetNamespace())
+		isEquivalent, _, err := equivalentKlusterletAddonConfig(getKlusterletAddonConfig(mch), match, mch)
+		if err != nil {
+			t.Errorf("equivalentKlusterletAddonConfig has error: %v", err)
+		}
+
+		if !isEquivalent {
+			t.Errorf("isEquivalent should be true")
+		}
+	})
+
+	t.Run("Should return isUpdate false when not match", func(t *testing.T) {
+		utils.AddInstallerLabel(notMatch, mch.GetName(), mch.GetNamespace())
+		isEquivalent, _, err := equivalentKlusterletAddonConfig(getKlusterletAddonConfig(mch), notMatch, mch)
+		if err != nil {
+			t.Errorf("equivalentKlusterletAddonConfig has error: %v", err)
+		}
+
+		if isEquivalent {
+			t.Errorf("isEquivalent should be false")
+		}
+	})
 }


### PR DESCRIPTION




# Description 

Before deleting the clustermanagementaddon, sync KlusterletAddonConfig with multiclusterhub to prevent creating orphan managedcluteraddons


## Related Issue

Ref: https://redhat-internal.slack.com/archives/CUEMEHRA9/p1712935780994539


- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
