### PR TITLE
Added template resource name for missing MCE CRD log

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -797,12 +797,13 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 	} else {
 		// Check if the resource exists before creating it.
 		for _, gvk := range operatorv1.MCECRDs {
-			if template.GroupVersionKind().Group == gvk.Group && template.GetKind() == gvk.Kind && template.GroupVersionKind().Version == gvk.Version {
+			if template.GroupVersionKind().Group == gvk.Group && template.GetKind() == gvk.Kind &&
+				template.GroupVersionKind().Version == gvk.Version {
 				crd := &apixv1.CustomResourceDefinition{}
 
 				if err := r.Client.Get(ctx, types.NamespacedName{Name: gvk.Name}, crd); errors.IsNotFound(err) {
 					log.Info("CustomResourceDefinition does not exist. Skipping resource creation",
-						"Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind)
+						"Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind, "Name", template.GetName())
 					return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, nil
 
 				} else if err != nil {


### PR DESCRIPTION
# Description

During ACM installation, MCH will try to deploy specific resource types created during the MCE standup. If the corresponding CRDs are missing from the cluster, we only log which CRD is unavailable but do not capture the resource name. This PR will include the name of the template resource being applied during runtime in the log.

```
2025-02-20T14:01:13.096Z INFO reconcile CustomResourceDefinition does not exist. Skipping resource creation {"Group": "addon.open-cluster-management.io", "Version": "v1alpha1", "Kind": "ClusterManagementAddOn"}
```

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated missing CRD logging.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
