### PR TITLE
[ACM-11732] Enhance available component statuses

### DIFF
--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -271,8 +271,11 @@ type MultiClusterHubStatus struct {
 
 // StatusCondition contains condition information.
 type StatusCondition struct {
+	// The component name
+	Name string `json:"name,omitempty"`
+
 	// The resource kind this condition represents
-	Kind string `json:"-"`
+	Kind string `json:"kind,omitempty"`
 
 	// Available indicates whether this component is considered properly running
 	Available bool `json:"-"`

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -286,6 +286,8 @@ spec:
                 additionalProperties:
                   description: StatusCondition contains condition information.
                   properties:
+                    kind:
+                      type: string
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition
                         changed from one status to another.
@@ -294,6 +296,8 @@ spec:
                     message:
                       description: Message is a human-readable message indicating
                         details about the last status change.
+                      type: string
+                    name:
                       type: string
                     reason:
                       description: Reason is a (brief) reason for the condition's

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -287,6 +287,7 @@ spec:
                   description: StatusCondition contains condition information.
                   properties:
                     kind:
+                      description: The resource kind this condition represents
                       type: string
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition
@@ -298,6 +299,7 @@ spec:
                         details about the last status change.
                       type: string
                     name:
+                      description: The component name
                       type: string
                     reason:
                       description: Reason is a (brief) reason for the condition's

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -316,6 +316,8 @@ spec:
                 items:
                   description: StatusCondition contains condition information.
                   properties:
+                    kind:
+                      type: string
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition
                         changed from one status to another.
@@ -328,6 +330,8 @@ spec:
                     message:
                       description: Message is a human-readable message indicating
                         details about the last status change.
+                      type: string
+                    name:
                       type: string
                     reason:
                       description: Reason is a (brief) reason for the condition's

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -287,6 +287,9 @@ spec:
                 additionalProperties:
                   description: StatusCondition contains condition information.
                   properties:
+                    kind:
+                      description: The resource kind this condition represents
+                      type: string
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition
                         changed from one status to another.
@@ -295,6 +298,9 @@ spec:
                     message:
                       description: Message is a human-readable message indicating
                         details about the last status change.
+                      type: string
+                    name:
+                      description: The component name
                       type: string
                     reason:
                       description: Reason is a (brief) reason for the condition's
@@ -316,8 +322,6 @@ spec:
                 items:
                   description: StatusCondition contains condition information.
                   properties:
-                    kind:
-                      type: string
                     lastTransitionTime:
                       description: LastTransitionTime is the last time the condition
                         changed from one status to another.
@@ -330,8 +334,6 @@ spec:
                     message:
                       description: Message is a human-readable message indicating
                         details about the last status change.
-                      type: string
-                    name:
                       type: string
                     reason:
                       description: Reason is a (brief) reason for the condition's

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -515,6 +515,9 @@ func Test_mapCSV(t *testing.T) {
 		{
 			name: "Successful install",
 			csv: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "advanced-cluster-management.v2.11.0",
+				},
 				Status: olmv1alpha1.ClusterServiceVersionStatus{
 					Conditions: []olmv1alpha1.ClusterServiceVersionCondition{
 						{
@@ -526,6 +529,7 @@ func Test_mapCSV(t *testing.T) {
 				},
 			},
 			want: operatorsv1.StatusCondition{
+				Name:      "advanced-cluster-management.v2.11.0",
 				Kind:      "ClusterServiceVersion",
 				Status:    metav1.ConditionTrue,
 				Reason:    "InstallSucceeded",
@@ -539,7 +543,7 @@ func Test_mapCSV(t *testing.T) {
 			csv: &olmv1alpha1.ClusterServiceVersion{
 				Status: olmv1alpha1.ClusterServiceVersionStatus{},
 			},
-			want: unknownStatus,
+			want: unknownStatus("advanced-cluster-management.v2.11.0", "ClusterServiceVersion"),
 		},
 	}
 	for _, tt := range tests {
@@ -579,6 +583,9 @@ func Test_mapMCE(t *testing.T) {
 		{
 			name: "Successful install",
 			mce: &mcev1.MultiClusterEngine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "multicluster-engine.v2.6.0",
+				},
 				Status: mcev1.MultiClusterEngineStatus{
 					Conditions: []mcev1.MultiClusterEngineCondition{
 						{
@@ -591,7 +598,8 @@ func Test_mapMCE(t *testing.T) {
 				},
 			},
 			want: operatorsv1.StatusCondition{
-				Kind:      "ClusterServiceVersion",
+				Name:      "multicluster-engine.v2.6.0",
+				Kind:      "MultiClusterEngine",
 				Status:    metav1.ConditionTrue,
 				Reason:    "Available",
 				Message:   "",
@@ -606,7 +614,7 @@ func Test_mapMCE(t *testing.T) {
 					Conditions: []mcev1.MultiClusterEngineCondition{},
 				},
 			},
-			want: unknownStatus,
+			want: unknownStatus("multicluster-engine.v2.6.0", "MultiClusterEngine"),
 		},
 	}
 	for _, tt := range tests {
@@ -672,7 +680,7 @@ func Test_mapSubscription(t *testing.T) {
 			sub: &olmv1alpha1.Subscription{
 				Status: olmv1alpha1.SubscriptionStatus{},
 			},
-			want: unknownStatus,
+			want: unknownStatus("test", "Subscription"),
 		},
 	}
 	for _, tt := range tests {
@@ -770,7 +778,7 @@ func Test_getComponentStatuses(t *testing.T) {
 				},
 			},
 			want: map[string]operatorsv1.StatusCondition{
-				"local-cluster": unknownStatus,
+				"local-cluster": unknownStatus("local-cluster", "Component"),
 			},
 		},
 	}


### PR DESCRIPTION
# Description

Enhanced the MCH component status to include `name` and `kind`. This PR will also add additional logging to show when a component within MCH is not available.

```yaml
    multicluster-engine-csv:
      kind: ClusterServiceVersion
      lastTransitionTime: '2024-06-07T16:39:07Z'
      message: install strategy completed with no errors
      name: multicluster-engine.v2.6.0
      reason: InstallSucceeded
      status: 'True'
      type: Available
```

```
2024-06-07T11:49:06.668Z INFO reconcile The component is now available. {"Kind": "MultiClusterEngine", "Name": "multiclusterengine"}
```

## Related Issue

https://issues.redhat.com/browse/ACM-11732

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
