### PR TITLE
Added PAT support for regenerate-sha-commit script

### DIFF
--- a/.github/workflows/regenerate-sha-commit.yml
+++ b/.github/workflows/regenerate-sha-commit.yml
@@ -35,6 +35,8 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Regenerate Operator SHAs Commits
         id: generate_sha_commit
+        env:
+          GH_READ_PAT: ${{ secrets.GH_READ_PAT }}
         run: |
           make regenerate-operator-sha-commits
           exit_code=$?


### PR DESCRIPTION
# Description

Added support for Personal Access Token (PAT) for the regenerate sha commit script. When pulling from a private  repository, you need to provide a token for the github action to clone the private repository.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Added `env` for `GH_READ_PAT` for `regenerate-sha-commit` script.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [x] Documentation is updated.
- [x] All checks and tests pass.
- [x] Approved by at least one reviewer.
- [x] Merged into the main/master branch.
