### PR TITLE
[ACM-12430] Added MultiClusterHub current and desired version columns to MCH CRD

### DIFF
--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -357,6 +357,8 @@ type HubCondition struct {
 // is determined based on the configuration that is defined in this resource.
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="The overall status of the multiclusterhub"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="CurrentVersion",type="string",JSONPath=".status.currentVersion",description="The current version of the multiclusterhub"
+// +kubebuilder:printcolumn:name="DesiredVersion",type="string",JSONPath=".status.desiredVersion",description="The desired version of the multiclusterhub"
 // +operator-sdk:csv:customresourcedefinitions:displayName="MultiClusterHub"
 type MultiClusterHub struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -355,10 +355,10 @@ type HubCondition struct {
 // for an instance of a multicluster hub, a central point for managing multiple
 // Kubernetes-based clusters. The deployment of multicluster hub components
 // is determined based on the configuration that is defined in this resource.
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="The overall status of the multiclusterhub"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="The overall status of the MultiClusterHub"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="CurrentVersion",type="string",JSONPath=".status.currentVersion",description="The current version of the multiclusterhub"
-// +kubebuilder:printcolumn:name="DesiredVersion",type="string",JSONPath=".status.desiredVersion",description="The desired version of the multiclusterhub"
+// +kubebuilder:printcolumn:name="CurrentVersion",type="string",JSONPath=".status.currentVersion",description="The current version of the MultiClusterHub"
+// +kubebuilder:printcolumn:name="DesiredVersion",type="string",JSONPath=".status.desiredVersion",description="The desired version of the MultiClusterHub"
 // +operator-sdk:csv:customresourcedefinitions:displayName="MultiClusterHub"
 type MultiClusterHub struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -24,6 +24,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: The current version of the multiclusterhub
+      jsonPath: .status.currentVersion
+      name: CurrentVersion
+      type: string
+    - description: The desired version of the multiclusterhub
+      jsonPath: .status.desiredVersion
+      name: DesiredVersion
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -17,18 +17,18 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The overall status of the multiclusterhub
+    - description: The overall status of the MultiClusterHub
       jsonPath: .status.phase
       name: Status
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - description: The current version of the multiclusterhub
+    - description: The current version of the MultiClusterHub
       jsonPath: .status.currentVersion
       name: CurrentVersion
       type: string
-    - description: The desired version of the multiclusterhub
+    - description: The desired version of the MultiClusterHub
       jsonPath: .status.desiredVersion
       name: DesiredVersion
       type: string

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -24,6 +24,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: The current version of the multiclusterhub
+      jsonPath: .status.currentVersion
+      name: CurrentVersion
+      type: string
+    - description: The desired version of the multiclusterhub
+      jsonPath: .status.desiredVersion
+      name: DesiredVersion
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -17,18 +17,18 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: The overall status of the multiclusterhub
+    - description: The overall status of the MultiClusterHub
       jsonPath: .status.phase
       name: Status
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - description: The current version of the multiclusterhub
+    - description: The current version of the MultiClusterHub
       jsonPath: .status.currentVersion
       name: CurrentVersion
       type: string
-    - description: The desired version of the multiclusterhub
+    - description: The desired version of the MultiClusterHub
       jsonPath: .status.desiredVersion
       name: DesiredVersion
       type: string


### PR DESCRIPTION
# Description

Added `currentVersion` and `desiredVersion` to the `additionalPrinterColumns` in MCH CRD.

## Related Issue

https://issues.redhat.com/browse/ACM-12430

## Changes Made

Added support to print out the `currentVersion` and `desiredVersion` of the MCH operator.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
