### PR TITLE
[ACM-19914] Updated chart render to support OADP stable-1.5 channel for OCP 4.19

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -25,61 +25,28 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type Values struct {
-	Global    Global    `json:"global" structs:"global"`
-	HubConfig HubConfig `json:"hubconfig" structs:"hubconfig"`
-	Org       string    `json:"org" structs:"org"`
-}
-
-type Global struct {
-	ImageOverrides      map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
-	TemplateOverrides   map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
-	PullPolicy          string               `json:"pullPolicy" structs:"pullPolicy"`
-	PullSecret          string               `json:"pullSecret" structs:"pullSecret"`
-	Namespace           string               `json:"namespace" structs:"namespace"`
-	ImageRepository     string               `json:"imageRepository" structs:"namespace"`
-	Name                string               `json:"name" structs:"name"`
-	Channel             string               `json:"channel" structs:"Channel"`
-	MinOADPChannel      string               `json:"minOADPChannel" structs:"minOADPChannel"`
-	InstallPlanApproval subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
-	Source              string               `json:"source" structs:"source"`
-	SourceNamespace     string               `json:"sourceNamespace" structs:"sourceNamespace"`
-	HubSize             v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
-	APIUrl              string               `json:"apiUrl" structs:"apiUrl"`
-	Target              string               `json:"target" structs:"target"`
-	BaseDomain          string               `json:"baseDomain" structs:"baseDomain"`
-	DeployOnOCP         bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
-	StorageClassName    string               `json:"storageClassName" structs:"storageClassName"`
-	StartingCSV         string               `json:"startingCSV" structs:"startingCSV"`
-}
-
-type HubConfig struct {
-	ClusterSTSEnabled bool              `json:"clusterSTSEnabled" structs:"clusterSTSEnabled"`
-	NodeSelector      map[string]string `json:"nodeSelector" structs:"nodeSelector"`
-	ProxyConfigs      map[string]string `json:"proxyConfigs" structs:"proxyConfigs"`
-	ReplicaCount      int               `json:"replicaCount" structs:"replicaCount"`
-	Tolerations       []Toleration      `json:"tolerations" structs:"tolerations"`
-	OCPVersion        string            `json:"ocpVersion" structs:"ocpVersion"`
-	HubVersion        string            `json:"hubVersion" structs:"hubVersion"`
-	OCPIngress        string            `json:"ocpIngress" structs:"ocpIngress"`
-	SubscriptionPause string            `json:"subscriptionPause" structs:"subscriptionPause"`
-}
-
-type Toleration struct {
-	Key               string                    `json:"Key" protobuf:"bytes,1,opt,name=key"`
-	Operator          corev1.TolerationOperator `json:"Operator" protobuf:"bytes,2,opt,name=operator,casttype=TolerationOperator"`
-	Value             string                    `json:"Value" protobuf:"bytes,3,opt,name=value"`
-	Effect            corev1.TaintEffect        `json:"Effect" protobuf:"bytes,4,opt,name=effect,casttype=TaintEffect"`
-	TolerationSeconds *int64                    `json:"TolerationSeconds" protobuf:"varint,5,opt,name=tolerationSeconds"`
-}
-
 // defaults for the OADP subscription that will be created by the installer
 const (
-	defaultOADPChannel         = "stable-1.4" // This will also be the minOADPChannel (min version we expect to be installed)
-	defaultOADPName            = "redhat-oadp-operator"
-	defaultOADPInstallPlan     = "Automatic"
-	defaultOADPSource          = "redhat-operators"
-	defaultOADPSourceNamespace = "openshift-marketplace"
+	// defaultOADPChannel specifies the minimum OADP channel version that should be installed by default.
+	// This also represents the minimum expected version for installation.
+	defaultOADPChannel = "stable-1.4"
+
+	// ocp419OADPChannel indicates the required OADP channel for clusters running OCP 4.19.
+	// Only the "stable-1.5" channel is supported on OCP 4.19.
+	ocp419OADPChannel = "stable-1.5"
+
+	// defaultOADPName is the name of the OADP operator to be created by the installer.
+	defaultOADPName = "redhat-oadp-operator"
+
+	// defaultOADPInstallPlan defines the default approval policy for the OADP subscription's install plan.
+	// Supported values are: "Automatic" or "Manual".
+	defaultOADPInstallPlan = "Automatic"
+
+	// defaultOADPCatalogSource specifies the default operator catalog source for the OADP subscription.
+	defaultOADPCatalogSource = "redhat-operators"
+
+	// defaultOADPCatalogSourceNamespace defines the default namespace where the OADP operator catalog source is located.
+	defaultOADPCatalogSourceNamespace = "openshift-marketplace"
 )
 
 var log = logf.Log.WithName("reconcile")
@@ -375,6 +342,8 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 
 	values.Global.Name, values.Global.Channel, values.Global.InstallPlanApproval, values.Global.Source, values.Global.SourceNamespace, values.Global.StartingCSV = GetOADPConfig(mch)
 
