### PR TITLE
Add `acm-cli` console CLI download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ IMG ?= $(REGISTRY)/multiclusterhub-operator:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.20
+ENVTEST_K8S_VERSION = 1.30
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1064,6 +1064,9 @@ rules:
   - authorization.k8s.io
   resources:
   - uids
+  - userextras/authentication.kubernetes.io/credential-id
+  - userextras/authentication.kubernetes.io/node-name
+  - userextras/authentication.kubernetes.io/node-uid
   - userextras/authentication.kubernetes.io/pod-name
   - userextras/authentication.kubernetes.io/pod-uid
   verbs:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,11 +19,9 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"os"
 	"testing"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -40,15 +38,8 @@ func TestController(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
-var signalHandlerContext context.Context
-
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	// SetupSignalHandler can only be called once, so we'll save the
-	// context it returns and reuse it each time we start a new
-	// manager.
-	signalHandlerContext = ctrl.SetupSignalHandler()
 
 	os.Setenv("POD_NAMESPACE", "open-cluster-management")
 	os.Setenv("CRDS_PATH", "../pkg/templates/crds")

--- a/pkg/templates/charts/toggle/console/templates/acm-cli-consoleclidownload.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-consoleclidownload.yaml
@@ -1,0 +1,49 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  labels:
+    app: console-chart-v2
+    chart: "console-chart-{{ .Values.hubconfig.hubVersion }}"
+    component: console
+    subcomponent: acm-cli-downloads
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
+  name: acm-cli-downloads
+spec:
+  description: |
+    With the CLIs for Red Hat Advanced Cluster Management for Kubernetes (RHACM) you 
+    can enhance your multicluster experience at the terminal. This includes:
+    - `policytools`
+        - Interact with RHACM policies locally, including resolving templates locally.
+    - `PolicyGenerator`
+        - Build RHACM policies from Kubernetes manifest YAML files, which are 
+          provided through a `PolicyGenerator` manifest YAML file that is used to 
+          configure it. The Policy Generator is implemented as a Kustomize generator 
+          plug-in, allowing integration with GitOps.
+  displayName: "Advanced Cluster Management - {{ .Values.hubconfig.hubVersion }}"
+  links:
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/linux-amd64-policytools.tar.gz"
+      text: Download policytools for Linux for x86_64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/linux-arm64-policytools.tar.gz"
+      text: Download policytools for Linux for ARM64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/darwin-amd64-policytools.tar.gz"
+      text: Download policytools for Mac for x86_64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/darwin-arm64-policytools.tar.gz"
+      text: Download policytools for Mac for ARM64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/windows-amd64-policytools.zip"
+      text: Download policytools for Windows for x86_64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/windows-arm64-policytools.zip"
+      text: Download policytools for Windows for ARM64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/linux-amd64-PolicyGenerator.tar.gz"
+      text: Download PolicyGenerator for Linux for x86_64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/linux-arm64-PolicyGenerator.tar.gz"
+      text: Download PolicyGenerator for Linux for ARM64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/darwin-amd64-PolicyGenerator.tar.gz"
+      text: Download PolicyGenerator for Mac for x86_64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/darwin-arm64-PolicyGenerator.tar.gz"
+      text: Download PolicyGenerator for Mac for ARM64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/windows-amd64-PolicyGenerator.zip"
+      text: Download PolicyGenerator for Windows for x86_64
+    - href: "https://acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}/windows-arm64-PolicyGenerator.zip"
+      text: Download PolicyGenerator for Windows for ARM64

--- a/pkg/templates/charts/toggle/console/templates/acm-cli-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-deployment.yaml
@@ -1,0 +1,131 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    app: console-chart-v2
+    chart: "console-chart-{{ .Values.hubconfig.hubVersion }}"
+    component: console
+    subcomponent: acm-cli-downloads
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
+  name: acm-cli-downloads
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      subcomponent: acm-cli-downloads
+  template:
+    metadata:
+      labels:
+        subcomponent: acm-cli-downloads
+    spec:
+      containers:
+        - name: acm-cli-downloads
+          args:
+            - --secure=true
+          image: "{{ .Values.global.imageOverrides.acm_cli }}"
+          imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+              cpu: "50m"
+          ports:
+            - containerPort: 8443
+              name: downloads
+              protocol: TCP
+          volumeMounts:
+            - mountPath: "/var/run/acm-cli-cert"
+              name: acm-cli-cert
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              port: downloads
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              port: downloads
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+              - ALL
+      volumes:
+        - name: acm-cli-cert
+          secret:
+            secretName: acm-cli-cert
+      automountServiceAccountToken: false
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+      {{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.global.pullSecret  }}
+      imagePullSecrets:
+      - name: {{ .Values.global.pullSecret  }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+                - arm64
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - console
+                - key: component
+                  operator: In
+                  values:
+                  - console
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - console
+                - key: component
+                  operator: In
+                  values:
+                  - console

--- a/pkg/templates/charts/toggle/console/templates/acm-cli-route.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-route.yaml
@@ -1,0 +1,24 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: console-chart-v2
+    chart: "console-chart-{{ .Values.hubconfig.hubVersion }}"
+    component: console
+    subcomponent: acm-cli-downloads
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
+  name: acm-cli-downloads
+  namespace: "{{ .Values.global.namespace }}"
+spec:
+  host: "acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}"
+  port:
+    targetPort: https-8443
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: acm-cli-downloads
+  wildcardPolicy: None

--- a/pkg/templates/charts/toggle/console/templates/acm-cli-service.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: console-chart-v2
+    chart: "console-chart-{{ .Values.hubconfig.hubVersion }}"
+    component: console
+    subcomponent: acm-cli-downloads
+    release: console
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console-chart
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: acm-cli-cert
+  name: acm-cli-downloads
+spec:
+  ports:
+    - name: https-8443
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  sessionAffinity: None
+  selector:
+    subcomponent: acm-cli-downloads

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -13,10 +13,11 @@ import (
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	renderer "github.com/stolostron/multiclusterhub-operator/pkg/rendering"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const (
@@ -61,6 +62,8 @@ func main() {
 	// os.Setenv("DIRECTORY_OVERRIDE", "../../.git")
 	// defer os.Unsetenv("DIRECTORY_OVERRIDE")
 	os.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
+
+	ctrl.SetLogger(zap.New(zap.ConsoleEncoder()))
 
 	testMCH := &operatorv1.MultiClusterHub{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -31,6 +31,7 @@ var resources = []string{
 	"ClusterRoleBinding",
 	"ClusterRole",
 	"ConfigMap",
+	"ConsoleCLIDownload",
 	"ConsolePlugin",
 	"ConsoleQuickStart",
 	"CustomResourceDefinition",

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -114,7 +114,7 @@ package main
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-//+kubebuilder:rbac:groups=authentication.k8s.io;authorization.k8s.io,resources=uids;userextras/authentication.kubernetes.io/pod-name;userextras/authentication.kubernetes.io/pod-uid,verbs=impersonate
+//+kubebuilder:rbac:groups=authentication.k8s.io;authorization.k8s.io,resources=uids;userextras/authentication.kubernetes.io/credential-id;userextras/authentication.kubernetes.io/node-name;userextras/authentication.kubernetes.io/node-uid;userextras/authentication.kubernetes.io/pod-name;userextras/authentication.kubernetes.io/pod-uid,verbs=impersonate
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=create;delete
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -335,7 +335,7 @@ func GetTestImages() []string {
 		"cert_policy_controller", "config_policy_controller", "governance_policy_framework_addon",
 		"cluster_backup_controller", "console", "volsync_addon_controller", "multicluster_operators_application",
 		"multicloud_integrations", "multicluster_operators_channel", "multicluster_operators_subscription",
-		"multicluster_observability_operator", "cluster_permission", "siteconfig_operator", "submariner_addon",
+		"multicluster_observability_operator", "cluster_permission", "siteconfig_operator", "submariner_addon", "acm_cli",
 	}
 }
 

--- a/test/unit-tests/crds/consoleclidownloads.yaml
+++ b/test/unit-tests/crds/consoleclidownloads.yaml
@@ -1,0 +1,75 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleclidownloads.console.openshift.io
+spec:
+  conversion:
+    strategy: None
+  group: console.openshift.io
+  names:
+    kind: ConsoleCLIDownload
+    listKind: ConsoleCLIDownloadList
+    plural: consoleclidownloads
+    singular: consoleclidownload
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleCLIDownload is an extension for configuring openshift
+          web console command line interface (CLI) downloads. \n Compatibility level
+          2: Stable within a major release for a minimum of 9 months or 3 minor releases
+          (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleCLIDownloadSpec is the desired cli download configuration.
+            properties:
+              description:
+                description: description is the description of the CLI download (can
+                  include markdown).
+                type: string
+              displayName:
+                description: displayName is the display name of the CLI download.
+                type: string
+              links:
+                description: links is a list of objects that provide CLI download
+                  link details.
+                items:
+                  properties:
+                    href:
+                      description: href is the absolute secure URL for the link (must
+                        use https)
+                      pattern: ^https://
+                      type: string
+                    text:
+                      description: text is the display text for the link
+                      type: string
+                  required:
+                  - href
+                  type: object
+                type: array
+            required:
+            - description
+            - displayName
+            - links
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status: {}

--- a/test/unit-tests/crds/route.yaml
+++ b/test/unit-tests/crds/route.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: routes.route.openshift.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: route.openshift.io
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Host
+          type: string
+          jsonPath: .status.ingress[0].host
+        - name: Admitted
+          type: string
+          jsonPath: .status.ingress[0].conditions[?(@.type=="Admitted")].status
+        - name: Service
+          type: string
+          jsonPath: .spec.to.name
+        - name: TLS
+          type: string
+          jsonPath: .spec.tls.type
+      subresources:
+        # enable spec/status
+        status: {}
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: routes
+    # singular name to be used as an alias on the CLI and for display
+    singular: route
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Route

--- a/test/unit-tests/crds/search.yaml
+++ b/test/unit-tests/crds/search.yaml
@@ -2,10 +2,15 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.3
+  generation: 1
+  labels:
+    installer.name: multiclusterhub
+    installer.namespace: open-cluster-management
   name: searches.search.open-cluster-management.io
 spec:
+  conversion:
+    strategy: None
   group: search.open-cluster-management.io
   names:
     kind: Search
@@ -17,7 +22,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Search is the Schema for the searches API
+        description: Search is the schema for the searches API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,15 +37,16 @@ spec:
           metadata:
             type: object
           spec:
-            description: SearchSpec defines the desired state of Search
+            description: SearchSpec defines the desired state of Search.
             properties:
               availabilityConfig:
-                description: 'Specifies deployment replication for improved availability.
-                  Options are: Basic and High (default)'
+                description: '[PLACEHOLDER, NOT IMPLEMENTED] Specifies deployment
+                  replication for improved availability. Options are: Basic and High
+                  (default)'
                 type: string
               dbConfig:
-                description: Configmap name contains parameters to override default
-                  db parameters
+                description: The config map name contains parameters to override default
+                  database parameters.
                 type: string
               dbStorage:
                 description: Storage configuration for the database.
@@ -57,27 +63,167 @@ spec:
                     type: string
                 type: object
               deployments:
-                description: Customization for search deployments
+                description: Customization for search deployments.
                 properties:
                   collector:
-                    description: Configuration for collector Deployment
+                    description: Configuration for the collector.
                     properties:
                       arguments:
                         description: Container Arguments
                         items:
                           type: string
                         type: array
+                      envVar:
+                        description: Container Env variables
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       imageOverride:
                         description: Image_override
                         type: string
                       replicaCount:
-                        description: Number of pod instances for deployment
+                        description: Number of pod instances for the deployment.
                         format: int32
                         minimum: 1
                         type: integer
                       resources:
-                        description: Compute Resources required by deployment
+                        description: Compute resources required by deployment.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -99,29 +245,169 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                     type: object
                   database:
-                    description: Configuration for DB Deployment
+                    description: Configuration for the database.
                     properties:
                       arguments:
                         description: Container Arguments
                         items:
                           type: string
                         type: array
+                      envVar:
+                        description: Container Env variables
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       imageOverride:
                         description: Image_override
                         type: string
                       replicaCount:
-                        description: Number of pod instances for deployment
+                        description: Number of pod instances for the deployment.
                         format: int32
                         minimum: 1
                         type: integer
                       resources:
-                        description: Compute Resources required by deployment
+                        description: Compute resources required by deployment.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -143,29 +429,169 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                     type: object
                   indexer:
-                    description: Configuration for indexer Deployment
+                    description: Configuration for the indexer.
                     properties:
                       arguments:
                         description: Container Arguments
                         items:
                           type: string
                         type: array
+                      envVar:
+                        description: Container Env variables
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       imageOverride:
                         description: Image_override
                         type: string
                       replicaCount:
-                        description: Number of pod instances for deployment
+                        description: Number of pod instances for the deployment.
                         format: int32
                         minimum: 1
                         type: integer
                       resources:
-                        description: Compute Resources required by deployment
+                        description: Compute resources required by deployment.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -187,29 +613,169 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                     type: object
                   queryapi:
-                    description: Configuration for api Deployment
+                    description: Configuration for Query API.
                     properties:
                       arguments:
                         description: Container Arguments
                         items:
                           type: string
                         type: array
+                      envVar:
+                        description: Container Env variables
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
                       imageOverride:
                         description: Image_override
                         type: string
                       replicaCount:
-                        description: Number of pod instances for deployment
+                        description: Number of pod instances for the deployment.
                         format: int32
                         minimum: 1
                         type: integer
                       resources:
-                        description: Compute Resources required by deployment
+                        description: Compute resources required by deployment.
                         properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -231,15 +797,16 @@ spec:
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
                               specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                     type: object
                 type: object
               externalDBInstance:
-                description: Kubernetes secret name containing user provided db secret
-                  Secret should contain connection parameters [db_host, db_port, db_user,
-                  db_password, db_name, ca_cert] Not supported for development preview.
+                description: '[PLACEHOLDER, NOT IMPLEMENTED] Kubernetes secret name
+                  containing user provided db secret Secret should contain connection
+                  parameters [db_host, db_port, db_user, db_password, db_name, ca_cert]
+                  Not supported for development preview.'
                 type: string
               imagePullPolicy:
                 description: ImagePullPolicy
@@ -250,11 +817,53 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector to schedule on nodes with matching labels
+                description: Define the nodes that you want to schedule with matching
+                  labels.
                 type: object
+              tolerations:
+                description: Define tolerations to schedule pods on nodes with matching
+                  taints.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
             type: object
           status:
-            description: SearchStatus defines the observed state of Search
+            description: SearchStatus defines the observed state of Search.
             properties:
               conditions:
                 description: Conditions
@@ -262,13 +871,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -327,7 +935,7 @@ spec:
                   type: object
                 type: array
               db:
-                description: Database used by search
+                description: Database used by Search.
                 type: string
               storage:
                 description: Storage used by database


### PR DESCRIPTION
# Description

Add an `acm-cli` chart to add a plugin to download CLIs from the OCP console.

## Related Issue

https://issues.redhat.com/browse/ACM-12551

## Changes Made

Adds a new chart with Deployment, Route, Service, and ConsoleCLIDownload manifests to deploy the `acm-cli` image. The image is a Golang HTTP server that serves the files made available in the console via the ConsoleCLIDownload plugin.

## Screenshots (if applicable)

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/9420fa18-fa2b-42af-bf3c-64ce160e43a2">

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

--

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
