### PR TITLE
ACM-11855 - Revisit OADP operator policy templates

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -253,7 +253,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: redhat-oadp-operator
+          name: oadp-operator-exists
         spec:
           object-templates:
             - complianceType: musthave
@@ -264,20 +264,20 @@ spec:
                   namespace: open-cluster-management-backup
                 spec:
                   name: redhat-oadp-operator
-                  channel: {{ .Values.global.channel }}
           remediationAction: inform
           severity: high
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: oadp-channel
+          name: oadp-channel-validation
         spec:
           remediationAction: inform
           severity: high
           object-templates-raw: |
+            {{ printf `{{ $ch := %s }}` .Values.global.channel }}
             {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "" "").items }}` }}
-            {{ `{{- if eq $ss.spec.name "redhat-oadp-operator" }}` }}
+            {{ `{{- if and (eq $ss.spec.name "redhat-oadp-operator") (lt $ss.spec.channel  $ch) }}` }}
             - complianceType: musthave
               objectDefinition:
                 kind: Subscription
@@ -286,7 +286,7 @@ spec:
                   name: {{ `{{ $ss.metadata.name }}` }}
                   namespace: {{ `{{ $ss.metadata.namespace }}` }}
                 spec:
-                  channel: {{ .Values.global.channel }}
+                  channel: {{ `{{ $ch }}` }}
             {{ `{{- end }}` }}
             {{ `{{- end }}` }}                                                                      
   remediationAction: inform

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -276,8 +276,8 @@ spec:
           severity: high
           object-templates-raw: |
             {{ printf `{{ $ch := %s }}` .Values.global.channel }}
-            {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "" "").items }}` }}
-            {{ `{{- if and (eq $ss.spec.name "redhat-oadp-operator") (lt $ss.spec.channel  $ch) }}` }}
+            {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "open-cluster-management-backup" "").items }}` }}
+              {{ `{{- if and (eq $ss.spec.name "redhat-oadp-operator") (lt $ss.spec.channel $ch) }}` }}
             - complianceType: musthave
               objectDefinition:
                 kind: Subscription
@@ -287,6 +287,37 @@ spec:
                   namespace: {{ `{{ $ss.metadata.namespace }}` }}
                 spec:
                   channel: {{ `{{ $ch }}` }}
+              {{ `{{- end }}` }}
             {{ `{{- end }}` }}
-            {{ `{{- end }}` }}                                                                      
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: custom-oadp-channel-validation
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates-raw: |
+            {{ `{{- $ch := "" }}` }}
+            {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "open-cluster-management-backup" "").items }}` }}
+              {{ `{{- if (eq $ss.spec.name "redhat-oadp-operator") }}` }}
+                {{ `{{ $ch = $ss.spec.channel }}` }}
+                {{ `{{ break }}` }}
+              {{ `{{- end }}` }}
+            {{ `{{- end }}` }}
+            {{ `{{- if $ch }}` }}
+              {{ `{{- range $cs := (lookup "operators.coreos.com/v1alpha1" "Subscription" "" "").items }}` }}
+                {{ `{{- if and (eq $cs.spec.name "redhat-oadp-operator") (ne $cs.spec.channel $ch) }}` }}
+            - complianceType: musthave
+              objectDefinition:
+                kind: Subscription
+                apiVersion: operators.coreos.com/v1alpha1
+                metadata:
+                  name: {{ `{{ $cs.metadata.name }}` }}
+                  namespace: {{ `{{ $cs.metadata.namespace }}` }}
+                spec:
+                  channel: {{ `{{ $ch }}` }}
+                {{ `{{- end }}` }}
+              {{ `{{- end }}` }}
+            {{ `{{- end }}` }}                                                                  
   remediationAction: inform


### PR DESCRIPTION
# Description

Revisit templates checking OADP version

## Related Issue

https://issues.redhat.com/browse/ACM-11855

## Changes Made

Added policy templates to check for the following:

- The oadp-operator-exists template checks that an OADP subscription exists in the open-cluster-management-backup namespace.
- The oadp-channel-validation template checks that the OADP installed in the open-cluster-management-backup namespace matches the chart version or has a newer version.
- The custom-oadp-channel-validation template checks that any OADP installed in any namespace matches the version of OADP in the open-cluster-management-backup namespace.


## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
