### PR TITLE
[ACM-15851] Updated MCE CSV conversion to use reconciler scheme convert

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -556,11 +556,13 @@ func (r *MultiClusterHubReconciler) GetCSVFromSubscription(sub *subv1alpha1.Subs
 	if err != nil {
 		return nil, err
 	}
-	csv, err := runtime.DefaultUnstructuredConverter.ToUnstructured(mceCSV)
-	if err != nil {
+
+	csv := &unstructured.Unstructured{}
+	if err := r.Scheme.Convert(mceCSV, csv, nil); err != nil {
 		return nil, err
 	}
-	return &unstructured.Unstructured{Object: csv}, nil
+
+	return csv, nil
 }
 
 // mergeErrors combines errors into a single string

--- a/controllers/finalizers.go
+++ b/controllers/finalizers.go
@@ -146,6 +146,7 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 		r.Log.Info("MCE shares namespace with MCH; skipping namespace termination")
 	}
 
+	log.Info("MultiClusterEngine finalized")
 	return nil
 }
 func (r *MultiClusterHubReconciler) cleanupNamespaces(reqLogger logr.Logger, m *operatorsv1.MultiClusterHub) error {

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -63,7 +63,10 @@ const (
 var (
 	ctrlCtx    context.Context
 	ctrlCancel context.CancelFunc
-	recon      = MultiClusterHubReconciler{Client: fake.NewClientBuilder().Build()}
+	recon      = MultiClusterHubReconciler{
+		Client: fake.NewClientBuilder().Build(),
+		Scheme: scheme.Scheme,
+	}
 )
 
 func ApplyPrereqs(k8sClient client.Client) {

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -916,7 +916,7 @@ func Test_ComponentsAreRunning(t *testing.T) {
 			}
 
 			if err := recon.Client.Create(context.TODO(), &tt.mce); err != nil {
-				t.Errorf("failed to create clusterserviceversion: %v", err)
+				t.Errorf("failed to create multiclusterengine: %v", err)
 			}
 
 			if err := recon.Client.Create(context.TODO(), &tt.deploy); err != nil {


### PR DESCRIPTION
# Description

When we disabled the caching for the `ClusterServiceVersion` resource, that caused issues when attempting to convert the MCE resource to a `unstructured.unstructured{}` resource. The issue that was occurring was that the `Kind` and `ApiVersion` of the resource were being dropped due to the resource being uncached. To resolve this, we can use the kube scheme that our operator registers during runtime to handle the conversion.

## Related Issue

https://issues.redhat.com/browse/ACM-15851

## Changes Made

Update MCE CSV conversion func.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
