### PR TITLE
startingCSV can now be set via annotation

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -50,6 +50,7 @@ type Global struct {
 	BaseDomain          string               `json:"baseDomain" structs:"baseDomain"`
 	DeployOnOCP         bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
 	StorageClassName    string               `json:"storageClassName" structs:"storageClassName"`
+	StartingCSV         string               `json:"startingCSV" structs:"startingCSV"`
 }
 
 type HubConfig struct {
@@ -372,16 +373,16 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 		values.HubConfig.ProxyConfigs = proxyVar
 	}
 
-	values.Global.Name, values.Global.Channel, values.Global.InstallPlanApproval, values.Global.Source, values.Global.SourceNamespace = GetOADPConfig(mch)
+	values.Global.Name, values.Global.Channel, values.Global.InstallPlanApproval, values.Global.Source, values.Global.SourceNamespace, values.Global.StartingCSV = GetOADPConfig(mch)
 
 	values.Global.MinOADPChannel = defaultOADPChannel
 
 	// TODO: Define all overrides
 }
 
-func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval, string, string) {
+func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval, string, string, string) {
 	sub := &subv1alpha1.SubscriptionSpec{}
-	var name, channel, source, sourceNamespace string
+	var name, channel, source, sourceNamespace, startingCSV string
 	var installPlan subv1alpha1.Approval
 
 	if oadpSpec := utils.GetOADPAnnotationOverrides(m); oadpSpec != "" {
@@ -389,7 +390,7 @@ func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval,
 		err := json.Unmarshal([]byte(oadpSpec), sub)
 		if err != nil {
 			log.Info(fmt.Sprintf("Failed to unmarshal OADP annotation: %s.", oadpSpec))
-			return "", "", "", "", ""
+			return "", "", "", "", "", ""
 		}
 	}
 
@@ -422,5 +423,9 @@ func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval,
 	} else {
 		sourceNamespace = defaultOADPSourceNamespace
 	}
-	return name, channel, installPlan, source, sourceNamespace
+
+	if sub.StartingCSV != "" {
+		startingCSV = sub.StartingCSV
+	}
+	return name, channel, installPlan, source, sourceNamespace, startingCSV
 }

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -307,7 +307,7 @@ func TestRenderCRDs(t *testing.T) {
 }
 
 func TestOADPAnnotation(t *testing.T) {
-	oadp := `{"channel": "stable-1.0", "installPlanApproval": "Manual", "name": "redhat-oadp-operator2", "source": "redhat-operators2", "sourceNamespace": "openshift-marketplace2"}`
+	oadp := `{"channel": "stable-1.0", "installPlanApproval": "Manual", "name": "redhat-oadp-operator2", "source": "redhat-operators2", "sourceNamespace": "openshift-marketplace2", "startingCSV": "test-csv"}`
 	mch := &v1.MultiClusterHub{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
@@ -317,7 +317,7 @@ func TestOADPAnnotation(t *testing.T) {
 		},
 	}
 
-	test1, test2, test3, test4, test5 := GetOADPConfig(mch)
+	test1, test2, test3, test4, test5, test6 := GetOADPConfig(mch)
 
 	if test1 != "redhat-oadp-operator2" {
 		t.Error("Cluster Backup missing OADP overrides for name")
@@ -339,6 +339,10 @@ func TestOADPAnnotation(t *testing.T) {
 		t.Error("Cluster Backup missing OADP overrides for source namespace")
 	}
 
+	if test6 != "test-csv" {
+		t.Error("Cluster Backup missing startingCSV overrides for source")
+	}
+
 	mch = &v1.MultiClusterHub{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test",
@@ -346,7 +350,7 @@ func TestOADPAnnotation(t *testing.T) {
 	}
 
 	// These should all be the defaults (no overrides)
-	test1, test2, test3, test4, test5 = GetOADPConfig(mch)
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
 
 	if test1 != defaultOADPName {
 		t.Error("Cluster Backup missing OADP overrides for name")
@@ -366,5 +370,9 @@ func TestOADPAnnotation(t *testing.T) {
 
 	if test5 != defaultOADPSourceNamespace {
 		t.Error("Cluster Backup missing OADP overrides for source namespace")
+	}
+
+	if test6 != "" {
+		t.Error("Cluster Backup Defaulted to something other than \"\"")
 	}
 }

--- a/pkg/templates/charts/toggle/cluster-backup/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/values.yaml
@@ -18,6 +18,7 @@ global:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   hubSize: Small
+  startingCSV: ""
 hubconfig:
   clusterSTSEnabled: false
   nodeSelector: null


### PR DESCRIPTION
Annotation `installer.open-cluster-management.io/oadp-subscription-spec` now accepts `startingCSV`