### PR TITLE
fix DataUploader ns and Backup vmUID annotations

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
@@ -190,7 +190,7 @@ spec:
                         {{ `{{- end }}` }}
                         {{ `{{ if not (contains $vms.metadata.uid $vms_uids) }}` }}
                           {{ `{{- /* add VM uid if not already in the vms_uids  */ -}}` }}
-                          {{ `{{- $vms_uids = (cat ((cat $vms_uids $vms.metadata.uid "#" $vms.metadata.namespace "--" $vms.metadata.name) | replace " " "") " ") }}` }}
+                          {{ `{{- $vms_uids = (cat ((cat $vms_uids $vms.metadata.uid "#" $vms.metadata.namespace "--" $vms.metadata.name) | replace " " "") "*") | replace " " "" }}` }}
                         {{ `{{- end }}` }}
                       {{ `{{- end }}` }}
                     {{ `{{- end }}` }}
@@ -208,7 +208,7 @@ spec:
                             cluster.open-cluster-management.io/backup-cluster: {{ `{{ fromClusterClaim "id.openshift.io" }}` }}
                             cluster.open-cluster-management.io/backup-schedule-type: kubevirt
                           annotations:
-                            {{ `{{- range $vms_uid := split " " $vms_uids }}` }}
+                            {{ `{{- range $vms_uid := split "*" $vms_uids }}` }}
                               {{ `{{ if not (eq $vms_uid "") }}` }}
                                 {{ `{{- $vms_data := splitn "#" 2 $vms_uid }}` }}
                                 {{ `{{- $vm_uid := $vms_data._0 }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
@@ -133,6 +133,8 @@ spec:
                   name: {{ `{{ $restoreName }}` }}
                   namespace: {{ `{{ $ns }}` }}
                 spec:
+                  namespaceMapping:
+                    open-cluster-management-backup: {{ `{{ $ns }} ` }}              
                   backupName: {{ `{{ $backupName }}` }}
                   restorePVs: true
                   {{ `{{ if not (eq $vms_ns " ") }}` }}


### PR DESCRIPTION
# Description

There is an issue with the DataUploader on restore if velero is installed in a different namespace on the backup cluster vs restore cluster. There is a workaround provided by the OADP team for that, added this here ; https://redhat-internal.slack.com/archives/C0144ECKUJ0/p1736274571133809?thread_ts=1736269804.273929&cid=C0144ECKUJ0
Also fixed the backup annotation for vmuid if more than one vm is backed up

## Related Issue

https://issues.redhat.com/browse/ACM-16218

## Changes Made

Updated restore policy and added a namespaceMapping
Updated Backup policy and fixed the vmUId parse when multiple vms are backed up by the same schedule

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
