### PR TITLE
POD_NAMESPACE env var in volsync-addon-controller

### DIFF
--- a/pkg/templates/charts/toggle/volsync-controller/templates/volsync-addon-controller-deployment.yaml
+++ b/pkg/templates/charts/toggle/volsync-controller/templates/volsync-addon-controller-deployment.yaml
@@ -124,6 +124,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           {{- if .Values.hubconfig.proxyConfigs }}
           - name: HTTP_PROXY
             value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
# Description

volsync-addon-controller will need to look at the mch image manifest configmap, and would like to restrict the search to the mch namespace, that is, the namespace of the volsync-addon-controller pod itself.

Update is to use the downward api to pass in POD_NAMESPACE to the volsync-addon-controller in the deployment.yaml

## Related Issue

https://issues.redhat.com/browse/ACM-16311

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
