### PR TITLE
[ACM-15448] Updated client to disable caching for ClusterServiceVersion resources

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,6 +187,7 @@ func main() {
 					&corev1.ServiceAccount{},
 					&olmapi.PackageManifest{},
 					&ocmapi.ClusterManagementAddOn{},
+					&subv1alpha1.ClusterServiceVersion{},
 				},
 			},
 		},


### PR DESCRIPTION
# Description

When a user has a large cluster with a lot of operator running, there is a chance where the MCH operator will hit a limit when caching the `ClusterServiceVersion` resources. This PR will disable the caching for the CSV resources. Since we only need to get the MCE CSV resource, we can disable caching and watching for all CSV resources under the covers.

```bash
W1107 17:45:46.730207 1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.3/tools/cache/reflector.go:232: failed to list *v1alpha1.ClusterServiceVersion: stream error when reading response body, may be caused by closed connection. Please retry. Original error: stream error: stream ID 23079; INTERNAL_ERROR; received from peer
E1107 17:45:46.730257 1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.3/tools/cache/reflector.go:232: Failed to watch *v1alpha1.ClusterServiceVersion: failed to list *v1alpha1.ClusterServiceVersion: stream error when reading response body, may be caused by closed connection. Please retry. Original error: stream error: stream ID 23079; INTERNAL_ERROR; received from peer 
```

## Related Issue

https://issues.redhat.com/browse/ACM-15448

## Changes Made

Added `ClusterServiceVersion` resources to the disabled cached resources.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
