### PR TITLE
 Add site config to the list of deployments for status

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -422,6 +422,9 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEn
 		nn = append(nn, types.NamespacedName{Name: "insights-client", Namespace: m.Namespace})
 		nn = append(nn, types.NamespacedName{Name: "insights-metrics", Namespace: m.Namespace})
 	}
+	if m.Enabled(operatorsv1.SiteConfig) {
+		nn = append(nn, types.NamespacedName{Name: "siteconfig-controller-manager", Namespace: m.Namespace})
+	}
 	if m.Enabled(operatorsv1.Search) {
 		nn = append(nn, types.NamespacedName{Name: "search-v2-operator-controller-manager", Namespace: m.Namespace})
 		nn = append(nn, types.NamespacedName{Name: "search-api", Namespace: m.Namespace})


### PR DESCRIPTION
# Description

Site config was previously missing from the list of deployments to be checked in the status check

## Related Issue

https://issues.redhat.com/browse/ACM-13731

## Changes Made

Added site config the list of conditionals in the function `ListDeploymentsForStatus`
