### PR TITLE
[release-2.13][ACM-19713] Updated charts-config imageMapping for edge-manager

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -11,7 +11,9 @@
         flightctl-api: flightctl_api
         flightctl-ui: flightctl_ui
         flightctl-ocp-ui: flightctl_ocp_ui
+        origin-cli: origin_cli
         postgresql-12-c8s: postgresql_16
+        redis: redis
       inclusions:
         - "pullSecretOverride"
       skipRBACOverrides: true


### PR DESCRIPTION
# Description

In ACM 2.13 our automation has detected that `edge-manager` needs the following image keys added to the `imageMapping`:
- `origin-cli`
- `redis`

## Related Issue

https://issues.redhat.com/browse/ACM-19713

## Changes Made

Updated `imageMapping` for `edge-manager`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
