### PR TITLE
create DPA only if secret exists and remove mapping

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
@@ -35,6 +35,16 @@ spec:
                       name: "{{ `{{hub $config_name hub}}` }}"
                       namespace: "open-cluster-management-backup"
             {{ `{{hub else hub}}` }}
+                {{ `{{- $acm_crd_name := "multiclusterhubs.operator.open-cluster-management.io" }}` }}
+                {{ `{{- $acm_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $acm_crd_name  }}` }}
+                {{ `{{- /* check if this is a hub, acm installed  */ -}}` }}
+                {{ `{{- $is_hub := eq $acm_crd.metadata.name  $acm_crd_name }}` }}
+                {{ `{{- /* ns is the namespace for the OADP deployment  */ -}}` }}
+                {{ `{{- $ns := "open-cluster-management-backup" }}` }}
+                {{ `{{ if not $is_hub }}` }}
+                  {{ `{{- $ns = "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "backupNS" hub}}" }}` }}
+                {{ `{{- end }}` }}
+
                 {{ `{{hub $cloud_creds_file_name := (fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "credentials_hub_secret_name") hub}}` }}
                 {{ `{{hub $cloud_creds_file := lookup "v1" "Secret" "" $cloud_creds_file_name hub}}` }}
                 {{ `{{hub $cloud_creds_file_exists := eq $cloud_creds_file.metadata.name $cloud_creds_file_name hub}}` }}
@@ -45,7 +55,7 @@ spec:
                     kind: Secret
                     metadata:
                       name: "{{ `{{hub $cloud_creds_file_name hub}}` }}"
-                      namespace: "open-cluster-management-backup"
+                      namespace: {{ `{{ $ns }}` }}
                 {{ `{{hub end hub}}` }}
             {{ `{{hub end hub}}` }}
     - objectDefinition:
@@ -319,7 +329,7 @@ spec:
                       name: {{ `{{ $credentialsName }}` }}
                       namespace: {{ `{{ $ns }}` }}
                     data: '{{ `{{hub copySecretData "" $cloud_creds_file_name hub}}` }}'
-                {{ `{{hub end hub}}` }}
+                  {{ `{{hub end hub}}` }}
 
                 - complianceType: musthave
                   objectDefinition:
@@ -346,12 +356,12 @@ spec:
                       source: {{ `{{ $subscriptionSource }}` }}
                       sourceNamespace: {{ `{{ $subscriptionSourceNamespace }}` }}
 
-                {{ `{{- /* tag the csv with the subscription uid; to be used when policy is installed and need to clean up previous policy csv - they are not cleaned up when the policy is uninstalled  */ -}}` }}
-                {{ `{{- $installedSubs := lookup "operators.coreos.com/v1alpha1" "Subscription" $ns $subscription_name }}` }}
+                  {{ `{{- /* tag the csv with the subscription uid; to be used when policy is installed and need to clean up previous policy csv - they are not cleaned up when the policy is uninstalled  */ -}}` }}
+                  {{ `{{- $installedSubs := lookup "operators.coreos.com/v1alpha1" "Subscription" $ns $subscription_name }}` }}
                   {{ `{{- $owningSubs := "cluster.open-cluster-management.io/ownSubs" }}` }}
 
-                {{ `{{ if and (eq $installedSubs.metadata.name $subscription_name) (hasKey $installedSubs.status "installedCSV") }}` }}
-                  {{ `{{ $csv_name := $installedSubs.status.installedCSV }}` }}
+                  {{ `{{ if and (eq $installedSubs.metadata.name $subscription_name) (hasKey $installedSubs.status "installedCSV") }}` }}
+                    {{ `{{ $csv_name := $installedSubs.status.installedCSV }}` }}
                 - complianceType: musthave
                   objectDefinition:
                     apiVersion: operators.coreos.com/v1alpha1
@@ -361,13 +371,13 @@ spec:
                       namespace: {{ `{{ $ns }}` }}
                       annotations:
                        {{ `{{ $owningSubs }}` }}: {{ `{{ $installedSubs.metadata.uid }}` }}
