### PR TITLE
[ACM-11156] Updated MCH to tolerate if a MCE CRD is missing

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -6,6 +6,13 @@ import (
 	"os"
 )
 
+type ResourceGVK struct {
+	Group   string `json:"group"`
+	Kind    string `json:"kind"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
 // Name of the MultiClusterHub (MCH) operator.
 const MCH = "multiclusterhub-operator"
 
@@ -83,6 +90,15 @@ var MCEComponents = []string{
 	MCEManagedServiceAccountPreview,
 	MCEManagedServiceAccount,
 	MCEServerFoundation,
+}
+
+var MCECRDs = []ResourceGVK{
+	{
+		Group:   "addon.open-cluster-management.io",
+		Version: "v1alpha1",
+		Kind:    "ClusterManagementAddOn",
+		Name:    "clustermanagementaddons.addon.open-cluster-management.io",
+	},
 }
 
 /*
@@ -323,28 +339,28 @@ func IsCommunity() (bool, error) {
 }
 
 // func (h HubSize) String() string {
-// 	return HubSizeStrings[h]
+//  return HubSizeStrings[h]
 // }
 
 // func (h *HubSize) UnmarshalJSON(b []byte) error {
-// 	fmt.Printf("Unmarshaling JSON is occuring: %v\n", string(b))
-// 	var hubsize string
-// 	if err := json.Unmarshal(b, &hubsize); err != nil {
-// 		return err
-// 	}
+//  fmt.Printf("Unmarshaling JSON is occuring: %v\n", string(b))
+//  var hubsize string
+//  if err := json.Unmarshal(b, &hubsize); err != nil {
+//      return err
+//  }
 
-// 	fmt.Printf("HubSize: %v\n", hubsize)
+//  fmt.Printf("HubSize: %v\n", hubsize)
 
-// 	var exists bool
-// 	hubsizeobj, exists := HubSizeFromString[hubsize]
+//  var exists bool
+//  hubsizeobj, exists := HubSizeFromString[hubsize]
 
-// 	if !exists {
-// 		return fmt.Errorf("key %v does not exist in map", hubsize)
-// 	}
+//  if !exists {
+//      return fmt.Errorf("key %v does not exist in map", hubsize)
+//  }
 
-// 	fmt.Printf("Hubsize: %v\n", hubsizeobj)
-// 	*h = hubsizeobj
-// 	return nil
+//  fmt.Printf("Hubsize: %v\n", hubsizeobj)
+//  *h = hubsizeobj
+//  return nil
 // }
 
 // IsInHostedMode returns true if mch is configured for hosted mode

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -41,6 +41,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -92,7 +93,7 @@ const (
 
 var (
 	log              = logf.Log.WithName("reconcile")
-	stsEnabledStatus = false
+	STSEnabledStatus = false
 )
 
 //+kubebuilder:rbac:groups="";"admissionregistration.k8s.io";"apiextensions.k8s.io";"apiregistration.k8s.io";"apps";"apps.open-cluster-management.io";"authorization.k8s.io";"hive.openshift.io";"mcm.ibm.com";"proxy.open-cluster-management.io";"rbac.authorization.k8s.io";"security.openshift.io";"clusterview.open-cluster-management.io";"discovery.open-cluster-management.io";"wgpolicyk8s.io",resources=apiservices;channels;clusterjoinrequests;clusterrolebindings;clusterstatuses/log;configmaps;customresourcedefinitions;deployments;discoveryconfigs;hiveconfigs;mutatingwebhookconfigurations;validatingwebhookconfigurations;namespaces;pods;policyreports;replicasets;rolebindings;secrets;serviceaccounts;services;subjectaccessreviews;subscriptions;helmreleases;managedclusters;managedclustersets,verbs=get
@@ -181,9 +182,17 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	/*
+	   In ACM 2.11, we need to determine if the operator is running in a STS enabled environment.
+	*/
+	stsEnabled, err := r.isSTSEnabled(ctx)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, err
+	}
+
 	originalStatus := multiClusterHub.Status.DeepCopy()
 	defer func() {
-		statusQueue, statusError := r.syncHubStatus(multiClusterHub, originalStatus, allDeploys, allCRs, ocpConsole)
+		statusQueue, statusError := r.syncHubStatus(multiClusterHub, originalStatus, allDeploys, allCRs, ocpConsole, stsEnabled)
 		if statusError != nil {
 			r.Log.Error(retError, "Error updating status")
 		}
@@ -251,14 +260,6 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Update cache with template overrides and related information.
 	r.CacheSpec.TemplateOverrides = templateOverrides
 	r.CacheSpec.TemplateOverridesCM = utils.GetTemplateOverridesConfigmapName(multiClusterHub)
-
-	/*
-	  In ACM 2.11, we need to determine if the operator is running in a STS enabled environment.
-	*/
-	stsEnabled, err := r.isSTSEnabled(ctx)
-	if err != nil {
-		return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, err
-	}
 
 	// Check if the multiClusterHub instance is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.
@@ -338,6 +339,20 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	// Install CRDs
+	var reason string
+	reason, err = r.installCRDs(r.Log, multiClusterHub)
+	if err != nil {
+		condition := NewHubCondition(
+			operatorv1.Progressing,
+			metav1.ConditionFalse,
+			reason,
+			fmt.Sprintf("Error installing CRDs: %s", err),
+		)
+		SetHubCondition(&multiClusterHub.Status, *condition)
+		return ctrl.Result{}, err
+	}
+
 	// 2.6 -> 2.7 upgrade logic
 	// There are ClusterManagementAddOns in the GRC appsub that need to be preserved when deleting the helmrelease
 	// To stop helm from removing them we will remove the finalizer on the GRC helmrelease, delete the appsub,
@@ -370,20 +385,6 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	*/
 	for _, kind := range operatorv1.GetLegacyConfigKind() {
 		_ = r.removeLegacyConfigurations(ctx, "openshift-monitoring", kind)
-	}
-
-	// Install CRDs
-	var reason string
-	reason, err = r.installCRDs(r.Log, multiClusterHub)
-	if err != nil {
-		condition := NewHubCondition(
-			operatorv1.Progressing,
-			metav1.ConditionFalse,
-			reason,
-			fmt.Sprintf("Error installing CRDs: %s", err),
-		)
-		SetHubCondition(&multiClusterHub.Status, *condition)
-		return ctrl.Result{}, err
 	}
 
 	if utils.ProxyEnvVarsAreSet() {
@@ -471,7 +472,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Cleanup unused resources once components up-to-date
-	if r.ComponentsAreRunning(multiClusterHub, ocpConsole) {
+	if r.ComponentsAreRunning(multiClusterHub, ocpConsole, stsEnabled) {
 		result, err = r.ensureRemovalsGone(multiClusterHub)
 		if result != (ctrl.Result{}) {
 			return result, err
@@ -497,7 +498,7 @@ func (r *MultiClusterHubReconciler) ensureAuthenticationIssuerNotEmpty(ctx conte
 
 	stsEnabled := auth.Spec.ServiceAccountIssuer != "" // Determine STS enabled status
 
-	if stsEnabledStatus && !stsEnabled {
+	if STSEnabledStatus && !stsEnabled {
 		r.Log.Info("Cluster is no longer STS enabled due to empty Authentication ServiceAccountIssuer",
 			"Name", auth.GetName())
 	}
@@ -518,7 +519,7 @@ func (r *MultiClusterHubReconciler) ensureCloudCredentialModeManual(ctx context.
 
 	stsEnabled := cloudCred.Spec.CredentialsMode == "Manual" // Determine STS enabled status
 
-	if stsEnabledStatus && !stsEnabled {
+	if STSEnabledStatus && !stsEnabled {
 		r.Log.Info("Cluster is no longer STS enabled due to CloudCredential CredentialMode not set to Manual.", "Name",
 			cloudCred.GetName())
 	}
@@ -539,7 +540,7 @@ func (r *MultiClusterHubReconciler) ensureInfrastructureAWS(ctx context.Context)
 
 	stsEnabled := infra.Spec.PlatformSpec.Type == "AWS"
 
-	if stsEnabledStatus && !stsEnabled {
+	if STSEnabledStatus && !stsEnabled {
 		r.Log.Info("Infrastructure platform type is not AWS. Cluster is not STS enabled", "Name", infra.GetName(),
 			"Type", infra.Spec.PlatformSpec.Type)
 	}
@@ -589,10 +590,10 @@ func (r *MultiClusterHubReconciler) isSTSEnabled(ctx context.Context) (bool, err
 	allConditionsMet := authOK && cloudCredOK && infraOK
 
 	// Check if the status has changed, and log the message if it has changed
-	if allConditionsMet != stsEnabledStatus {
-		stsEnabledStatus = allConditionsMet
+	if allConditionsMet != STSEnabledStatus {
+		STSEnabledStatus = allConditionsMet
 
-		if stsEnabledStatus {
+		if STSEnabledStatus {
 			r.Log.Info("STS is enabled.")
 
 		} else {
@@ -745,6 +746,23 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 			return result, err
 		}
 	} else {
+		// Check if the resource exists before creating it.
+		for _, gvk := range operatorv1.MCECRDs {
+			if template.GroupVersionKind().Group == gvk.Group && template.GetKind() == gvk.Kind && template.GroupVersionKind().Version == gvk.Version {
+				crd := &apixv1.CustomResourceDefinition{}
+
+				if err := r.Client.Get(ctx, types.NamespacedName{Name: gvk.Name}, crd); errors.IsNotFound(err) {
+					log.Info("CustomResourceDefinition does not exist. Skipping resource creation",
+						"Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
+
+					return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, nil
+				} else if err != nil {
+					log.Error(err, "failed to get CustomResourceDefinition", "Resource", gvk)
+					return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, err
+				}
+			}
+		}
+
 		// Apply the object data.
 		force := true
 		err := r.Client.Patch(ctx, template, client.Apply, &client.PatchOptions{Force: &force, FieldManager: "multiclusterhub-operator"})
@@ -758,7 +776,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 	return ctrl.Result{}, nil
 }
 
-func (r *MultiClusterHubReconciler) fetchChartLocation(ctx context.Context, component string) string {
+func (r *MultiClusterHubReconciler) fetchChartLocation(component string) string {
 	switch component {
 	case operatorv1.Appsub:
 		return utils.AppsubChartLocation
@@ -863,7 +881,7 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 		return ctrl.Result{}, nil
 	}
 
-	chartLocation := r.fetchChartLocation(ctx, component)
+	chartLocation := r.fetchChartLocation(component)
 
 	// Renders all templates from charts
 	templates, errs := renderer.RenderChart(chartLocation, m, cachespec.ImageOverrides, cachespec.TemplateOverrides,
@@ -913,7 +931,7 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 		return ctrl.Result{}, nil
 	}
 
-	chartLocation := r.fetchChartLocation(ctx, component)
+	chartLocation := r.fetchChartLocation(component)
 
 	switch component {
 	case operatorv1.Console:

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -1071,6 +1071,7 @@ func registerScheme() {
 	ocopv1.AddToScheme(scheme.Scheme)
 	operatorv1.AddToScheme(scheme.Scheme)
 	backplanev1.AddToScheme(scheme.Scheme)
+	subv1alpha1.AddToScheme(scheme.Scheme)
 }
 
 func Test_ensureAuthenticationIssuerNotEmpty(t *testing.T) {

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -1105,7 +1105,7 @@ func Test_ensureAuthenticationIssuerNotEmpty(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				stsEnabledStatus = true
+				STSEnabledStatus = true
 				recon.Client.Delete(context.TODO(), tt.auth)
 			}()
 
@@ -1149,7 +1149,7 @@ func Test_ensureCloudCredentialModeManual(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				stsEnabledStatus = true
+				STSEnabledStatus = true
 				recon.Client.Delete(context.TODO(), tt.cloudCred)
 			}()
 
@@ -1193,7 +1193,7 @@ func Test_ensureInfrastructureAWS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				stsEnabledStatus = true
+				STSEnabledStatus = true
 				recon.Client.Delete(context.TODO(), tt.infra)
 			}()
 

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -772,7 +772,7 @@ func Test_getComponentStatuses(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getComponentStatuses(tt.args.hub, tt.args.allDeps, tt.args.allCRs, true); len(got) == 0 {
+			if got := getComponentStatuses(tt.args.hub, tt.args.allDeps, tt.args.allCRs, true, false); len(got) == 0 {
 				t.Errorf("getComponentStatuses() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	utils "github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	"github.com/stolostron/multiclusterhub-operator/pkg/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+var replicas int32 = 1
 
 func Test_allComponentsSuccessful(t *testing.T) {
 	available := operatorsv1.StatusCondition{Type: "Available", Status: metav1.ConditionTrue, Available: true}
@@ -774,6 +778,145 @@ func Test_getComponentStatuses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getComponentStatuses(tt.args.hub, tt.args.allDeps, tt.args.allCRs, true, false); len(got) == 0 {
 				t.Errorf("getComponentStatuses() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_ComponentsAreRunning(t *testing.T) {
+	tests := []struct {
+		name   string
+		csv    olmv1alpha1.ClusterServiceVersion
+		deploy appsv1.Deployment
+		mce    mcev1.MultiClusterEngine
+		mch    operatorsv1.MultiClusterHub
+		ns     corev1.Namespace
+		ns2    corev1.Namespace
+		sub    olmv1alpha1.Subscription
+		want   bool
+	}{
+		{
+			name: "should ensure that components are not running",
+			csv: olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multicluster-engine.v2.6.0",
+					Namespace: "multicluster-engine",
+				},
+			},
+			deploy: appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "search-v2-operator",
+					Namespace: "ocm",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "search-v2-operator",
+							Namespace: "ocm",
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "agent",
+									Image: "quay.io/stolostron/search-v2-operator:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			mce: mcev1.MultiClusterEngine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "multiclusterengine",
+					Labels: map[string]string{
+						utils.MCEManagedByLabel: "true",
+					},
+				},
+				Spec: mcev1.MultiClusterEngineSpec{
+					TargetNamespace: "multicluster-engine",
+				},
+			},
+			mch: operatorsv1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multiclusterhub",
+					Namespace: "ocm",
+				},
+			},
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ocm",
+				},
+			},
+			ns2: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "multicluster-engine",
+				},
+			},
+			sub: olmv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multicluster-engine",
+					Namespace: "multicluster-engine",
+					Labels: map[string]string{
+						utils.MCEManagedByLabel: "true",
+					},
+				},
+				Spec: &olmv1alpha1.SubscriptionSpec{
+					Channel:                "stable-2.6",
+					InstallPlanApproval:    "Automatic",
+					CatalogSource:          "multiclusterengine-catalog",
+					CatalogSourceNamespace: "openshift-marketplace",
+					Package:                "multicluster-engine",
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					CurrentCSV: "multicluster-engine.v2.6.0",
+				},
+			},
+			want: false,
+		},
+	}
+
+	registerScheme()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if err := recon.Client.Delete(context.TODO(), &tt.ns); err != nil {
+					t.Errorf("failed to delete namespace: %v", err)
+				}
+				if err := recon.Client.Delete(context.TODO(), &tt.ns2); err != nil {
+					t.Errorf("failed to delete namespace: %v", err)
+				}
+				if err := recon.Client.Delete(context.TODO(), &tt.mce); err != nil {
+					t.Errorf("failed to delete multiclusterengine: %v", err)
+				}
+			}()
+
+			if err := recon.Client.Create(context.TODO(), &tt.ns); err != nil {
+				t.Errorf("failed to create namespace: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.ns2); err != nil {
+				t.Errorf("failed to create namespace: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.sub); err != nil {
+				t.Errorf("failed to create subscription: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.csv); err != nil {
+				t.Errorf("failed to create clusterserviceversion: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.mce); err != nil {
+				t.Errorf("failed to create clusterserviceversion: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.deploy); err != nil {
+				t.Errorf("failed to create deployment: %v", err)
+			}
+
+			if ok := recon.ComponentsAreRunning(&tt.mch, true, false); ok != tt.want {
+				t.Errorf("failed to ensure that components are running: %v", ok)
 			}
 		})
 	}

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -6,7 +6,7 @@ package main
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;patch;update;watch;create
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;patch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;update
 //+kubebuilder:rbac:groups="",resources=configmaps;endpoints;events;secrets;serviceaccounts;services;services/proxy,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups="",resources=configmaps;events,verbs=get;list;watch;create;update;delete;deletecollection;patch
 //+kubebuilder:rbac:groups="",resources=configmaps;jobs;namespaces;pods;secrets,verbs=list;watch

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -412,7 +412,7 @@ func GetCustomResources(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 	}
 }
 
-func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole bool) []types.NamespacedName {
+func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEnabled bool) []types.NamespacedName {
 	nn := []types.NamespacedName{}
 	if m.Enabled(operatorsv1.Insights) {
 		nn = append(nn, types.NamespacedName{Name: "insights-client", Namespace: m.Namespace})
@@ -437,7 +437,10 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole bool) []
 	}
 	if m.Enabled(operatorsv1.ClusterBackup) {
 		nn = append(nn, types.NamespacedName{Name: "cluster-backup-chart-clusterbackup", Namespace: ClusterSubscriptionNamespace})
-		nn = append(nn, types.NamespacedName{Name: "openshift-adp-controller-manager", Namespace: ClusterSubscriptionNamespace})
+
+		if !isSTSEnabled {
+			nn = append(nn, types.NamespacedName{Name: "openshift-adp-controller-manager", Namespace: ClusterSubscriptionNamespace})
+		}
 	}
 	if m.Enabled(operatorsv1.GRC) {
 		nn = append(nn, types.NamespacedName{Name: "grc-policy-addon-controller", Namespace: m.Namespace})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -686,3 +686,65 @@ func TestUpdateMCEOverrides(t *testing.T) {
 	}
 	// Ok if local-cluster not found
 }
+
+func Test_GetDeploymentsForStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		mch        mchv1.MultiClusterHub
+		stsEnabled bool
+		want       int
+	}{
+		{
+			name:       "should get deployment status for MCH components",
+			mch:        resources.EmptyMCH(),
+			stsEnabled: false,
+			want:       19,
+		},
+		{
+			name: "should get deployment status for MCH components with STS enabled",
+			mch: mchv1.MultiClusterHub{
+				Spec: mchv1.MultiClusterHubSpec{
+					Overrides: &mchv1.Overrides{
+						Components: []mchv1.ComponentConfig{
+							{
+								Name:    mchv1.ClusterBackup,
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			stsEnabled: true,
+			want:       20,
+		},
+		{
+			name: "should get deployment status for MCH components with STS disabled",
+			mch: mchv1.MultiClusterHub{
+				Spec: mchv1.MultiClusterHubSpec{
+					Overrides: &mchv1.Overrides{
+						Components: []mchv1.ComponentConfig{
+							{
+								Name:    mchv1.ClusterBackup,
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+			stsEnabled: false,
+			want:       21,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := SetDefaultComponents(&tt.mch); err != nil {
+				t.Errorf("failed to set default components: %v", err)
+			}
+
+			if deployments := GetDeploymentsForStatus(&tt.mch, true, tt.stsEnabled); len(deployments) != tt.want {
+				t.Errorf("expected %v, got %v", len(deployments), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -178,19 +178,19 @@ var _ = Describe("utility functions", func() {
 		})
 		It("gets deployments for status with mcho-repo disabled", func() {
 			mch := resources.EmptyMCH()
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(0))
 		})
 		It("gets deployments for status with insights enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable("insights")
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(2))
 		})
 		It("gets deployments for status with cluster-lifecycle enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.ClusterLifecycle)
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(1))
 		})
 		It("gets deployments for status with cluster-backkup enabled", func() {
@@ -200,37 +200,37 @@ var _ = Describe("utility functions", func() {
 		It("gets deployments for status with grc enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.GRC)
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(2))
 		})
 		It("gets deployments for status with app-lifecycle enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.Appsub)
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(5))
 		})
 		It("gets deployments for status with console enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.Console)
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(1))
 		})
 		It("gets deployments for status with observability enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.MultiClusterObservability)
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(1))
 		})
 		It("gets deployments for status with volsync enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.Volsync)
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(1))
 		})
 		It("gets deployments for status with cluster-permission enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.ClusterPermission)
-			d := GetDeploymentsForStatus(&mch, true)
+			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(1))
 		})
 		It("Sets Default Component values", func() {


### PR DESCRIPTION
# Description

When ACM is awaiting for an MCE sub-component's CRD to be created we are currently throwing an error status which is giving off the appearance that something is broken within the cluster very early; however, this is not the case. This change will ignore the CR instance creation until the CRD is present on the cluster.

## Related Issue

https://issues.redhat.com/browse/ACM-11156

## Changes Made

Add logic to support missing MCE sub-component's CRD toleration.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
