### PR TITLE
remove install policy check and use startingCSV

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
@@ -25,19 +25,16 @@ spec:
             {{ `{{- $sch_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $sch_crd_name  }}` }}
             {{ `{{- $sch_crd_exists := eq $sch_crd.metadata.name  $sch_crd_name }}` }}
 
-            {{ `{{- /* check if install policy is compliant */ -}}` }}
-            {{ `{{- $policy_install_compliant := "false" }}` }}
-            {{ `{{- $cluster_name := "{{hub .ManagedClusterName hub}}" }}` }}
-            {{ `{{- $policy_label := "policy.open-cluster-management.io/root-policy, policy.open-cluster-management.io/root-policy in (open-cluster-management-backup.acm-dr-virt-install)"}}` }}
-            {{ `{{- range $policy_install := (lookup "policy.open-cluster-management.io/v1" "Policy" "$cluster_name" "" $policy_label).items }}` }}
-              {{ `{{- $policy_install_compliant = eq $policy_install.status.compliant "Compliant" }}` }}
-            {{ `{{- end }}` }}
-
             {{ `{{hub $config_name := index .ManagedClusterLabels "acm-virt-config" hub}}` }}
             {{ `{{hub $config_file := lookup "v1" "ConfigMap" "" $config_name hub}}` }}
             {{ `{{hub $config_file_exists := eq $config_file.metadata.name $config_name hub}}` }}
             {{ `{{hub if $config_file_exists hub}}` }}
-              {{ `{{ if and $sch_crd_exists $policy_install_compliant }}` }}
+              {{ `{{- /* check if schedule_hub_config_name configMap exists */ -}}` }}
+              {{ `{{hub $cron_file_name := (fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "schedule_hub_config_name") hub}}` }}
+              {{ `{{hub $cron_file := lookup "v1" "ConfigMap" "" $cron_file_name hub}}` }}
+              {{ `{{- $cron_file_exists := {{hub eq $cron_file.metadata.name $cron_file_name hub}} }}` }}
+
+              {{ `{{ if and $sch_crd_exists $cron_file_exists }}` }}
                 {{ `{{- /* ns is the namespace for the OADP deployment  */ -}}` }}
                 {{ `{{- $ns := "open-cluster-management-backup" }}` }}
                 {{ `{{- $acm_virt_sch_name := "acm-rho-virt-schedule" }}` }}
@@ -81,13 +78,9 @@ spec:
                   {{ `{{- $oadp_channel := "" }}` }}
                   {{ `{{ if ($sch_crd_exists) }}` }}
                     {{ `{{- /* Velero Schedule CRD is installed */ -}}` }}
-
-                    {{ `{{hub if $config_file_exists hub}}` }}
-                      {{ `{{ if not $is_hub }}` }}
-                        {{ `{{- $ns = "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "backupNS" hub}}" }}` }}
-                      {{ `{{- end }}` }}
-                    {{ `{{hub end hub}}` }}
-
+                    {{ `{{ if not $is_hub }}` }}
+                      {{ `{{- $ns = "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "backupNS" hub}}" }}` }}
+                    {{ `{{- end }}` }}
 
                     {{ `{{- $config_map := lookup "v1" "ConfigMap" $ns "acm-virt-config-cls" }}` }}
                     {{ `{{ if hasKey $config_map.data "scheduleTTL" }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
@@ -295,6 +295,7 @@ spec:
                   {{ `{{ if not (eq "" $subscriptionSourceConfig) }}` }}
                     {{ `{{- $subscriptionSource = $subscriptionSourceConfig }}` }}
                   {{ `{{- end }}` }}
+                  {{ `{{- $startingCSV := "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "subscriptionStartingCSV" hub}}" }}` }}
 
                   {{ `{{- /* ns is the namespace for the OADP deployment  */ -}}` }}
                   {{ `{{- $ns := "open-cluster-management-backup" }}` }}
@@ -400,6 +401,9 @@ spec:
                       name: {{ `{{ $channelName }}` }}
                       source: {{ `{{ $subscriptionSource }}` }}
                       sourceNamespace: {{ `{{ $subscriptionSourceNamespace }}` }}
+                      {{ `{{ if not (eq "" $startingCSV) }}` }}
+                      startingCSV: {{ `{{ $startingCSV }}` }}
+                      {{ `{{- end }}` }}
 
                   {{ `{{- /* tag the csv with the subscription uid; to be used when policy is installed and need to clean up previous policy csv - they are not cleaned up when the policy is uninstalled  */ -}}` }}
                   {{ `{{- $installedSubs := lookup "operators.coreos.com/v1alpha1" "Subscription" $ns $subscription_name }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
@@ -66,19 +66,11 @@ spec:
             {{ `{{- $sch_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $sch_crd_name  }}` }}
             {{ `{{- $sch_crd_exists := eq $sch_crd.metadata.name  $sch_crd_name }}` }}
 
-            {{ `{{- /* check if install policy is compliant */ -}}` }}
-            {{ `{{- $policy_install_compliant := "false" }}` }}
-            {{ `{{- $cluster_name := "{{hub .ManagedClusterName hub}}" }}` }}
-            {{ `{{- $policy_label := "policy.open-cluster-management.io/root-policy, policy.open-cluster-management.io/root-policy in (open-cluster-management-backup.acm-dr-virt-install)"}}` }}
-            {{ `{{- range $policy_install := (lookup "policy.open-cluster-management.io/v1" "Policy" "$cluster_name" "" $policy_label).items }}` }}
-              {{ `{{- $policy_install_compliant = eq $policy_install.status.compliant "Compliant" }}` }}
-            {{ `{{- end }}` }}
-
             {{ `{{- /* check if acm-virt-restore-cls exists */ -}}` }}
             {{ `{{- $restore_config_file := lookup "v1" "ConfigMap" $ns $cls_restore_configmap_name }}` }}
             {{ `{{- $restore_config_file_exists := eq $restore_config_file.metadata.name $cls_restore_configmap_name }}` }}
 
-            {{ `{{ if and $sch_crd_exists $policy_install_compliant $restore_config_file_exists }}` }}
+            {{ `{{ if and $sch_crd_exists $restore_config_file_exists }}` }}
             
             {{ `{{- $restoreClusterID := fromClusterClaim "id.openshift.io" }}` }}
             {{ `{{- $restoreNameProp := (cat  $restoreClusterID "_" "restoreName") | replace " " ""}}` }}


### PR DESCRIPTION
# Description

Allow setting the startingCSV for the OADP install.
Remove check for install policy compliance and check required configMaps instead, to avoid cleaning up restore or schedule resources when the install policy is non compliant.

## Related Issue

https://issues.redhat.com/browse/ACM-16218

## Changes Made

Updated install policy and included the startingCSV prop for the oadp subscription.
Removed the install compliance policy check from the backup and restore policies; replaced that with required configMaps check instead.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
