### PR TITLE
tag and cleanup csv's when policy is installed

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
@@ -346,6 +346,39 @@ spec:
                       source: {{ `{{ $subscriptionSource }}` }}
                       sourceNamespace: {{ `{{ $subscriptionSourceNamespace }}` }}
 
+                {{ `{{- /* tag the csv with the subscription uid; to be used when policy is installed and need to clean up previous policy csv - they are not cleaned up when the policy is uninstalled  */ -}}` }}
+                {{ `{{- $installedSubs := lookup "operators.coreos.com/v1alpha1" "Subscription" $ns $subscription_name }}` }}
+                  {{ `{{- $owningSubs := "cluster.open-cluster-management.io/ownSubs" }}` }}
+
+                {{ `{{ if and (eq $installedSubs.metadata.name $subscription_name) (hasKey $installedSubs.status "installedCSV") }}` }}
+                  {{ `{{ $csv_name := $installedSubs.status.installedCSV }}` }}
+                - complianceType: musthave
+                  objectDefinition:
+                    apiVersion: operators.coreos.com/v1alpha1
+                    kind: ClusterServiceVersion
+                    metadata:
+                      name: {{ `{{ $csv_name }}` }}
+                      namespace: {{ `{{ $ns }}` }}
+                      annotations:
+                       {{ `{{ $owningSubs }}` }}: {{ `{{ $installedSubs.metadata.uid }}` }}
+                {{ `{{- end }}` }}
+
+                {{ `{{- /* delete any csv created by a previous policy install  */ -}}` }}
+                {{ `{{- range $csv := (lookup "operators.coreos.com/v1alpha1" "ClusterServiceVersion" "" "").items }}` }}
+                  {{ `{{ if and (eq $csv.spec.displayName "OADP Operator") (hasKey $csv.metadata.annotations $owningSubs) }}` }}
+                    {{ `{{- $otherOwningSubs := index $csv.metadata.annotations $owningSubs }}` }}
+                    {{ `{{ if not (eq $otherOwningSubs $installedSubs.metadata.uid )}}` }}
+                - complianceType: mustnothave
+                  objectDefinition:
+                    apiVersion: operators.coreos.com/v1alpha1
+                    kind: ClusterServiceVersion
+                    metadata:
+                      name: {{ `{{ $csv.metadata.name }}` }}
+                      namespace: {{ `{{ $csv.metadata.namespace }}` }}
+                    {{ `{{- end }}` }}
+                  {{ `{{- end }}` }}
+                {{ `{{- end }}` }}
+
                 {{ `{{- /* check if OADP CRD is installed  */ -}}` }}
                 {{ `{{- $dpa_crd_name := "dataprotectionapplications.oadp.openshift.io" }}` }}
                 {{ `{{- $dpa_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "dataprotectionapplications.oadp.openshift.io"  }}` }}


### PR DESCRIPTION
# Description

Cleanup oadp csv created by the policy, when the policy is reapplied. The issue : if the user applies the policy, OADP is installed in the specified namespace. If the namespace already exists ( so is not going to be deleted when the policy is removed ), then only the Subscription and OperatorGroup resources are being cleaned up. The CSV is created by the Subscription, so not by the policy, and as a result it will remain after the policy is removed from the managed cluster.
Next time the policy is placed on the same managed cluster, the OADP install fails because there is already a csv in that ns.
The fix 
- tag the CSV created by the Subscription with an annotation, `cluster.open-cluster-management.io/ownSubs: subscriptionUID` , when the Subscription is created
- delete any OADP csv using the same version, if the OADP has the annotation and the UID is not the same with the current subscription UID

## Related Issue

https://issues.redhat.com/browse/ACM-16968

## Changes Made

Updated install policy.
Add a cluster.open-cluster-management.io/ownSubs: subscriptionUID to the CSV when the subscription is installed
Remove any csv with a cluster.open-cluster-management.io/ownSubs: subscriptionUID annotation and subscriptionUID not matching current Subscription id

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
