### PR TITLE
ACM-12881 - Support customizing local cluster name

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-placementrule.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-placementrule.yaml
@@ -12,7 +12,7 @@ spec:
       type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - key: name
+      - key: local-cluster
         operator: In
         values:
-          - local-cluster
+          - 'true'


### PR DESCRIPTION
# Description

Support hub policy to run on a hub with name changed from local-cluster

## Related Issue

https://issues.redhat.com/browse/ACM-12881

## Changes Made

In the existing PlacementRule, instead of checking the label name=local-cluster, look for the label local-cluster=true to identify the local cluster, no need to check the name, because the local-cluster=true label has been added for several releases, could not bring backward compatibility issue. 

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
