### PR TITLE
Revert shell script org to stolostron

### DIFF
--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -38,7 +38,7 @@ def main(args):
     start_time = time.time()  # Record start time
 
     repo_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp/dev-tools") # Destination path for cloned repository.
-    clone_repository("https://github.com/dislbenn/installer-dev-tools.git", repo_path)
+    clone_repository("https://github.com/stolostron/installer-dev-tools.git", repo_path)
     script_dir = "tmp/dev-tools/bundle-generation"
 
     if args.lint_bundles:


### PR DESCRIPTION
# Description

Changing the repository path back to `stolostron`. It is currently pointing towards a forked repository.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
