### PR TITLE
[ACM-19115] Improved storage class name handling for PVC and StatefulSet resources

### DIFF
--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2003,26 +2003,12 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 					Name:      "multiclusterhub",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						utils.AnnotationDefaultStorageClass: "gp3-csi",
+						utils.AnnotationDefaultStorageClass: "gp2-csi",
 					},
 				},
 			},
-			storageClasses: []storagev1.StorageClass{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "gp2-csi",
-					},
-					Provisioner: "ebs.csi.aws.com",
-					Parameters: map[string]string{
-						"encrypted": "true",
-						"type":      "gp2",
-					},
-					ReclaimPolicy:        &reclaimPolicy,
-					AllowVolumeExpansion: &allowVolumeExpansion,
-					VolumeBindingMode:    &volumeBindingMode,
-				},
-			},
-			expectedEnv: "gp3-csi",
+			storageClasses: []storagev1.StorageClass{},
+			expectedEnv:    "gp2-csi",
 		},
 		{
 			name: "should set default storageClassName when default marked",
@@ -2054,6 +2040,7 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 		},
 	}
 
+	os.Setenv(helpers.DefaultStorageClassName, "test-storage-class")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer os.Unsetenv(helpers.DefaultStorageClassName)

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2049,6 +2049,8 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer os.Unsetenv(helpers.DefaultStorageClassName)
+
 			for _, sc := range tt.storageClasses {
 				if err := recon.Client.Create(context.TODO(), &sc); err != nil {
 					t.Errorf("failed to create StorageClass: %v", err)

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2032,7 +2032,6 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 					AllowVolumeExpansion: &allowVolumeExpansion,
 					VolumeBindingMode:    &volumeBindingMode,
 				},
-			},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gp3-csi",

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2021,6 +2021,20 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 			storageClasses: []storagev1.StorageClass{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name: "gp2-csi",
+					},
+					Provisioner: "ebs.csi.aws.com",
+					Parameters: map[string]string{
+						"encrypted": "true",
+						"type":      "gp2",
+					},
+					ReclaimPolicy:        &reclaimPolicy,
+					AllowVolumeExpansion: &allowVolumeExpansion,
+					VolumeBindingMode:    &volumeBindingMode,
+				},
+			},
+				{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "gp3-csi",
 						Annotations: map[string]string{
 							utils.AnnotationKubeDefaultStorageClass: "true",

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -331,13 +331,11 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 	values.Global.ImageRepository = utils.GetImageRepository(mch)
 
 	annotations := mch.GetAnnotations()
-	if val, ok := annotations[utils.AnnotationEdgeManagerDefaultStorageClass]; ok {
+	if val, ok := annotations[utils.AnnotationDefaultStorageClass]; ok {
 		values.Global.StorageClassName = val
 	} else {
 		values.Global.StorageClassName = os.Getenv(helpers.DefaultStorageClassName)
 	}
-	
-	
 
 	// TODO: put this back later
 	// values.Global.HubSize = mch.Spec.HubSize

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -80,10 +80,16 @@ var (
 	AnnotationHubSize = "installer.open-cluster-management.io/hub-size"
 
 	/*
-		AnnotationDefaultStorageClass is an annotation used in the cluster to determine the default storage class
+		AnnotationDefaultStorageClass is an annotation used to set the default storage class name for multiclusterhub
+		component resources to use.
+	*/
+	AnnotationDefaultStorageClass = "installer.open-cluster-management.io/default-storage-class"
+
+	/*
+		AnnotationKubeDefaultStorageClass is an annotation used in the cluster to determine the default storage class
 		resource.
 	*/
-	AnnotationDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
+	AnnotationKubeDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
 )
 
 /*
@@ -175,6 +181,13 @@ func getAnnotationOrDefaultForMap(old, new map[string]string, primaryKey, deprec
 	}
 
 	return oldValue == newValue
+}
+
+/*
+GetDefaultStorageClassOverride
+*/
+func GetDefaultStorageClassOverride(instance *operatorsv1.MultiClusterHub) string {
+	return getAnnotation(instance, AnnotationDefaultStorageClass)
 }
 
 /*

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -305,6 +305,20 @@ func Test_GetOADPAnnotationOverrides(t *testing.T) {
 	})
 }
 
+func Test_GetDefaultStorageClassOverride(t *testing.T) {
+	t.Run("Get Default storage class annotation override for MCH", func(t *testing.T) {
+		mch := &operatorsv1.MultiClusterHub{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationDefaultStorageClass: "gp3-csi",
+			}},
+		}
+		want := "gp3-csi"
+		if got := GetDefaultStorageClassOverride(mch); got != want {
+			t.Errorf("GetDefaultStorageClassOverride(mch) = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestShouldIgnoreOCPVersion(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# Description

Setting a custom storage class name for StatefulSet and PersistentVolumeClaim resources through an environment variable (DEFAULT_STORAGE_CLASS_NAME) is not working as expected. The default storage class name always takes precedence, overriding any custom setting, and leading to StatefulSet resources application failure.

This PR will add the missing logic for the StatefulSet resources and ensure that the environment variable that is set is not getting overridden.

## Related Issue

https://issues.redhat.com/browse/ACM-19115

## Changes Made

Updated storage class name logic in the operator controller.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
