### PR TITLE
rename edge management

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -30,7 +30,7 @@ const (
 	MultiClusterObservability string = "multicluster-observability"
 	Repo                      string = "multiclusterhub-repo"
 	Search                    string = "search"
-	FlightControl             string = "flight-control-preview"
+	EdgeManagement            string = "edge-management-preview"
 	SiteConfig                string = "siteconfig"
 	SubmarinerAddon           string = "submariner-addon"
 	Volsync                   string = "volsync"
@@ -74,7 +74,7 @@ var MCHComponents = []string{
 	MCH,                // Adding MCH component to ensure legacy resources are cleaned up properly.
 	MultiClusterObservability,
 	Search,
-	FlightControl,
+	EdgeManagement,
 	SiteConfig,
 	SubmarinerAddon,
 	Volsync,
@@ -178,7 +178,7 @@ func GetDefaultDisabledComponents() ([]string, error) {
 	defaultDisabledComponents := []string{
 		ClusterBackup,
 		SiteConfig,
-		FlightControl,
+		EdgeManagement,
 	}
 	return defaultDisabledComponents, nil
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -193,10 +193,10 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 	}
 	mceannotations[mceutils.AnnotationHubSize] = string(utils.GetHubSize(m))
 
-	if m.Enabled(operatorv1.FlightControl) {
-		mceannotations[mceutils.AnnotationFlightEnabled] = "true"
+	if m.Enabled(operatorv1.EdgeManagement) {
+		mceannotations[mceutils.AnnotationEdgeManagementEnabled] = "true"
 	} else {
-		mceannotations[mceutils.AnnotationFlightEnabled] = "false"
+		mceannotations[mceutils.AnnotationEdgeManagementEnabled] = "false"
 	}
 
 	// TODO: put this back later

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -851,8 +851,8 @@ func (r *MultiClusterHubReconciler) fetchChartLocation(component string) string 
 	case operatorv1.Volsync:
 		return utils.VolsyncChartLocation
 
-	case operatorv1.FlightControl:
-		return utils.FlightControlChartLocation
+	case operatorv1.EdgeManagement:
+		return utils.EdgeManagementChartLocation
 
 	default:
 		log.Info(fmt.Sprintf("Unregistered component detected: %v", component))

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -32,7 +32,7 @@ var chartPaths = []string{
 	utils.GRCChartLocation,
 	utils.ConsoleChartLocation,
 	utils.VolsyncChartLocation,
-	utils.FlightControlChartLocation,
+	utils.EdgeManagementChartLocation,
 }
 
 func TestRender(t *testing.T) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -92,8 +92,8 @@ const (
 	// VolsyncChartLocation is the location of the Volsync Controller chart.
 	VolsyncChartLocation = "/charts/toggle/volsync-controller"
 
-	// FlightControlChartLocation is the location of the Flight Control Controller chart.
-	FlightControlChartLocation = "/charts/toggle/flight-control"
+	// EdgeManagementChartLocation is the location of the Flight Control Controller chart.
+	EdgeManagementChartLocation = "/charts/toggle/flight-control"
 )
 
 const (


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ACM-17576

Renaming all references to flight control to edge management per marketing decision. references to flight control remain in the charts pending their teams updates