### PR TITLE
[ACM-16805] Fixed regression for template resource patching

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -524,7 +524,7 @@ func (r *MultiClusterHubReconciler) waitForMCEReady(ctx context.Context) (ctrl.R
 		err = version.ValidMCEVersion(existingMCE.Status.CurrentVersion)
 	}
 	if err != nil {
-		return ctrl.Result{RequeueAfter: resyncPeriod}, fmt.Errorf("MCE version requirement not met: %w", err)
+		return ctrl.Result{}, fmt.Errorf("MCE version requirement not met: %w", err)
 	}
 	return ctrl.Result{}, nil
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -56,7 +56,7 @@ type CacheSpec struct {
 }
 
 func (r *MultiClusterHubReconciler) ensureNoNamespace(m *operatorv1.MultiClusterHub, u *unstructured.Unstructured) (ctrl.Result, error) {
-	subLog := r.Log.WithValues("Name", u.GetName(), "Kind", u.GetKind())
+	subLog := r.Log.WithValues("Kind", u.GetKind(), "Name", u.GetName())
 	gone, err := r.uninstall(m, u)
 	if err != nil {
 		subLog.Error(err, "Failed to uninstall namespace")
@@ -70,7 +70,7 @@ func (r *MultiClusterHubReconciler) ensureNoNamespace(m *operatorv1.MultiCluster
 }
 
 func (r *MultiClusterHubReconciler) ensureUnstructuredResource(m *operatorv1.MultiClusterHub, u *unstructured.Unstructured) (ctrl.Result, error) {
-	obLog := r.Log.WithValues("Namespace", u.GetNamespace(), "Name", u.GetName(), "Kind", u.GetKind())
+	obLog := r.Log.WithValues("Namespace", u.GetNamespace(), "Kind", u.GetKind(), "Name", u.GetName())
 
 	found := &unstructured.Unstructured{}
 	found.SetGroupVersionKind(u.GroupVersionKind())

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -773,7 +773,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 				if err := r.Client.Create(ctx, template, &client.CreateOptions{}); err != nil {
 					return r.logAndSetCondition(err, "failed to create resource", template, m)
 				}
-				log.Info("Creating resource", "Name", template.GetName(), "Kind", template.GetKind())
+				log.Info("Creating resource", "Kind", template.GetKind(), "Name", template.GetName())
 			} else {
 				return r.logAndSetCondition(err, "failed to get resource", existing, m)
 			}
@@ -1256,7 +1256,7 @@ func (r *MultiClusterHubReconciler) deleteTemplate(ctx context.Context, m *opera
 		log.Error(err, "Failed to delete template")
 		return ctrl.Result{}, err
 	} else {
-		r.Log.Info("Finalizing template... Deleting resource", "Name", template.GetName(), "Kind", template.GetKind())
+		r.Log.Info("Finalizing template... Deleting resource", "Kind", template.GetKind(), "Name", template.GetName())
 	}
 	return ctrl.Result{}, nil
 }
@@ -1797,8 +1797,8 @@ func (r *MultiClusterHubReconciler) ensureResourceVersionAlignment(template *uns
 func (r *MultiClusterHubReconciler) logAndSetCondition(err error, message string,
 	template *unstructured.Unstructured, m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 
-	log.Error(err, message, "Name", template.GetName(), "Kind", template.GetKind())
-	wrappedError := pkgerrors.Wrapf(err, "%s Name: %s Kind: %s", message, template.GetName(), template.GetKind())
+	log.Error(err, message, "Kind", template.GetKind(), "Name", template.GetName())
+	wrappedError := pkgerrors.Wrapf(err, "%s Kind: %s Name: %s", message, template.GetName(), template.GetKind())
 
 	condType := fmt.Sprintf("%v: %v (Kind:%v)", operatorv1.ComponentFailure, template.GetName(),
 		template.GetKind())

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -445,7 +445,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	result, err = r.waitForMCEReady(ctx)
-	if result != (ctrl.Result{}) {
+	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}
 

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -774,7 +774,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 				if err := r.Client.Create(ctx, template, &client.CreateOptions{}); err != nil {
 					return r.logAndSetCondition(err, "failed to create resource", template, m)
 				}
-				log.Info("Created resource", "Name", template.GetName(), "Kind", template.GetKind())
+				log.Info("Creating resource", "Name", template.GetName(), "Kind", template.GetKind())
 			} else {
 				return r.logAndSetCondition(err, "failed to get resource", templateCopy, m)
 			}

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -1821,3 +1821,45 @@ func Test_applyEnvConfig(t *testing.T) {
 		})
 	}
 }
+
+func Test_logAndSetCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		mch      *operatorv1.MultiClusterHub
+		message  string
+		template *unstructured.Unstructured
+	}{
+		{
+			name: "should log and set condition of MCH",
+			err:  fmt.Errorf("Test error"),
+			mch: &operatorv1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multiclusterhub",
+					Namespace: "test-ns",
+				},
+			},
+			message: "This is a test error",
+			template: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if _, err := recon.logAndSetCondition(tt.err, tt.message, tt.template, tt.mch); err == nil {
+				t.Errorf("logAndSetCondition() = %v, expected an error", err)
+			}
+		})
+	}
+}

--- a/controllers/uninstall.go
+++ b/controllers/uninstall.go
@@ -238,7 +238,7 @@ func (r *MultiClusterHubReconciler) ensureRemovalsGone(m *operatorsv1.MultiClust
 // uninstall return true if resource does not exist and returns an error if a GET or DELETE errors unexpectedly. A false response without error
 // means the resource is in the process of deleting.
 func (r *MultiClusterHubReconciler) uninstall(m *operatorsv1.MultiClusterHub, u *unstructured.Unstructured) (bool, error) {
-	obLog := r.Log.WithValues("Namespace", u.GetNamespace(), "Name", u.GetName(), "Kind", u.GetKind())
+	obLog := r.Log.WithValues("Namespace", u.GetNamespace(), "Kind", u.GetKind(), "Name", u.GetName())
 
 	err := r.Client.Get(context.TODO(), types.NamespacedName{
 		Name:      u.GetName(),


### PR DESCRIPTION
# Description

After merging this PR: https://github.com/stolostron/multiclusterhub-operator/pull/1882, a regression was introduced that affected ACM version upgrades. This new PR aims to resolve the issue and enable successful upgrades.

## Related Issue

https://issues.redhat.com/browse/ACM-16805

## Changes Made

Removed setting the template ManagedFields to nil:
```go
template.SetManagedFields(nil)
```

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
