### PR TITLE
[ACM-19115] Improved storage class name handling for PVC and StatefulSet resources

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -5,7 +5,7 @@ REPO ?= installer-dev-tools
 BRANCH ?= main
 
 PIPELINE_REPO ?= pipeline
-PIPELINE_BRANCH ?= 2.12-integration
+PIPELINE_BRANCH ?= 2.14-integration
 
 .PHONY: update-manifest 
 

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: operator.open-cluster-management.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,9 +7,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multiclusterhub-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.35.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,10 +17,10 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-09-20T16:41:29Z"
+    createdAt: "2025-03-25T19:28:33Z"
     description: Open management of Openshift and Kubernetes clusters
-    operators.operatorframework.io/builder: operator-sdk-v1.35.0
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/builder: operator-sdk-v1.39.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/open-cluster-management/multiclusterhub-operator
     support: The Open Cluster Management Project
   name: multiclusterhub-operator.v0.0.1
@@ -29,10 +29,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: MulticlusterHub defines the configuration for an instance of a
-        multicluster hub, a central point for managing multiple Kubernetes-based clusters.
-        The deployment of multicluster hub components is determined based on the configuration
-        that is defined in this resource.
+    - description: |-
+        MulticlusterHub defines the configuration
+        for an instance of a multicluster hub, a central point for managing multiple
+        Kubernetes-based clusters. The deployment of multicluster hub components
+        is determined based on the configuration that is defined in this resource.
       displayName: MultiClusterHub
       kind: MultiClusterHub
       name: multiclusterhubs.operator.open-cluster-management.io
@@ -253,6 +254,19 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - endpoints
           - pods
           - services
@@ -333,16 +347,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups:
-          - ""
-          resources:
-          - serviceaccounts
-          verbs:
-          - create
-          - delete
-          - get
-          - patch
-          - update
         - apiGroups:
           - ""
           resources:
@@ -974,15 +978,6 @@ spec:
           - agent-install.openshift.io
           resources:
           - infraenvs
-          verbs:
-          - create
-          - delete
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - agent-install.openshift.io
-          resources:
           - nmstateconfigs
           verbs:
           - create
@@ -1179,6 +1174,9 @@ spec:
           - authorization.k8s.io
           resources:
           - uids
+          - userextras/authentication.kubernetes.io/credential-id
+          - userextras/authentication.kubernetes.io/node-name
+          - userextras/authentication.kubernetes.io/node-uid
           - userextras/authentication.kubernetes.io/pod-name
           - userextras/authentication.kubernetes.io/pod-uid
           verbs:
@@ -1460,16 +1458,12 @@ spec:
           resources:
           - agentclusterinstalls
           verbs:
-          - create
-          - delete
-          - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - extensions.hive.openshift.io
           resources:
+          - agentclusterinstalls
           - imageclusterinstalls
           verbs:
           - create
@@ -1477,6 +1471,60 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - flightctl.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - flightctl.io
+          resources:
+          - certificatesigningrequests
+          verbs:
+          - create
+          - get
+          - list
+        - apiGroups:
+          - flightctl.io
+          resources:
+          - devices
+          - fleets
+          - resourcesyncs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+        - apiGroups:
+          - flightctl.io
+          resources:
+          - devices/console
+          verbs:
+          - get
+        - apiGroups:
+          - flightctl.io
+          resources:
+          - enrollmentrequests
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - flightctl.io
+          resources:
+          - enrollmentrequests/approval
+          verbs:
+          - post
+        - apiGroups:
+          - flightctl.io
+          resources:
+          - fleets/templateversions
+          - repositories
+          verbs:
+          - get
+          - list
         - apiGroups:
           - hive.openshift.io
           resources:
@@ -1593,6 +1641,7 @@ spec:
           - metal3.io
           resources:
           - baremetalhosts
+          - hostfirmwaresettings
           verbs:
           - create
           - delete
@@ -1607,16 +1656,6 @@ spec:
           verbs:
           - list
           - watch
-        - apiGroups:
-          - metal3.io
-          resources:
-          - hostfirmwaresettings
-          verbs:
-          - create
-          - delete
-          - get
-          - patch
-          - update
         - apiGroups:
           - migration.k8s.io
           resources:
@@ -1644,6 +1683,7 @@ spec:
           - monitoring.coreos.com
           resources:
           - prometheusrules
+          - scrapeconfigs
           verbs:
           - create
           - delete
@@ -1748,7 +1788,14 @@ spec:
           - get
           - list
           - patch
