### PR TITLE
Add permissions for standalon-hub-templates addon

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-clusterrole.yaml
@@ -35,6 +35,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - clustermanagementaddons/finalizers
   verbs:
@@ -45,6 +46,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - clustermanagementaddons/status
   verbs:
@@ -66,6 +68,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - managedclusteraddons
   verbs:
@@ -76,6 +79,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - managedclusteraddons/finalizers
   verbs:
@@ -86,6 +90,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - managedclusteraddons/status
   verbs:
@@ -151,6 +156,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - leases
   verbs:
@@ -246,6 +252,7 @@ rules:
   - open-cluster-management:cert-policy-controller-hub
   - open-cluster-management:config-policy-controller-hub
   - open-cluster-management:policy-framework-hub
+  - open-cluster-management:governance-standalone-hub-templating
   resources:
   - clusterroles
   verbs:
@@ -265,6 +272,7 @@ rules:
   - open-cluster-management:cert-policy-controller-hub
   - open-cluster-management:config-policy-controller-hub
   - open-cluster-management:policy-framework-hub
+  - open-cluster-management:governance-standalone-hub-templating
   resources:
   - rolebindings
   verbs:

--- a/pkg/templates/charts/toggle/grc/templates/standalone-hub-templates-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/standalone-hub-templates-clustermanagementaddon.yaml
@@ -1,0 +1,11 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: governance-standalone-hub-templating
+spec:
+  addOnMeta:
+    description: Allows the config-policy-controller to resolve hub templates on the managed cluster.
+    displayName: Governance Standalone Hub Templating
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs


### PR DESCRIPTION
Refs:
 - https://issues.redhat.com/browse/ACM-16091

# Description

Adds permissions to the GRC role for its new (optional, off-by-default) addon, as well as that addon's CMAO.

## Related Issue

https://issues.redhat.com/browse/ACM-16088

## Changes Made

Adds some permissions and a ClusterManagementAddOn resource.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
