### PR TITLE
Revert "[ACM-19914] Updated chart render to support OADP stable-1.5 channel for OCP 4.19"

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -31,10 +31,6 @@ const (
 	// This also represents the minimum expected version for installation.
 	defaultOADPChannel = "stable-1.4"
 
-	// ocp419OADPChannel indicates the required OADP channel for clusters running OCP 4.19.
-	// Only the "stable-1.5" channel is supported on OCP 4.19.
-	ocp419OADPChannel = "stable-1.5"
-
 	// defaultOADPName is the name of the OADP operator to be created by the installer.
 	defaultOADPName = "redhat-oadp-operator"
 
@@ -341,8 +337,6 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 	}
 
 	values.Global.Name, values.Global.Channel, values.Global.InstallPlanApproval, values.Global.Source, values.Global.SourceNamespace, values.Global.StartingCSV = GetOADPConfig(mch)
-
-	values.Global.Channel15 = ocp419OADPChannel
 
 	values.Global.MinOADPChannel = defaultOADPChannel
 

--- a/pkg/rendering/values.go
+++ b/pkg/rendering/values.go
@@ -22,7 +22,6 @@ type Global struct {
 	ImageRepository     string               `json:"imageRepository" structs:"namespace"`
 	Name                string               `json:"name" structs:"name"`
 	Channel             string               `json:"channel" structs:"channel"`
-	Channel15           string               `json:"channel15" structs:"channel15"`
 	MinOADPChannel      string               `json:"minOADPChannel" structs:"minOADPChannel"`
 	InstallPlanApproval subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
 	Source              string               `json:"source" structs:"source"`


### PR DESCRIPTION
# Description

Based on conversation on slack:

> OADP will have a common channel going forward, names stable - had a discussion with them yesterday
And this would fix support for all OCP version 4.19 or newer

Reverts stolostron/multiclusterhub-operator#2147

## Related Issue

- https://issues.redhat.com/browse/ACM-19914
- https://github.com/stolostron/multiclusterhub-operator/pull/2148

## Changes Made

Reverted changes for `stable-1.5` channel support.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
