### PR TITLE
create acm-virt-config-cls map with install policy

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
@@ -304,6 +304,15 @@ spec:
                     metadata:
                       name: {{ `{{ $ns }}` }}
 
+                - complianceType: mustonlyhave
+                  objectDefinition:
+                    apiVersion: v1
+                    kind: ConfigMap
+                    metadata:
+                      name: "acm-virt-config-cls"
+                      namespace: {{ `{{ $ns }}` }}
+                    data: {{ `'{{hub copyConfigMapData "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) hub}}'` }}
+
               {{ `{{hub $cron_file_name := (fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "schedule_hub_config_name") hub}}` }}
               {{ `{{hub $cron_file := lookup "v1" "ConfigMap" "" $cron_file_name hub}}` }}
               {{ `{{hub $cron_file_exists := eq $cron_file.metadata.name $cron_file_name hub}}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
@@ -74,7 +74,11 @@ spec:
               {{ `{{- $policy_install_compliant = eq $policy_install.status.compliant "Compliant" }}` }}
             {{ `{{- end }}` }}
 
-            {{ `{{ if and $sch_crd_exists $policy_install_compliant }}` }}
+            {{ `{{- /* check if acm-virt-restore-cls exists */ -}}` }}
+            {{ `{{- $restore_config_file := lookup "v1" "ConfigMap" $ns $cls_restore_configmap_name }}` }}
+            {{ `{{- $restore_config_file_exists := eq $restore_config_file.metadata.name $cls_restore_configmap_name }}` }}
+
+            {{ `{{ if and $sch_crd_exists $policy_install_compliant $restore_config_file_exists }}` }}
             
             {{ `{{- $restoreClusterID := fromClusterClaim "id.openshift.io" }}` }}
             {{ `{{- $restoreNameProp := (cat  $restoreClusterID "_" "restoreName") | replace " " ""}}` }}
@@ -204,7 +208,7 @@ spec:
                 {{ `{{- $acm_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $acm_crd_name  }}` }}
                 {{ `{{- $is_hub := eq $acm_crd.metadata.name  $acm_crd_name }}` }}
                 {{ `{{ if not $is_hub }}` }}
-                  {{ `{{- $ns = "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "backupNS" hub}}" }}` }}
+                  {{ `{{- $ns = "{{ `{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "backupNS" hub}}` }}" }}` }}
                 {{ `{{- end }}` }}
 
                 {{ `{{- /* cls_restore_configmap_name is the name of the main restore config map, copied over to the cluster  */ -}}` }}


### PR DESCRIPTION
# Description

Create acm-virt-config-cls map with install policy
Related to PR https://github.com/stolostron/multiclusterhub-operator/pull/1954

## Related Issue

https://issues.redhat.com/browse/ACM-16218

## Changes Made

Updated install policy to create the acm-virt-config-cls
Updated restore policy to check if the acm-virt-restore-cls configMap exists 

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
