### PR TITLE
update CRD to include user restore options

### DIFF
--- a/pkg/templates/crds/cluster-backup/cluster.open-cluster-management.io_restores.yaml
+++ b/pkg/templates/crds/cluster-backup/cluster.open-cluster-management.io_restores.yaml
@@ -28,7 +28,12 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Restore is the Schema for the restores API
+        description: Restore is an ACM resource that you can use to restore resources
+          from a cluster backup to a target cluster. The restore resource has properties
+          that you can use to restore only passive data or to restore managed cluster
+          activation resources. Additionally, it has a property that you can use to
+          periodically check for new backups and automatically restore them on the
+          target cluster.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -52,15 +57,15 @@ spec:
                   restoring the new data.
                 type: string
               excludedNamespaces:
-                description: ExcludedNamespaces contains a list of namespaces that
-                  are not included in the restore.
+                description: velero option - ExcludedNamespaces contains a list of
+                  namespaces that are not included in the restore.
                 items:
                   type: string
                 nullable: true
                 type: array
               excludedResources:
-                description: ExcludedResources is a slice of resource names that are
-                  not included in the restore.
+                description: velero option - ExcludedResources is a slice of resource
+                  names that are not included in the restore.
                 items:
                   type: string
                 nullable: true
@@ -506,7 +511,11 @@ spec:
                                                         properties:
                                                           name:
                                                             description: The header
-                                                              field name
+                                                              field name. This will
+                                                              be canonicalized upon
+                                                              output, so case-variant
+                                                              names will be understood
+                                                              as the same header.
                                                             type: string
                                                           value:
                                                             description: The header
@@ -630,7 +639,11 @@ spec:
                                                         properties:
                                                           name:
                                                             description: The header
-                                                              field name
+                                                              field name. This will
+                                                              be canonicalized upon
+                                                              output, so case-variant
+                                                              names will be understood
+                                                              as the same header.
                                                             type: string
                                                           value:
                                                             description: The header
@@ -729,9 +742,7 @@ spec:
                                               type: integer
                                             grpc:
                                               description: GRPC specifies an action
-                                                involving a GRPC port. This is a beta
-                                                field and requires enabling GRPCContainerProbe
-                                                feature gate.
+                                                involving a GRPC port.
                                               properties:
                                                 port:
                                                   description: Port number of the
@@ -771,7 +782,10 @@ spec:
                                                     properties:
                                                       name:
                                                         description: The header field
-                                                          name
+                                                          name. This will be canonicalized
+                                                          upon output, so case-variant
+                                                          names will be understood
+                                                          as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -975,9 +989,7 @@ spec:
                                               type: integer
                                             grpc:
                                               description: GRPC specifies an action
-                                                involving a GRPC port. This is a beta
-                                                field and requires enabling GRPCContainerProbe
-                                                feature gate.
+                                                involving a GRPC port.
                                               properties:
                                                 port:
                                                   description: Port number of the
@@ -1017,7 +1029,10 @@ spec:
                                                     properties:
                                                       name:
                                                         description: The header field
-                                                          name
+                                                          name. This will be canonicalized
+                                                          upon output, so case-variant
+                                                          names will be understood
+                                                          as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -1121,6 +1136,31 @@ spec:
                                               format: int32
                                               type: integer
                                           type: object
+                                        resizePolicy:
+                                          description: Resources resize policy for
+                                            the container.
+                                          items:
+                                            description: ContainerResizePolicy represents
+                                              resource resize policy for the container.
+                                            properties:
+                                              resourceName:
+                                                description: 'Name of the resource
+                                                  to which this resource resize policy
+                                                  applies. Supported values: cpu,
+                                                  memory.'
+                                                type: string
+                                              restartPolicy:
+                                                description: Restart policy to apply
+                                                  when specified resource is resized.
+                                                  If not specified, it defaults to
+                                                  NotRequired.
+                                                type: string
+                                            required:
+                                            - resourceName
+                                            - restartPolicy
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         resources:
                                           description: 'Compute Resources required
                                             by this container. Cannot be updated.
@@ -1176,7 +1216,8 @@ spec:
                                                 a container, it defaults to Limits
                                                 if that is explicitly specified, otherwise
                                                 to an implementation-defined value.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                Requests cannot exceed Limits. More
+                                                info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                               type: object
                                           type: object
                                         securityContext:
@@ -1447,9 +1488,7 @@ spec:
                                               type: integer
                                             grpc:
                                               description: GRPC specifies an action
-                                                involving a GRPC port. This is a beta
-                                                field and requires enabling GRPCContainerProbe
-                                                feature gate.
+                                                involving a GRPC port.
                                               properties:
                                                 port:
                                                   description: Port number of the
@@ -1489,7 +1528,10 @@ spec:
                                                     properties:
                                                       name:
                                                         description: The header field
-                                                          name
+                                                          name. This will be canonicalized
+                                                          upon output, so case-variant
+                                                          names will be understood
+                                                          as the same header.
                                                         type: string
                                                       value:
                                                         description: The header field
@@ -1744,6 +1786,131 @@ spec:
                       type: object
                     type: array
                 type: object
+              includedNamespaces:
+                description: velero option - IncludedNamespaces is a slice of namespace
+                  names to include objects from. If empty, all namespaces are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedResources:
+                description: velero option - IncludedResources is a slice of resource
+                  names to include in the restore. If empty, all resources in the
+                  backup are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              labelSelector:
+                description: velero option - LabelSelector is a metav1.LabelSelector
+                  to filter with when restoring individual objects from the backup.
+                  If empty or nil, all objects are included. Optional.
+                nullable: true
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              namespaceMapping:
+                additionalProperties:
+                  type: string
+                description: velero option - NamespaceMapping is a map of source namespace
+                  names to target namespace names to restore into. Any source namespaces
+                  not included in the map will be restored into namespaces of the
+                  same name.
+                type: object
+              orLabelSelectors:
+                description: velero option - OrLabelSelectors is list of metav1.LabelSelector
+                  to filter with when restoring individual objects from the backup.
+                  If multiple provided they will be joined by the OR operator. LabelSelector
+                  as well as OrLabelSelectors cannot co-exist in restore request,
+                  only one of them can be used
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                nullable: true
+                type: array
               preserveNodePorts:
                 description: velero option - PreserveNodePorts specifies whether to
                   restore old nodePorts from backup.


### PR DESCRIPTION
# Description


The user should be able to filter restore resources using velero restore options

## Related Issue

https://issues.redhat.com/browse/ACM-12973

## Changes Made

Updated CRD for restores.cluster.open-cluster-management.io to include 
includedResources
includedNamespaces
LabelSelector
OrLabelSelector

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
