### PR TITLE
[ACM-15851] Updated MCE CSV conversion to use reconciler scheme convert

### DIFF
--- a/controllers/finalizers.go
+++ b/controllers/finalizers.go
@@ -104,23 +104,26 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 		if err == nil { // CSV Exists
 			err = r.Client.Delete(ctx, csv)
 			if err != nil && !errors.IsNotFound(err) {
+				log.Error(err, "Failed to delete MCE CSV", "Name", csv.GetName(), "Namespace",
+					csv.GetNamespace())
 				return err
 			}
-			err = r.Client.Get(ctx,
-				types.NamespacedName{Name: csv.GetName(), Namespace: namespace},
-				csv)
+
+			err = r.Client.Get(ctx, types.NamespacedName{Name: csv.GetName(), Namespace: namespace}, csv)
 			if err == nil {
 				return fmt.Errorf("CSV has not yet been terminated")
 			}
 		}
 
-		err = r.Client.Get(ctx,
-			types.NamespacedName{Name: mceSub.Name, Namespace: namespace},
-			&subv1alpha1.Subscription{})
-		if err == nil {
+		err = r.Client.Get(ctx, types.NamespacedName{
+			Name: mceSub.Name, Namespace: namespace}, &subv1alpha1.Subscription{})
 
+		if err == nil {
 			err = r.Client.Delete(ctx, mceSub)
 			if err != nil && !errors.IsNotFound(err) {
+				log.Error(err, "Failed to delete MCE Subscription", "Name", mceSub.GetName(), "Namespace",
+					mceSub.GetNamespace())
+
 				return err
 			}
 			return fmt.Errorf("subscription has not yet been terminated")
@@ -129,6 +132,7 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 
 	err = r.Client.Delete(ctx, multiclusterengine.OperatorGroup())
 	if err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "Failed to delete MCE OperatorGroup", "Name", multiclusterengine.OperatorGroup().GetName())
 		return err
 	}
 
@@ -146,6 +150,7 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 		r.Log.Info("MCE shares namespace with MCH; skipping namespace termination")
 	}
 
