### PR TITLE
Updated .tekton push sast-coverity-check-oci-ta config to include IMAGE value

### DIFF
--- a/.tekton/multiclusterhub-operator-pull-request.yaml
+++ b/.tekton/multiclusterhub-operator-pull-request.yaml
@@ -403,8 +403,6 @@ spec:
               - "false"
       - name: sast-coverity-check
         params:
-          - name: image-digest
-            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
           - name: IMAGE

--- a/.tekton/multiclusterhub-operator-push.yaml
+++ b/.tekton/multiclusterhub-operator-push.yaml
@@ -400,10 +400,27 @@ spec:
               - "false"
       - name: sast-coverity-check
         params:
-          - name: image-digest
-            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
           - name: image-url
             value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: DOCKERFILE
+            value: $(params.dockerfile)
+          - name: CONTEXT
+            value: $(params.path-context)
+          - name: HERMETIC
+            value: $(params.hermetic)
+          - name: PREFETCH_INPUT
+            value: $(params.prefetch-input)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.image-expires-after)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: BUILD_ARGS
+            value:
+              - $(params.build-args[*])
+          - name: BUILD_ARGS_FILE
+            value: $(params.build-args-file)
           - name: SOURCE_ARTIFACT
             value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
           - name: CACHI2_ARTIFACT

--- a/hack/bundle-automation/chart-values/managed-serviceaccount/values.yaml
+++ b/hack/bundle-automation/chart-values/managed-serviceaccount/values.yaml
@@ -1,9 +1,0 @@
-# Image of the managed service-account instances
-image: org/repo/managed-serviceaccount
-tag: tag
-agentInstallAll: false
-featureGates:
-  ephemeralIdentity: true
-agentImagePullSecret: ""
-global:
-  hubSize: Small


### PR DESCRIPTION
# Description

Updated the `.tekton` push file to include an `IMAGE` value for the `sast-coverity-check-oci-ta` step. This field is needed after the recent migration.

```
[User error] Validation failed for pipelinerun multiclusterhub-operator-on-push-klgtb with error invalid input params for task sast-coverity-check-oci-ta: missing values for these params which have no default values: [IMAGE] 
```

## Related Issue

https://github.com/stolostron/multiclusterhub-operator/pull/1947

## Changes Made

Update `.tekton` file.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