+          - update
           - watch
+        - apiGroups:
+          - operator.open-cluster-management.io
+          resources:
+          - internalhubcomponents/finalizers
+          verbs:
+          - update
         - apiGroups:
           - operator.open-cluster-management.io
           resources:
@@ -1903,6 +1950,22 @@ spec:
           - '*'
           verbs:
           - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - delete
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - create
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,9 +6,9 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: multiclusterhub-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.35.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
@@ -15,10 +15,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: MulticlusterHub defines the configuration for an instance of a
-        multicluster hub, a central point for managing multiple Kubernetes-based clusters.
-        The deployment of multicluster hub components is determined based on the configuration
-        that is defined in this resource.
+    - description: |-
+        MulticlusterHub defines the configuration
+        for an instance of a multicluster hub, a central point for managing multiple
+        Kubernetes-based clusters. The deployment of multicluster hub components
+        is determined based on the configuration that is defined in this resource.
       displayName: MultiClusterHub
       kind: MultiClusterHub
       name: multiclusterhubs.operator.open-cluster-management.io

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -20,6 +20,7 @@ import (
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/helpers"
 	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine"
+	renderer "github.com/stolostron/multiclusterhub-operator/pkg/rendering"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	resources "github.com/stolostron/multiclusterhub-operator/test/unit-tests"
 	searchv2v1alpha1 "github.com/stolostron/search-v2-operator/api/v1alpha1"
@@ -1991,42 +1992,51 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		mch            *operatorv1.MultiClusterHub
 		storageClasses []storagev1.StorageClass
 		expectedEnv    string
 	}{
 		{
-			name:           "should not set default storage class name due to empty StorageClasses",
+			name: "should set default storageClassName with MCH annotation",
+			mch: &operatorv1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multiclusterhub",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						utils.AnnotationDefaultStorageClass: "gp2-csi",
+					},
+				},
+			},
 			storageClasses: []storagev1.StorageClass{},
-			expectedEnv:    "",
+			expectedEnv:    "gp2-csi",
 		},
 		{
-			name: "should set fallback storageClassName when default is not marked",
+			name: "should set default storageClassName when default marked",
+			mch: &operatorv1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multiclusterhub",
+					Namespace: "test-ns",
+				},
+			},
 			storageClasses: []storagev1.StorageClass{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "gp2-csi",
-						Annotations: map[string]string{},
+						Name: "gp2-csi",
 					},
 					Provisioner: "ebs.csi.aws.com",
 					Parameters: map[string]string{
 						"encrypted": "true",
-						"type":      "gp3",
+						"type":      "gp2",
 					},
 					ReclaimPolicy:        &reclaimPolicy,
 					AllowVolumeExpansion: &allowVolumeExpansion,
 					VolumeBindingMode:    &volumeBindingMode,
 				},
-			},
-			expectedEnv: "gp2-csi",
-		},
-		{
-			name: "should set default storageClassName when default marked",
-			storageClasses: []storagev1.StorageClass{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gp3-csi",
 						Annotations: map[string]string{
-							utils.AnnotationDefaultStorageClass: "true",
+							utils.AnnotationKubeDefaultStorageClass: "true",
 						},
 					},
 					Provisioner: "ebs.csi.aws.com",
@@ -2043,12 +2053,11 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 		},
 	}
 
