### PR TITLE
[release-2.13][ACM-19713] Updated test images references to include new Edge Manager images

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -340,7 +340,7 @@ func GetTestImages() []string {
 		"multicloud_integrations", "multicluster_operators_channel", "multicluster_operators_subscription",
 		"multicluster_observability_operator", "cluster_permission", "siteconfig_operator", "submariner_addon", "acm_cli",
 		"flightctl_worker", "flightctl_periodic", "flightctl_api", "flightctl_ui", "flightctl_ocp_ui",
-		"postgresql_12_c8s", "postgresql_12", "postgresql_16",
+		"postgresql_12_c8s", "postgresql_12", "postgresql_16", "origin_cli", "redis",
 	}
 }
 


### PR DESCRIPTION
# Description

As we onboard new image keys into MCH or MCE, it's important to make sure they are added to the `testImages` map so we can properly render resources in both `dev` and `prod` environments.

## Related Issue

https://issues.redhat.com/browse/ACM-19713
https://github.com/stolostron/multiclusterhub-operator/pull/2128

## Changes Made

Updated `testImages` map to include new image keys.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
