### PR TITLE
[ACM-10559] Updated client to disable caching for packagemanifests

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	consolev1 "github.com/openshift/api/operator/v1"
 
@@ -437,7 +436,7 @@ func (r *MultiClusterHubReconciler) ensureMCESubscription(ctx context.Context, m
 		ctlSrc, err = multiclusterengine.GetCatalogSource(r.Client)
 		if err != nil {
 			r.Log.Info("Failed to find a suitable catalogsource.", "error", err)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -185,6 +185,7 @@ func main() {
 					&rbacv1.RoleBinding{},
 					&corev1.ConfigMap{},
 					&corev1.ServiceAccount{},
+					&olmapi.PackageManifest{},
 				},
 			},
 		},


### PR DESCRIPTION
# Description

In #1447 we updated the functionality around getting the `packagemanifest` and determining the `catalogsource` based on `priority`. Within that PR we changed one of the funcs for using an `uncachedClient` to a regular `client`, which caused the operator to fail when trying to verify the `packagemanifests` and `catalogsource`. This is because the regular client will automatically try to watch resources; however, `packagemanifests` do not support `watch` for it's API group. 

## Related Issue

https://issues.redhat.com/browse/ACM-10559

## Changes Made

Updated client to disable caching for `packagemanifest` resources.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [x] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [x] Approved by at least one reviewer.
- [x] Merged into the main/master branch.