+	log.Info("MultiClusterEngine finalized")
 	return nil
 }
 func (r *MultiClusterHubReconciler) cleanupNamespaces(reqLogger logr.Logger, m *operatorsv1.MultiClusterHub) error {

--- a/controllers/finalizers.go
+++ b/controllers/finalizers.go
@@ -71,6 +71,7 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 	if err != nil && !apimeta.IsNoMatchError(err) {
 		return err
 	}
+
 	if mce != nil && !multiclusterengine.MCECreatedByMCH(mce, m) {
 		r.Log.Info("Preexisting MCE exists, skipping MCE finalization")
 		return nil
@@ -93,6 +94,7 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 	if err != nil {
 		return err
 	}
+
 	if mceSub != nil && !multiclusterengine.CreatedByMCH(mceSub, m) {
 		r.Log.Info("Preexisting MCE subscription exists, skipping MCE subscription finalization")
 		return nil

--- a/controllers/finalizers_test.go
+++ b/controllers/finalizers_test.go
@@ -2,12 +2,18 @@ package controllers
 
 import (
 	"context"
+	"os"
 	"testing"
 
+	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	resources "github.com/stolostron/multiclusterhub-operator/test/unit-tests"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBackupNamespace(t *testing.T) {
@@ -73,20 +79,49 @@ func TestBackupNamespaceUnstructured(t *testing.T) {
 func Test_cleanupMultiClusterEngine(t *testing.T) {
 	tests := []struct {
 		name string
+		csv  subv1alpha1.ClusterServiceVersion
+		ns   corev1.Namespace
 		mch  operatorv1.MultiClusterHub
 		mce  backplanev1.MultiClusterEngine
+		og   v1.OperatorGroup
+		sub  subv1alpha1.Subscription
 		want bool
 	}{
 		{
 			name: "should cleanup MultiClusterEngine",
-			mce:  resources.EmptyMCE(),
-			mch:  resources.EmptyMCH(),
+			csv: subv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multicluster-engine.v2.8.0",
+					Namespace: "multicluster-engine",
+				},
+			},
+			ns:  corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "multicluster-engine"}},
+			mce: resources.EmptyMCE(),
+			mch: resources.EmptyMCH(),
+			og:  *multiclusterengine.OperatorGroup(),
+			sub: subv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mce-sub",
+					Namespace: "multicluster-engine",
+					Labels: map[string]string{
+						utils.MCEManagedByLabel: "true",
+					},
+				},
+				Status: subv1alpha1.SubscriptionStatus{
+					CurrentCSV: "multicluster-engine.v2.8.0",
+				},
+			},
 			want: true,
 		},
 	}
 
 	registerScheme()
 	for _, tt := range tests {
+		os.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
+		defer func() {
+			os.Unsetenv("OPERATOR_PACKAGE")
+		}()
+
 		t.Run(tt.name, func(t *testing.T) {
 			if err := recon.Client.Create(context.TODO(), &tt.mch); err != nil {
 				t.Errorf("failed to create MultiClusterHub: %v", err)
@@ -97,8 +132,31 @@ func Test_cleanupMultiClusterEngine(t *testing.T) {
 				"installer.namespace":   tt.mch.GetNamespace(),
 				utils.MCEManagedByLabel: "true",
 			}
+
+			tt.sub.Labels = map[string]string{
+				"installer.name":        tt.mch.GetName(),
+				"installer.namespace":   tt.mch.GetNamespace(),
+				utils.MCEManagedByLabel: "true",
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.ns); err != nil {
+				t.Errorf("failed to create Namespace: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.sub); err != nil {
+				t.Errorf("failed to create Subscription: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.csv); err != nil {
+				t.Errorf("failed to create CSV: %v", err)
+			}
+
 			if err := recon.Client.Create(context.TODO(), &tt.mce); err != nil {
 				t.Errorf("failed to create MultiClusterEngine: %v", err)
+			}
+
+			if err := recon.Client.Create(context.TODO(), &tt.og); err != nil {
+				t.Errorf("failed to create OperatorGroup: %v", err)
 			}
 
 			// If MCE exists the first time it will return an error.
@@ -106,6 +164,17 @@ func Test_cleanupMultiClusterEngine(t *testing.T) {
 				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
 			}
 
+			// If the CSV exists, it will return an error
+			if err := recon.cleanupMultiClusterEngine(log, &tt.mch); err == nil {
+				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
+			}
+
+			// If the Subscription exists, it will return an error
+			if err := recon.cleanupMultiClusterEngine(log, &tt.mch); err == nil {
+				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
+			}
+
+			// If the OperatorGroup exists, it will return an error
 			if err := recon.cleanupMultiClusterEngine(log, &tt.mch); err != nil {
 				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
 			}

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -65,7 +65,7 @@ var (
 	ctrlCancel context.CancelFunc
 	recon      = MultiClusterHubReconciler{
 		Client: fake.NewClientBuilder().Build(),
-		Scheme: runtime.NewScheme(),
+		Scheme: scheme.Scheme,
 	}
 )
 

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -63,7 +63,10 @@ const (
 var (
 	ctrlCtx    context.Context
 	ctrlCancel context.CancelFunc
-	recon      = MultiClusterHubReconciler{Client: fake.NewClientBuilder().Build()}
+	recon      = MultiClusterHubReconciler{
+		Client: fake.NewClientBuilder().Build(),
+		Scheme: runtime.NewScheme(),
+	}
 )
 
 func ApplyPrereqs(k8sClient client.Client) {

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -916,7 +916,7 @@ func Test_ComponentsAreRunning(t *testing.T) {
 			}
 
 			if err := recon.Client.Create(context.TODO(), &tt.mce); err != nil {
-				t.Errorf("failed to create clusterserviceversion: %v", err)
+				t.Errorf("failed to create multiclusterengine: %v", err)
 			}
 
 			if err := recon.Client.Create(context.TODO(), &tt.deploy); err != nil {


### PR DESCRIPTION
# Description

When we disabled the caching for the `ClusterServiceVersion` resource, that caused issues when attempting to convert the MCE resource to a `unstructured.unstructured{}` resource. The issue that was occurring was that the `Kind` and `ApiVersion` of the resource were being dropped due to the resource being uncached. To resolve this, we can use the kube scheme that our operator registers during runtime to handle the conversion.

## Related Issue

https://issues.redhat.com/browse/ACM-15851

## Changes Made

Update MCE CSV conversion func.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
