### PR TITLE
allow updating acm-dr-virt-config props

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-backup.yaml
@@ -82,7 +82,7 @@ spec:
                       {{ `{{- $ns = "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "backupNS" hub}}" }}` }}
                     {{ `{{- end }}` }}
 
-                    {{ `{{- $config_map := lookup "v1" "ConfigMap" $ns "acm-virt-config-cls" }}` }}
+                    {{ `{{- $config_map := lookup "v1" "ConfigMap" $ns "acm-dr-virt-config--cls" }}` }}
                     {{ `{{ if hasKey $config_map.data "scheduleTTL" }}` }}
                     {{ `{{- $ttl_schedule = $config_map.data.scheduleTTL }}` }}
                     {{ `{{- end }}` }}
@@ -95,8 +95,8 @@ spec:
                     {{ `{{ if hasKey $config_map.data "schedule_useOwnerReferencesInBackup" }}` }}
                       {{ `{{- $useOwnerReferencesInBackup = ( $config_map.data.schedule_useOwnerReferencesInBackup ) | toBool }}` }}
                     {{ `{{- end }}` }}
-                    {{ `{{- $storageLocation = fromConfigMap $ns "acm-virt-config-cls" "storageLocation" }}` }}
-                    {{ `{{- $oadp_channel = fromConfigMap $ns "acm-virt-config-cls" "channel" }}` }}
+                    {{ `{{- $storageLocation = fromConfigMap $ns "acm-dr-virt-config--cls" "storageLocation" }}` }}
+                    {{ `{{- $oadp_channel = fromConfigMap $ns "acm-dr-virt-config--cls" "channel" }}` }}
 
                   {{ `{{- /* Velero Schedule CRD is installed */ -}}` }}
                   {{ `{{- end }}` }}
@@ -108,7 +108,7 @@ spec:
                     {{ `{{- $vms_to_backup := (lookup "kubevirt.io/v1" "VirtualMachine" "" "" $schedule_label) }}` }}
 
                     {{ `{{- /* get all cron jobs; for each of them define a backup schedule, if any vms are found for this schedule  */ -}}` }}
-                    {{ `{{- $jobs_map := ( lookup "v1" "ConfigMap" $ns "acm-virt-cron-schedules" ) }}` }}
+                    {{ `{{- $jobs_map := ( lookup "v1" "ConfigMap" $ns "acm-dr-virt-schedule-cron--cls" ) }}` }}
 
                     {{ `{{- range $jobs := $jobs_map.data }}` }}
 
@@ -127,7 +127,7 @@ spec:
                         {{ `{{- /* get the name of the cron job from the vm label  */ -}}` }}
                         {{ `{{- $cron_name := (index $vms.metadata.labels $schedule_label) }}` }}
 
-                        {{ `{{- $cron_schedule = fromConfigMap $ns "acm-virt-cron-schedules" $cron_name }}` }}
+                        {{ `{{- $cron_schedule = fromConfigMap $ns "acm-dr-virt-schedule-cron--cls" $cron_name }}` }}
 
                         {{ `{{ if eq $cron_schedule $jobs }}` }}
 
@@ -357,7 +357,7 @@ spec:
                   {{ `{{- $ns = "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "backupNS" hub}}" }}` }}
                 {{ `{{- end }}` }}
 
-                {{ `{{- $jobs_map := ( lookup "v1" "ConfigMap" $ns "acm-virt-cron-schedules" ).data }}` }}
+                {{ `{{- $jobs_map := ( lookup "v1" "ConfigMap" $ns "acm-dr-virt-schedule-cron--cls" ).data }}` }}
                 {{ `{{- $cron_label := "cluster.open-cluster-management.io/backup-vm" }}` }}
 
                 {{ `{{- /* get all vms with a backup label and check that the specified cron job name is valid  */ -}}` }}
@@ -371,7 +371,7 @@ spec:
                     apiVersion: v1
                     kind: ConfigMap
                     metadata:
-                      name: "acm-virt-cron-schedules"
+                      name: "acm-dr-virt-schedule-cron--cls"
                       namespace: {{ `{{ $ns }}` }}
                     data:
                       {{ `{{ $vm_cron_value }}` }}: {{ `{{$vms_to_backup.metadata.name}}` }}
@@ -384,4 +384,4 @@ spec:
           customMessage:
             compliant: "All cron schedule names used with the VirtualMachines cluster.open-cluster-management.io/backup-vm label are valid."
             noncompliant: |-
-              Some VirtualMachines use invalid cron job names for the cluster.open-cluster-management.io/backup-vm label as they are not defined by the acm-virt-cron-schedules ConfigMap.
+              Some VirtualMachines use invalid cron job names for the cluster.open-cluster-management.io/backup-vm label as they are not defined by the acm-dr-virt-schedule-cron--cls ConfigMap.

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
@@ -315,7 +315,7 @@ spec:
                     apiVersion: v1
                     kind: ConfigMap
                     metadata:
-                      name: "acm-virt-config-cls"
+                      name: "acm-dr-virt-config--cls"
                       namespace: {{ `{{ $ns }}` }}
                     data: {{ `'{{hub copyConfigMapData "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) hub}}'` }}
 
@@ -323,7 +323,7 @@ spec:
               {{ `{{hub $cron_file := lookup "v1" "ConfigMap" "" $cron_file_name hub}}` }}
               {{ `{{hub $cron_file_exists := eq $cron_file.metadata.name $cron_file_name hub}}` }}
               {{ `{{- /* cron_schedule_configmap_name is the name of the main cron config map, copied over to the cluster  */ -}}` }}
