### PR TITLE
Updated config.yaml to support escape-template-variables field

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -10,6 +10,13 @@
         multicloud-integrations: multicloud_integrations
         multicluster-operators-application: multicluster_operators_application
         multicluster-operators-channel: multicluster_operators_channel
+      escape-template-variables:
+        - GITOPS_OPERATOR_IMAGE
+        - GITOPS_OPERATOR_NAMESPACE
+        - GITOPS_IMAGE
+        - GITOPS_NAMESPACE
+        - REDIS_IMAGE
+        - RECONCILE_SCOPE
       exclusions:
         - readOnlyRootFilesystem
 


### PR DESCRIPTION
# Description

To onboard the `gitops` resources that the `multicloud-operators-subscription` component is requesting, we need to update the `config.yaml` to support adding `escape-template-variables`.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `config.yaml` entry for `multicloud-operators-subscription` component.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
