### PR TITLE
[ACM-18906] Updated MCH status for MCE subscription to reflect correct upgrade pending message

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -349,10 +349,15 @@ func mapSubscription(sub *unstructured.Unstructured) operatorsv1.StatusCondition
 	message := fmt.Sprintf("installPlanApproval: %s. installPlan: %s/%s",
 		installPlanApproval, installPlanNamespace, installPlanName)
 
+	/*
+		Based on the descriptions in the OLM Subscription CRD, the following holds true:
+		• InstalledCSV refers to the CSV that is currently installed by the Subscription.
+		• CurrentCSV refers to the CSV that the Subscription is in the process of upgrading to.
+	*/
 	if reason == "UpgradePending" {
 		currentCSV, _ := status["currentCSV"].(string)
 		installedCSV, _ := status["installedCSV"].(string)
-		message = fmt.Sprintf("Upgrade pending. Installed CSV: %s. Pending CSV: %s", currentCSV, installedCSV)
+		message = fmt.Sprintf("Upgrade pending. Installed CSV: %s. Pending CSV: %s", installedCSV, currentCSV)
 	}
 
 	return operatorsv1.StatusCondition{


### PR DESCRIPTION
# Description

In MCH, when reporting the status of the MCE subscription during an `UpgradePending` scenario, the `installedCSV` and `currentCSV` values are displayed in the incorrect order, which leads to confusion for end users. This PR will correct the order in which these values are referenced, ensuring clarity in the status message.

## Before
```yaml
    multicluster-engine-sub:
      kind: Subscription
      lastTransitionTime: '2025-03-14T16:00:38Z'
      message: 'Upgrade pending. Installed CSV: multicluster-engine.v2.6.6. Pending CSV: multicluster-engine.v2.6.5'
      name: multicluster-engine
      reason: UpgradePending
      status: 'True'
      type: Available 
```

## After
```yaml
    multicluster-engine-sub:
      kind: Subscription
      lastTransitionTime: '2025-03-14T16:00:38Z'
      message: 'Upgrade pending. Installed CSV: multicluster-engine.v2.6.5. Pending CSV: multicluster-engine.v2.6.6'
      name: multicluster-engine
      reason: UpgradePending
      status: 'True'
      type: Available 
```

## Related Issue

https://issues.redhat.com/browse/ACM-18906

## Changes Made

Updated MCE subscription status message for MCH CR.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