-              {{ `{{- $cron_schedule_configmap_name := "acm-virt-cron-schedules" }}` }}
+              {{ `{{- $cron_schedule_configmap_name := "acm-dr-virt-schedule-cron--cls" }}` }}
               {{ `{{hub if $cron_file_exists hub}}` }}
                 - complianceType: mustonlyhave
                   objectDefinition:

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
@@ -31,7 +31,7 @@ spec:
             {{ `{{- $is_hub := eq $acm_crd.metadata.name  $acm_crd_name }}` }}
 
             {{ `{{- /* cls_restore_configmap_name is the name of the main restore config map, copied over to the cluster  */ -}}` }}
-            {{ `{{- $cls_restore_configmap_name := "acm-virt-restore-cls" }}` }}
+            {{ `{{- $cls_restore_configmap_name := "acm-dr-virt-restore-config--cls" }}` }}
             {{ `{{hub $restore_file_exists := "false" hub}}` }}
 
             {{ `{{hub $config_name := index .ManagedClusterLabels "acm-virt-config" hub}}` }}
@@ -66,7 +66,7 @@ spec:
             {{ `{{- $sch_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $sch_crd_name  }}` }}
             {{ `{{- $sch_crd_exists := eq $sch_crd.metadata.name  $sch_crd_name }}` }}
 
-            {{ `{{- /* check if acm-virt-restore-cls exists */ -}}` }}
+            {{ `{{- /* check if acm-dr-virt-restore-config--cls exists */ -}}` }}
             {{ `{{- $restore_config_file := lookup "v1" "ConfigMap" $ns $cls_restore_configmap_name }}` }}
             {{ `{{- $restore_config_file_exists := eq $restore_config_file.metadata.name $cls_restore_configmap_name }}` }}
 
@@ -204,7 +204,7 @@ spec:
                 {{ `{{- end }}` }}
 
                 {{ `{{- /* cls_restore_configmap_name is the name of the main restore config map, copied over to the cluster  */ -}}` }}
-                {{ `{{- $cls_restore_configmap_name := "acm-virt-restore-cls" }}` }}
+                {{ `{{- $cls_restore_configmap_name := "acm-dr-virt-restore-config--cls" }}` }}
                 {{ `{{- $restoreNameProp := (cat  (fromClusterClaim "id.openshift.io") "_" "restoreName") | replace " " ""}}` }}
                 {{ `{{- $restoreName := fromConfigMap $ns $cls_restore_configmap_name $restoreNameProp }}` }}
 

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -30,35 +30,11 @@ spec:
         spec:
           remediationAction: enforce
           severity: high
-          object-templates:
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: v1
-                kind: ConfigMap
-                metadata:
-                  name: acm-dr-virt-restore-config
-                  namespace: open-cluster-management-backup
-                data:
-                  clusterID_restoreName: ""
-                  clusterID_vmsUID: "uid1 uid2"
-                  clusterID_backupName: backupName
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: v1
-                kind: ConfigMap
-                metadata:
-                  name: acm-dr-virt-schedule-cron
-                  namespace: open-cluster-management-backup
-                data:
-                  hourly: "0 */1 * * *"
-                  every_2_hours: "0 */2 * * *"
-                  every_3_hours: "0 */3 * * *"
-                  every_4_hours: "0 */4 * * *"
-                  every_5_hours: "0 */5 * * *"
-                  every_6_hours: "0 */6 * * *"
-                  twice_a_day: "0 */12 * * *"
-                  daily_8am: "0 8 * * *"
-                  every_sunday: "0 0 * * 0"
+          object-templates-raw: |
+            {{ `{{hub $config_name := "acm-dr-virt-schedule-cron" hub}}` }}
+            {{ `{{hub $config_file := lookup "v1" "ConfigMap" "" $config_name hub}}` }}
+            {{ `{{hub $config_file_exists := eq $config_file.metadata.name $config_name hub}}` }}
+            {{ `{{hub if not $config_file_exists hub}}` }}
             - complianceType: musthave
               recordDiff: InStatus
               objectDefinition:
@@ -104,7 +80,7 @@ spec:
                     },
                     velero: {
                       defaultPlugins: [
-                        csi,       
+                        csi,
                         openshift,
                         kubevirt,
                         aws
@@ -112,6 +88,35 @@ spec:
                     }
                   },
                 }"
+            {{ `{{hub end hub}}` }}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: acm-dr-virt-restore-config
+                  namespace: open-cluster-management-backup
+                data:
+                  clusterID_restoreName: ""
+                  clusterID_vmsUID: "uid1 uid2"
+                  clusterID_backupName: backupName
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: acm-dr-virt-schedule-cron
+                  namespace: open-cluster-management-backup
+                data:
+                  hourly: "0 */1 * * *"
+                  every_2_hours: "0 */2 * * *"
+                  every_3_hours: "0 */3 * * *"
+                  every_4_hours: "0 */4 * * *"
+                  every_5_hours: "0 */5 * * *"
+                  every_6_hours: "0 */6 * * *"
+                  twice_a_day: "0 */12 * * *"
+                  daily_8am: "0 8 * * *"
+                  every_sunday: "0 0 * * 0"
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy


### PR DESCRIPTION
# Description

Allow updating acm-dr-virt-config properties after the ConfigMap is created by the policy

## Related Issue

https://issues.redhat.com/browse/ACM-18090

## Changes Made

- Updated vm-config-setup template to attempt to create the acm-dr-virt-config ConfigMap only when the maps are first created. Allow this way for the user to update the ConfigMap after initial creation ( the policy is not going to try to reconcile the policy after its creation )
- Updated temporary configmap names for the ConfigMap created on the managed clusters from the hub resources. Easier to map them back to the initial ConfigMap from where they were originated. The name is also hard to be overwritten by user by mistake ( used --cls ) as a suffix for the copied ConfigMap name


## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
