### PR TITLE
get only backups created by this cluster

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
@@ -278,7 +278,12 @@ spec:
                       phase: Enabled
 
                   {{ `{{ if not (eq $scheduleObjLastBckTime "") }}` }}
-                    {{ `{{- range $backupList := (lookup "velero.io/v1" "Backup" "" "" $schedule_label).items }}` }}
+                    {{ `{{- /* get only backups created by this cluster  */ -}}` }}
+                    {{ `{{- $cluster_version := fromClusterClaim "id.openshift.io" }}` }}
+                    {{ `{{- $backup_label := "schedule_label_tmp, cluster.open-cluster-management.io/backup-cluster, cluster.open-cluster-management.io/backup-cluster in (cluster_version_tmp)"}}` }}
+                    {{ `{{- $backup_label = replace "schedule_label_tmp" $schedule_label $backup_label }}` }}
+                    {{ `{{- $backup_label = replace "cluster_version_tmp" $cluster_version $backup_label }}` }}
+                    {{ `{{- range $backupList := (lookup "velero.io/v1" "Backup" "" "" $backup_label).items }}` }}
                       {{ `{{- $backupCreation := $backupList.metadata.creationTimestamp  }}` }}
                       {{ `{{ if eq $backupCreation $scheduleObjLastBckTime }}` }}
 
@@ -307,7 +312,7 @@ spec:
                       namespace: {{ `{{ $backupList.metadata.namespace }}` }}
                       name: {{ `{{ $backupList.metadata.name }}` }}
                       labels:
-                        cluster.open-cluster-management.io/backup-cluster: {{ `{{ fromClusterClaim "id.openshift.io" }}` }}
+                        cluster.open-cluster-management.io/backup-cluster: {{ `{{ $cluster_version }}` }}
                         cluster.open-cluster-management.io/backup-schedule-type: kubevirt
                         velero.io/schedule-name: {{ `{{ $scheduleObj.metadata.name }}` }}
                     status:


### PR DESCRIPTION
# Description

When looking for backups with a startTimestamp, get only backups created by this cluster.
There are cases when backups are created on different clusters using the same virt schedule name, so they may have the same timestamp. When checking the status of the latest backup, get only backups created by this cluster.

## Related Issue

https://issues.redhat.com/browse/ACM-16218

## Changes Made

Updated check-backup-status-completed template to get only backups that have the label cluster.open-cluster-management.io/backup-cluster=cluster_version , where cluster_version is the clusterId for the current cluster


## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