-	if err := os.Setenv(helpers.DefaultStorageClassName, "test-storage-class"); err != nil {
-		t.Errorf("failed to set default StorageClassName: %v", err)
-	}
-
+	os.Setenv(helpers.DefaultStorageClassName, "test-storage-class")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer os.Unsetenv(helpers.DefaultStorageClassName)
+
 			for _, sc := range tt.storageClasses {
 				if err := recon.Client.Create(context.TODO(), &sc); err != nil {
 					t.Errorf("failed to create StorageClass: %v", err)
@@ -2056,12 +2065,79 @@ func Test_SetDefaultStorageClassName(t *testing.T) {
 			}
 
 			// Call the function under test
-			if err := recon.SetDefaultStorageClassName(context.TODO()); err != nil {
+			if _, err := recon.SetDefaultStorageClassName(context.TODO(), tt.mch); err != nil {
 				t.Errorf("SetDefaultStorageClassName failed: %v", err)
 			}
 
 			if got := os.Getenv(helpers.DefaultStorageClassName); got != tt.expectedEnv {
 				t.Errorf("Expected StorageClassName to be set to: %v, got: %v", tt.expectedEnv, got)
+			}
+		})
+	}
+}
+
+func Test_ApplyTemplate(t *testing.T) {
+	tests := []struct {
+		name             string
+		chartLocation    string
+		component        string
+		mch              *operatorv1.MultiClusterHub
+		storageClassName string
+		want             error
+	}{
+		{
+			name:             "should apply template for component",
+			chartLocation:    filepath.Join("../pkg/templates/", utils.EdgeManagerChartLocation),
+			component:        operatorv1.EdgeManagerPreview,
+			mch:              &operatorv1.MultiClusterHub{},
+			storageClassName: "gp2-csi",
+			want:             nil,
+		},
+	}
+
+	testImages := map[string]string{}
+	for _, v := range utils.GetTestImages() {
+		testImages[v] = "quay.io/test/test:Test"
+	}
+
+	testCacheSpec := CacheSpec{
+		ImageOverrides:    testImages,
+		TemplateOverrides: map[string]string{},
+	}
+
+	// Renders all templates from charts
+	registerScheme()
+	os.Setenv("ACM_HUB_OCP_VERSION", "4.18.0")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			templates, errs := renderer.RenderChart(tt.chartLocation, tt.mch, testCacheSpec.ImageOverrides,
+				testCacheSpec.TemplateOverrides, false)
+
+			if errs != nil {
+				t.Errorf("Failed to render chart for %v", tt.component)
+			}
+
+			for _, template := range templates {
+				if _, err := recon.applyTemplate(context.TODO(), tt.mch, template); err != nil {
+					t.Errorf("failed: %v", err)
+				}
+			}
+
+			os.Setenv(helpers.DefaultStorageClassName, "gp3-csi")
+			templates, errs = renderer.RenderChart(tt.chartLocation, tt.mch, testCacheSpec.ImageOverrides,
+				testCacheSpec.TemplateOverrides, false)
+
+			if errs != nil {
+				t.Errorf("Failed to render chart for %v", tt.component)
+			}
+
+			for _, template := range templates {
+				if template.GetKind() == "PersistentVolumeClaim" || template.GetKind() == "StatefulSet" {
+					if _, err := recon.applyTemplate(context.TODO(), tt.mch, template); err != nil {
+						t.Errorf("applyTemplate() = %v, want = %v", err, tt.want)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -80,10 +80,16 @@ var (
 	AnnotationHubSize = "installer.open-cluster-management.io/hub-size"
 
 	/*
-		AnnotationDefaultStorageClass is an annotation used in the cluster to determine the default storage class
+		AnnotationDefaultStorageClass is an annotation used to set the default storage class name for multiclusterhub
+		operand resources to use.
+	*/
+	AnnotationDefaultStorageClass = "installer.open-cluster-management.io/default-storage-class"
+
+	/*
+		AnnotationKubeDefaultStorageClass is an annotation used in the cluster to determine the default storage class
 		resource.
 	*/
-	AnnotationDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
+	AnnotationKubeDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
 )
 
 /*
@@ -175,6 +181,13 @@ func getAnnotationOrDefaultForMap(old, new map[string]string, primaryKey, deprec
 	}
 
 	return oldValue == newValue
+}
+
+/*
+GetDefaultStorageClassOverride
+*/
+func GetDefaultStorageClassOverride(instance *operatorsv1.MultiClusterHub) string {
+	return getAnnotation(instance, AnnotationDefaultStorageClass)
 }
 
 /*

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -305,6 +305,20 @@ func Test_GetOADPAnnotationOverrides(t *testing.T) {
 	})
 }
 
+func Test_GetDefaultStorageClassOverride(t *testing.T) {
+	t.Run("Get Default storage class annotation override for MCH", func(t *testing.T) {
+		mch := &operatorsv1.MultiClusterHub{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationDefaultStorageClass: "gp3-csi",
+			}},
+		}
+		want := "gp3-csi"
+		if got := GetDefaultStorageClassOverride(mch); got != want {
+			t.Errorf("GetDefaultStorageClassOverride(mch) = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestShouldIgnoreOCPVersion(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# Description

Setting a custom storage class name for StatefulSet and PersistentVolumeClaim resources through an environment variable (DEFAULT_STORAGE_CLASS_NAME) is not working as expected. The default storage class name always takes precedence, overriding any custom setting, and leading to StatefulSet resources application failure.

This PR will add the missing logic for the StatefulSet resources and ensure that the environment variable that is set is not getting overridden.

## Related Issue

https://issues.redhat.com/browse/ACM-19115

## Changes Made

Updated storage class name logic in the operator controller.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
