### PR TITLE
Add CSP directive for GitHub API access

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
@@ -12,6 +12,10 @@ spec:
       namespace: {{ .Values.global.namespace }}
       port: 3000
     type: Service
+  contentSecurityPolicy:
+    - directive: 'ConnectSrc'
+      values:
+        - 'https://api.github.com'
   i18n:
     loadType: Preload
   proxy:


### PR DESCRIPTION
# Description

OpenShift console will start reporting Content Security Policy violations with version 4.19
ACM needs to declare that it will access the GitHub API for listing branches and paths in respositories when deploying applications.

## Related Issue

https://issues.redhat.com/browse/ACM-17765

## Changes Made

Added new configuration to the `ConsolePlugin` resource which should be ignored on older releases.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