-                {{ `{{- end }}` }}
+                  {{ `{{- end }}` }}
 
-                {{ `{{- /* delete any csv created by a previous policy install  */ -}}` }}
-                {{ `{{- range $csv := (lookup "operators.coreos.com/v1alpha1" "ClusterServiceVersion" "" "").items }}` }}
-                  {{ `{{ if and (eq $csv.spec.displayName "OADP Operator") (hasKey $csv.metadata.annotations $owningSubs) }}` }}
-                    {{ `{{- $otherOwningSubs := index $csv.metadata.annotations $owningSubs }}` }}
-                    {{ `{{ if not (eq $otherOwningSubs $installedSubs.metadata.uid )}}` }}
+                  {{ `{{- /* delete any csv created by a previous policy install  */ -}}` }}
+                  {{ `{{- range $csv := (lookup "operators.coreos.com/v1alpha1" "ClusterServiceVersion" "" "").items }}` }}
+                    {{ `{{ if and (eq $csv.spec.displayName "OADP Operator") (hasKey $csv.metadata.annotations $owningSubs) }}` }}
+                      {{ `{{- $otherOwningSubs := index $csv.metadata.annotations $owningSubs }}` }}
+                      {{ `{{ if not (eq $otherOwningSubs $installedSubs.metadata.uid )}}` }}
                 - complianceType: mustnothave
                   objectDefinition:
                     apiVersion: operators.coreos.com/v1alpha1
@@ -375,15 +385,15 @@ spec:
                     metadata:
                       name: {{ `{{ $csv.metadata.name }}` }}
                       namespace: {{ `{{ $csv.metadata.namespace }}` }}
+                      {{ `{{- end }}` }}
                     {{ `{{- end }}` }}
                   {{ `{{- end }}` }}
-                {{ `{{- end }}` }}
 
-                {{ `{{- /* check if OADP CRD is installed  */ -}}` }}
-                {{ `{{- $dpa_crd_name := "dataprotectionapplications.oadp.openshift.io" }}` }}
-                {{ `{{- $dpa_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "dataprotectionapplications.oadp.openshift.io"  }}` }}
-                {{ `{{- $dpa_crd_exists := eq $dpa_crd.metadata.name  $dpa_crd_name }}` }}
-                  {{ `{{- if $dpa_crd_exists }}` }}
+                  {{ `{{- /* check if OADP CRD is installed  */ -}}` }}
+                  {{ `{{- $dpa_crd_name := "dataprotectionapplications.oadp.openshift.io" }}` }}
+                  {{ `{{- $dpa_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "dataprotectionapplications.oadp.openshift.io"  }}` }}
+                  {{ `{{- $dpa_crd_exists := eq $dpa_crd.metadata.name  $dpa_crd_name }}` }}
+                  {{ `{{- if and {{hub $cloud_creds_file_exists hub}} $dpa_crd_exists }}` }}
                 - complianceType: mustonlyhave
                   objectDefinition:
                     apiVersion: oadp.openshift.io/v1alpha1

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
@@ -142,8 +142,6 @@ spec:
                   name: {{ `{{ $restoreName }}` }}
                   namespace: {{ `{{ $ns }}` }}
                 spec:
-                  namespaceMapping:
-                    open-cluster-management-backup: {{ `{{ $ns }}` }}
                   backupName: {{ `{{ $backupName }}` }}
                   restorePVs: true
                   {{ `{{ if not (eq $vms_ns " ") }}` }}


### PR DESCRIPTION
# Description

Create DPA only if velero secret exists and remove restore namespace mapping workaround, the issue will be addressed with OADP 1.4.2

## Related Issue

https://issues.redhat.com/browse/ACM-17215
https://issues.redhat.com/browse/OADP-5460


## Changes Made

Updated install policy to create DPA only if the velero secret exists
Updated restore policy to remove namespace mapping workaround for the DataUpload resource, OADP will provide the fix with OADP 1.4.2

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
