### PR TITLE
get oadp from stable channel if OCP version is 4.19 or 4.2

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -423,8 +423,8 @@ spec:
                 {{ `{{- $ocp_version = $hist.version }}` }}
               {{ `{{- end }}` }}
             {{ `{{- end }}` }}
-            {{ `{{ if hasPrefix "4.19" $ocp_version }}` }}
-            {{ `{{- $ch = "stable-1.5" }}` }}
+            {{ `{{ if or (hasPrefix "4.19" $ocp_version) (hasPrefix "4.2" $ocp_version) }}` }}
+            {{ `{{- $ch = "stable" }}` }}
             {{ `{{- end }}` }}
             {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "open-cluster-management-backup" "").items }}` }}
               {{ `{{- if and (eq $ss.spec.name "redhat-oadp-operator") (lt $ss.spec.channel $ch) }}` }}
@@ -442,10 +442,10 @@ spec:
           customMessage:
             compliant: |- 
               The redhat-oadp-operator subscription installation does not exist in the open-cluster-management-backup namespace, 
-              or the installed version matches or exceeds the version set by the backup and restore operator Helm chart.
+              or the installed version matches or exceeds the supported version set by the backup and restore operator Helm chart.
             noncompliant: 
               The version of the redhat-oadp-operator operator installed in the open-cluster-management-backup namespace 
-              is lower than the version set by the backup and restore operator Helm chart.
+              is lower than the supported version set by the backup and restore operator Helm chart.
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy

--- a/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
@@ -13,8 +13,8 @@ metadata:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-2"
 data:
-  {{- if (hasPrefix "4.19" .Values.hubconfig.ocpVersion) }}
-  channel: {{ .Values.global.channel15 }}
+  {{- if or (hasPrefix "4.19" .Values.hubconfig.ocpVersion) (hasPrefix "4.2" .Values.hubconfig.ocpVersion) }}
+  channel: stable
   {{- else }}
   channel: {{ .Values.global.channel }}
   {{- end }}
@@ -37,8 +37,8 @@ metadata:
     "helm.sh/hook-weight": "-1"
     "helm.sh/resource-policy": delete
 spec:
-  {{- if (hasPrefix "4.19" .Values.hubconfig.ocpVersion) }}
-  channel: {{ .Values.global.channel15 }}
+  {{- if or (hasPrefix "4.19" .Values.hubconfig.ocpVersion) (hasPrefix "4.2" .Values.hubconfig.ocpVersion) }}
+  channel: stable
   {{- else }}
   channel: {{ .Values.global.channel }}
   {{- end }}

--- a/pkg/templates/charts/toggle/cluster-backup/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/values.yaml
@@ -19,7 +19,6 @@ global:
   sourceNamespace: openshift-marketplace
   hubSize: Small
   startingCSV: ""
-  channel15: stable-1.5
 hubconfig:
   clusterSTSEnabled: false
   nodeSelector: null


### PR DESCRIPTION
# Description

Fix oadp channel default for OCP 4.19 or higher. Use OADP stable channel for this, otherwise default to the chart specified oadp channel

## Related Issue

https://issues.redhat.com/browse/ACM-19914

## Changes Made

Updated the oadp subscription resource to use stable channel for OCP 4.19 or higher. ( odap-operator-pre-install-hook.yaml)
Update policy validation to use stable channel for OCP 4.19 or higher (hub-backup-pod.yaml)

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