+	values.Global.Channel15 = ocp419OADPChannel
+
 	values.Global.MinOADPChannel = defaultOADPChannel
 
 	// TODO: Define all overrides
@@ -415,13 +384,13 @@ func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval,
 	if sub.CatalogSource != "" {
 		source = sub.CatalogSource
 	} else {
-		source = defaultOADPSource
+		source = defaultOADPCatalogSource
 	}
 
 	if sub.CatalogSourceNamespace != "" {
 		sourceNamespace = sub.CatalogSourceNamespace
 	} else {
-		sourceNamespace = defaultOADPSourceNamespace
+		sourceNamespace = defaultOADPCatalogSourceNamespace
 	}
 
 	if sub.StartingCSV != "" {

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -364,11 +364,11 @@ func TestOADPAnnotation(t *testing.T) {
 		t.Error("Cluster Backup missing OADP overrides for install plan")
 	}
 
-	if test4 != defaultOADPSource {
+	if test4 != defaultOADPCatalogSource {
 		t.Error("Cluster Backup missing OADP overrides for source")
 	}
 
-	if test5 != defaultOADPSourceNamespace {
+	if test5 != defaultOADPCatalogSourceNamespace {
 		t.Error("Cluster Backup missing OADP overrides for source namespace")
 	}
 

--- a/pkg/rendering/values.go
+++ b/pkg/rendering/values.go
@@ -1,0 +1,57 @@
+// Copyright Contributors to the Open Cluster Management project
+package renderer
+
+import (
+	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Values struct {
+	Global    Global    `json:"global" structs:"global"`
+	HubConfig HubConfig `json:"hubconfig" structs:"hubconfig"`
+	Org       string    `json:"org" structs:"org"`
+}
+
+type Global struct {
+	ImageOverrides      map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
+	TemplateOverrides   map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
+	PullPolicy          string               `json:"pullPolicy" structs:"pullPolicy"`
+	PullSecret          string               `json:"pullSecret" structs:"pullSecret"`
+	Namespace           string               `json:"namespace" structs:"namespace"`
+	ImageRepository     string               `json:"imageRepository" structs:"namespace"`
+	Name                string               `json:"name" structs:"name"`
+	Channel             string               `json:"channel" structs:"channel"`
+	Channel15           string               `json:"channel15" structs:"channel15"`
+	MinOADPChannel      string               `json:"minOADPChannel" structs:"minOADPChannel"`
+	InstallPlanApproval subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
+	Source              string               `json:"source" structs:"source"`
+	SourceNamespace     string               `json:"sourceNamespace" structs:"sourceNamespace"`
+	HubSize             v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
+	APIUrl              string               `json:"apiUrl" structs:"apiUrl"`
+	Target              string               `json:"target" structs:"target"`
+	BaseDomain          string               `json:"baseDomain" structs:"baseDomain"`
+	DeployOnOCP         bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
+	StorageClassName    string               `json:"storageClassName" structs:"storageClassName"`
+	StartingCSV         string               `json:"startingCSV" structs:"startingCSV"`
+}
+
+type HubConfig struct {
+	ClusterSTSEnabled bool              `json:"clusterSTSEnabled" structs:"clusterSTSEnabled"`
+	NodeSelector      map[string]string `json:"nodeSelector" structs:"nodeSelector"`
+	ProxyConfigs      map[string]string `json:"proxyConfigs" structs:"proxyConfigs"`
+	ReplicaCount      int               `json:"replicaCount" structs:"replicaCount"`
+	Tolerations       []Toleration      `json:"tolerations" structs:"tolerations"`
+	OCPVersion        string            `json:"ocpVersion" structs:"ocpVersion"`
+	HubVersion        string            `json:"hubVersion" structs:"hubVersion"`
+	OCPIngress        string            `json:"ocpIngress" structs:"ocpIngress"`
+	SubscriptionPause string            `json:"subscriptionPause" structs:"subscriptionPause"`
+}
+
+type Toleration struct {
+	Key               string                    `json:"Key" protobuf:"bytes,1,opt,name=key"`
+	Operator          corev1.TolerationOperator `json:"Operator" protobuf:"bytes,2,opt,name=operator,casttype=TolerationOperator"`
+	Value             string                    `json:"Value" protobuf:"bytes,3,opt,name=value"`
+	Effect            corev1.TaintEffect        `json:"Effect" protobuf:"bytes,4,opt,name=effect,casttype=TaintEffect"`
+	TolerationSeconds *int64                    `json:"TolerationSeconds" protobuf:"varint,5,opt,name=tolerationSeconds"`
+}


### PR DESCRIPTION
# Description

When deploying ACM 2.14 on OCP 4.19, only the OADP `stable-1.5` channel is supported. As a result, we had to update our render functionality to allow selecting the appropriate channel for OCP 4.19.

## Related Issue

https://issues.redhat.com/browse/ACM-19914

## Changes Made

Updated `renderer.go` file.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
