### PR TITLE
look for acm-dr-virt-config instead of acm-dr-virt-schedule-cron

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -31,7 +31,7 @@ spec:
           remediationAction: enforce
           severity: high
           object-templates-raw: |
-            {{ `{{hub $config_name := "acm-dr-virt-schedule-cron" hub}}` }}
+            {{ `{{hub $config_name := "acm-dr-virt-config" hub}}` }}
             {{ `{{hub $config_file := lookup "v1" "ConfigMap" "" $config_name hub}}` }}
             {{ `{{hub $config_file_exists := eq $config_file.metadata.name $config_name hub}}` }}
             {{ `{{hub if not $config_file_exists hub}}` }}


### PR DESCRIPTION
# Description

Related to https://github.com/stolostron/multiclusterhub-operator/pull/2031
When checking if the config needs to be created, look for the acm-dr-virt-config configmap instead of acm-dr-virt-schedule-cron. In this way, only when the acm-dr-virt-config configmap is deleted, it gets recreated.

## Related Issue

https://issues.redhat.com/browse/ACM-18090

## Changes Made

Updated vm-config-setup template to check for  acm-dr-virt-config configmap instead of acm-dr-virt-schedule-cron

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
