### PR TITLE
[ACM-9668]: Add backup label to Search CR

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -749,6 +749,7 @@ func (r *MultiClusterHubReconciler) ensureSearchCR(m *operatorv1.MultiClusterHub
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "search-v2-operator",
 			Namespace: m.Namespace,
+			Labels:    map[string]string{"cluster.open-cluster-management.io/backup": ""},
 		},
 		Spec: searchv2v1alpha1.SearchSpec{
 			NodeSelector: m.Spec.NodeSelector,


### PR DESCRIPTION
# Description

Adds a label to the Search CR to enable backup.

## Related Issue
https://issues.redhat.com/browse/ACM-9668

## Changes Made
Adds a label to the Search CR to enable backup, based on documentation here: [https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for[…]ernetes/2.10/html/business_continuity/business-cont-overview](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/business_continuity/business-cont-overview#resources-that-are-backed-up)

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`
@dislbenn @jlpadilla 
## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
