### PR TITLE
Update backupschedule CRD to align with Velero 1.14 API

### DIFF
--- a/pkg/templates/crds/cluster-backup/cluster.open-cluster-management.io_backupschedules.yaml
+++ b/pkg/templates/crds/cluster-backup/cluster.open-cluster-management.io_backupschedules.yaml
@@ -468,7 +468,7 @@ spec:
                           itemOperationTimeout:
                             description: |-
                               ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
-                              The default value is 1 hour.
+                              The default value is 4 hour.
                             type: string
                           labelSelector:
                             description: |-
@@ -1037,7 +1037,7 @@ spec:
                           itemOperationTimeout:
                             description: |-
                               ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
-                              The default value is 1 hour.
+                              The default value is 4 hour.
                             type: string
                           labelSelector:
                             description: |-
@@ -1606,7 +1606,7 @@ spec:
                           itemOperationTimeout:
                             description: |-
                               ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
-                              The default value is 1 hour.
+                              The default value is 4 hour.
                             type: string
                           labelSelector:
                             description: |-


### PR DESCRIPTION
# Description

Update backupschedule CRD to align with Velero 1.14 API

## Related Issue

https://github.com/stolostron/cluster-backup-operator/pull/893

## Changes Made

Update backupschedule CRD to align with Velero 1.14 API

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
