### PR TITLE
[ACM-15080] Updated requeue logic for finalizing resources

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -1456,15 +1456,19 @@ func (r *MultiClusterHubReconciler) ingressDomain(
 }
 
 func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operatorv1.MultiClusterHub, ocpConsole,
-	isSTSEnabled bool,
-) error {
+	isSTSEnabled bool) error {
 	if err := r.cleanupAppSubscriptions(reqLogger, m); err != nil {
 		return err
 	}
 
 	for _, c := range operatorv1.MCHComponents {
-		if _, err := r.ensureNoComponent(context.TODO(), m, c, r.CacheSpec, isSTSEnabled); err != nil {
+		result, err := r.ensureNoComponent(context.TODO(), m, c, r.CacheSpec, isSTSEnabled)
+		if err != nil {
 			return err
+		}
+
+		if result != (ctrl.Result{}) {
+			return errors.NewBadRequest(fmt.Sprintf("Requeue needed for component: %v", c))
 		}
 	}
 

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -96,7 +96,7 @@ func removeSubmarinerFinalizer(k8sClient client.Client, reconciler *MultiCluster
 	}
 }
 
-func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler, mchoDeployment *appsv1.Deployment) {
+func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler, mchDeployment *appsv1.Deployment) {
 	By("Applying prereqs")
 	ctx := context.Background()
 	ApplyPrereqs(k8sClient)
@@ -106,7 +106,7 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 	// To skip ensureKlusterletAddonConfig
 	mch.Spec.DisableHubSelfManagement = true
 	Expect(k8sClient.Create(ctx, &mch)).Should(Succeed())
-	Expect(k8sClient.Create(ctx, mchoDeployment)).Should(Succeed())
+	Expect(k8sClient.Create(ctx, mchDeployment)).Should(Succeed())
 
 	By("Ensuring MCH is created")
 	createdMCH := &operatorv1.MultiClusterHub{}
@@ -209,7 +209,7 @@ func RunningState(k8sClient client.Client, reconciler *MultiClusterHubReconciler
 	Expect(clusterConsole.Spec.Plugins).To(ContainElement("acm"))
 }
 
-func PreexistingMCE(k8sClient client.Client, reconciler *MultiClusterHubReconciler, mchoDeployment *appsv1.Deployment) {
+func PreexistingMCE(k8sClient client.Client, reconciler *MultiClusterHubReconciler, mchDeployment *appsv1.Deployment) {
 	By("Applying prereqs")
 	ctx := context.Background()
 	ApplyPrereqs(k8sClient)
@@ -245,7 +245,7 @@ func PreexistingMCE(k8sClient client.Client, reconciler *MultiClusterHubReconcil
 	mch.Spec.DisableHubSelfManagement = true
 	mch.Spec.ImagePullSecret = "testsecret"
 	Expect(k8sClient.Create(ctx, &mch)).Should(Succeed())
-	Expect(k8sClient.Create(ctx, mchoDeployment)).Should(Succeed())
+	Expect(k8sClient.Create(ctx, mchDeployment)).Should(Succeed())
 
 	By("Ensuring MCH is created")
 	createdMCH := &operatorv1.MultiClusterHub{}
@@ -316,7 +316,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 		templateMetadata metav1.ObjectMeta
 		envs             []corev1.EnvVar
 		containers       []corev1.Container
-		mchoDeployment   *appsv1.Deployment
+		mchDeployment    *appsv1.Deployment
 		reconciler       *MultiClusterHubReconciler
 	)
 
@@ -355,7 +355,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		mchoDeployment = &appsv1.Deployment{
+		mchDeployment = &appsv1.Deployment{
 			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: mchName, Namespace: mchNamespace},
 			Spec: appsv1.DeploymentSpec{
@@ -488,46 +488,41 @@ var _ = Describe("MultiClusterHub controller", func() {
 		})).To(Succeed())
 	})
 
+	os.Setenv("DIRECTORY_OVERRIDE", "../pkg/templates")
+	defer os.Unsetenv("DIRECTORY_OVERRIDE")
+
+	os.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
+	defer os.Unsetenv("ACM_HUB_OCP_VERSION")
+
 	Context("When updating Multiclusterhub status", func() {
 		It("Should get to a running state", func() {
-			os.Setenv("DIRECTORY_OVERRIDE", "../pkg/templates")
-			defer os.Unsetenv("DIRECTORY_OVERRIDE")
 			os.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
 			defer os.Unsetenv("OPERATOR_PACKAGE")
-			RunningState(k8sClient, reconciler, mchoDeployment)
+			RunningState(k8sClient, reconciler, mchDeployment)
 		})
 
 		It("Should Manage Preexisting MCE", func() {
-			os.Setenv("DIRECTORY_OVERRIDE", "../pkg/templates")
-			defer os.Unsetenv("DIRECTORY_OVERRIDE")
 			os.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
 			defer os.Unsetenv("OPERATOR_PACKAGE")
-			PreexistingMCE(k8sClient, reconciler, mchoDeployment)
+			PreexistingMCE(k8sClient, reconciler, mchDeployment)
 		})
 
 		It("Should get to a running state in Community Mode", func() {
-			os.Setenv("DIRECTORY_OVERRIDE", "../pkg/templates")
-			defer os.Unsetenv("DIRECTORY_OVERRIDE")
 			os.Setenv("OPERATOR_PACKAGE", "stolostron")
 			defer os.Unsetenv("OPERATOR_PACKAGE")
-			os.Setenv("ACM_HUB_OCP_VERSION", "4.12.0")
-			defer os.Unsetenv("ACM_HUB_OCP_VERSION")
-			RunningState(k8sClient, reconciler, mchoDeployment)
+			RunningState(k8sClient, reconciler, mchDeployment)
 		})
 
 		It("Should Manage Preexisting MCE in Community Mode", func() {
-			os.Setenv("DIRECTORY_OVERRIDE", "../pkg/templates")
-			defer os.Unsetenv("DIRECTORY_OVERRIDE")
 			os.Setenv("OPERATOR_PACKAGE", "stolostron")
 			defer os.Unsetenv("OPERATOR_PACKAGE")
-			PreexistingMCE(k8sClient, reconciler, mchoDeployment)
+			PreexistingMCE(k8sClient, reconciler, mchDeployment)
 		})
 
 		It("Should allow MCH components to be optional", func() {
-			os.Setenv("DIRECTORY_OVERRIDE", "../pkg/templates")
-			defer os.Unsetenv("DIRECTORY_OVERRIDE")
 			os.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
 			defer os.Unsetenv("OPERATOR_PACKAGE")
+
 			By("Applying prereqs")
 			ctx := context.Background()
 			ApplyPrereqs(k8sClient)
@@ -538,7 +533,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 			mch.Spec.DisableHubSelfManagement = true
 			mch.Disable(operatorv1.Appsub)
 			Expect(k8sClient.Create(ctx, &mch)).Should(Succeed())
-			Expect(k8sClient.Create(ctx, mchoDeployment)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, mchDeployment)).Should(Succeed())
 
 			By("Ensuring MCH is created")
 			createdMCH := &operatorv1.MultiClusterHub{}
@@ -776,13 +771,10 @@ var _ = Describe("MultiClusterHub controller", func() {
 
 	Context("When managing deployments", func() {
 		It("Creates and removes a deployment", func() {
-			os.Setenv("DIRECTORY_OVERRIDE", "../pkg/templates")
-			defer os.Unsetenv("DIRECTORY_OVERRIDE")
 			By("Applying prereqs")
 			ApplyPrereqs(k8sClient)
 			ctx := context.Background()
 
-			By("Ensuring Insights")
 			mch := resources.SpecMCH()
 			testImages := map[string]string{}
 			for _, v := range utils.GetTestImages() {
@@ -794,6 +786,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 				TemplateOverrides: map[string]string{},
 			}
 
+			By("Ensuring Insights")
 			result, err := reconciler.ensureComponent(ctx, mch, operatorv1.Insights, testCacheSpec, false)
 			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).To(BeNil())
@@ -949,36 +942,6 @@ var _ = Describe("MultiClusterHub controller", func() {
 			result, err = reconciler.ensureOpenShiftNamespaceLabel(ctx, mch2)
 			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(BeNil())
-		})
-	})
-
-	Context("When managing deployments", func() {
-		It("Creates and removes a deployment", func() {
-			os.Setenv("DIRECTORY_OVERRIDE", "../../pkg/templates")
-			defer os.Unsetenv("DIRECTORY_OVERRIDE")
-			By("Applying prereqs")
-			ApplyPrereqs(k8sClient)
-			ctx := context.Background()
-
-			By("Ensuring Insights")
-			mch := resources.SpecMCH()
-			testImages := map[string]string{}
-			for _, v := range utils.GetTestImages() {
-				testImages[v] = "quay.io/test/test:Test"
-			}
-
-			testCacheSpec := CacheSpec{
-				ImageOverrides:    testImages,
-				TemplateOverrides: map[string]string{},
-			}
-
-			result, err := reconciler.ensureComponent(ctx, mch, operatorv1.Appsub, testCacheSpec, false)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 20000000000}))
-			Expect(err).To(BeNil())
-
-			result, err = reconciler.ensureNoComponent(ctx, mch, operatorv1.Appsub, testCacheSpec, false)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 20000000000}))
-			Expect(err).To(BeNil())
 		})
 	})
 

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -53,7 +53,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 60
+	timeout  = time.Second * 90
 	interval = time.Millisecond * 250
 
 	mchName      = "multiclusterhub-operator"

--- a/main.go
+++ b/main.go
@@ -186,6 +186,7 @@ func main() {
 					&corev1.ConfigMap{},
 					&corev1.ServiceAccount{},
 					&olmapi.PackageManifest{},
+					&ocmapi.ClusterManagementAddOn{},
 				},
 			},
 		},


### PR DESCRIPTION
# Description

When the MCH resources are being finalized upon uninstall, there was a possibility for the `clusterRoles` and `clusterRoleBindings` resources to be removed before the MCH operands could clean up any finalizers or other resources. This PR will add another condition to check if there was a requeue result returned, then re-reconcile.

## Related Issue

https://issues.redhat.com/browse/ACM-15080

## Changes Made

Added requeue result condition for finalizing hub resources.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
