### PR TITLE
[ACM-18309] Added ValidatingWebhookConfiguration for siteconfig

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -23,7 +23,7 @@
 
 - repo_name: multicluster-observability-operator
   github_ref: "https://github.com/stolostron/multicluster-observability-operator.git"
-  branch: "release-2.13"
+  branch: "release-2.14"
   operators:
     - name: multicluster-observability-operator
       bundlePath: "operators/multiclusterobservability/bundle/manifests/"
@@ -32,7 +32,7 @@
 
 - repo_name: search-v2-operator
   github_ref: "https://github.com/stolostron/search-v2-operator.git"
-  branch: "release-2.13"
+  branch: "release-2.14"
   operators:
     - name: search-v2-operator
       bundlePath: "bundle/manifests/"
@@ -53,6 +53,8 @@
       imageMappings:
         kube-rbac-proxy: kube_rbac_proxy
         siteconfig-operator: siteconfig_operator
+      webhook_paths:
+        - config/webhook/manifests.yaml
 
 - repo_name: submariner-addon
   github_ref: "https://github.com/stolostron/submariner-addon.git"

--- a/pkg/templates/charts/toggle/siteconfig-operator/templates/clusterinstances.siteconfig.open-cluster-management.io-validatingwebhookconfiguration.yaml
+++ b/pkg/templates/charts/toggle/siteconfig-operator/templates/clusterinstances.siteconfig.open-cluster-management.io-validatingwebhookconfiguration.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'
+  name: clusterinstances.siteconfig.open-cluster-management.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-clusterinstances-siteconfig-open-cluster-management-io
+      namespace: '{{ default "system" .Values.global.namespace }}'
+      path: /validate-siteconfig-open-cluster-management-io-v1alpha1-clusterinstance
+  failurePolicy: Fail
+  name: clusterinstances.siteconfig.open-cluster-management.io
+  rules:
+  - apiGroups:
+    - siteconfig.open-cluster-management.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusterinstances
+  sideEffects: None


### PR DESCRIPTION
# Description

To ensure the SiteConfig operator starts up correctly, we need to deploy the webhook resource in ACM 2.13 and 2.14. In this PR, we've updated our automation config to retrieve the `validatingwebhookconfiguration` for their component, enabling MCH to deploy it during runtime.

## Related Issue

https://issues.redhat.com/browse/ACM-18309

## Changes Made

Updated `hack/bundle-automation/config.yaml` to include webhook path for SiteConfig component.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
