### PR TITLE
add support for ocp 4.19 on virt policies

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
@@ -107,7 +107,24 @@ spec:
                       name: "{{ `{{hub $config_name hub}}` }}"
                       namespace: "open-cluster-management-backup"
             {{ `{{hub else hub}}` }}
-              {{ `{{- $ch := "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "channel" hub}}" }}` }}
+              {{ `{{- $oadp_channel := "stable-1.4" }}` }}
+              {{ `{{- $ocp_version := "" }}` }}
+              {{ `{{- $cluster_version := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version")  }}` }}
+              {{ `{{- if eq $cluster_version.metadata.name  "version" }}` }}
+                {{ `{{- range $hist := $cluster_version.status.history}}` }}
+                  {{ `{{- $ocp_version = $hist.version }}` }}
+                {{ `{{- end }}` }}
+              {{ `{{- end }}` }}
+              {{ `{{ if or (hasPrefix "4.19" $ocp_version) (hasPrefix "4.2" $ocp_version) }}` }}
+              {{ `{{- $oadp_channel = "stable" }}` }}
+              {{ `{{- end }}` }}
+              {{ `{{ if hasPrefix "4.12" $ocp_version }}` }}
+              {{ `{{- $oadp_channel = "stable-1.3" }}` }}
+              {{ `{{- end }}` }}
+              {{ `{{- $oadp_channel_version := "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "channel" hub}}" }}` }}
+              {{ `{{ if not (eq "" $oadp_channel_version) }}` }}
+                {{ `{{- $oadp_channel = $oadp_channel_version }}` }}
+              {{ `{{- end }}` }}
               {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "" "").items }}` }}
                 {{ `{{ if (eq $ss.spec.name "redhat-oadp-operator")  }}` }}
                 - complianceType: musthave
@@ -118,7 +135,7 @@ spec:
                       name: {{ `{{ $ss.metadata.name }}` }}
                       namespace: {{ `{{ $ss.metadata.namespace }}` }}
                     spec:
-                      channel: {{ `{{ $ch }}` }}
+                      channel: {{ `{{ $oadp_channel }}` }}
                     status:
                       conditions:
                         - reason: AllCatalogSourcesHealthy
@@ -267,8 +284,23 @@ spec:
             {{ `{{- $acm_crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $acm_crd_name  }}` }}
             {{ `{{- $is_hub := eq $acm_crd.metadata.name  $acm_crd_name }}` }}
 
+            {{ `{{- /* inferre the oadp channel from the cluster ocp version */ -}}` }}
             {{ `{{- $oadp_channel := "stable-1.4" }}` }}
+            {{ `{{- $ocp_version := "" }}` }}
+            {{ `{{- $cluster_version := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version")  }}` }}
+            {{ `{{- if eq $cluster_version.metadata.name  "version" }}` }}
+              {{ `{{- range $hist := $cluster_version.status.history}}` }}
+                {{ `{{- $ocp_version = $hist.version }}` }}
+              {{ `{{- end }}` }}
+            {{ `{{- end }}` }}
+            {{ `{{ if or (hasPrefix "4.19" $ocp_version) (hasPrefix "4.2" $ocp_version) }}` }}
+            {{ `{{- $oadp_channel = "stable" }}` }}
+            {{ `{{- end }}` }}
+            {{ `{{ if hasPrefix "4.12" $ocp_version }}` }}
+            {{ `{{- $oadp_channel = "stable-1.3" }}` }}
+            {{ `{{- end }}` }}
             {{ `{{- $subscriptionInstallPlanApproval := "Automatic" }}` }}
+            {{ `{{- /* channelName - optional, set this property for custom installation only */ -}}` }}
             {{ `{{- $channelName := "redhat-oadp-operator" }}` }}
             {{ `{{- $subscriptionSourceNamespace := "openshift-marketplace" }}` }}
             {{ `{{- $subscriptionSource := "redhat-operators" }}` }}
@@ -278,7 +310,10 @@ spec:
             {{ `{{hub $config_file_exists := eq $config_file.metadata.name $config_name hub}}` }}
 
             {{ `{{hub if $config_file_exists hub}}` }}
-                  {{ `{{- $oadp_channel := "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "channel" hub}}" }}` }}
+                  {{ `{{- $oadp_channel_version := "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "channel" hub}}" }}` }}
+                  {{ `{{ if not (eq "" $oadp_channel_version) }}` }}
+                    {{ `{{- $oadp_channel = $oadp_channel_version }}` }}
+                  {{ `{{- end }}` }}
                   {{ `{{- $subscPlanConfig := "{{hub fromConfigMap "" (printf "%s" (index .ManagedClusterLabels "acm-virt-config")) "subscriptionInstallPlanApproval" hub}}" }}` }}
                   {{ `{{ if not (eq "" $subscPlanConfig) }}` }}
                     {{ `{{- $subscriptionInstallPlanApproval = $subscPlanConfig }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -45,7 +45,6 @@ spec:
                   namespace: open-cluster-management-backup
                 data:
                   backupNS: open-cluster-management-backup
-                  channel: stable-1.4
                   credentials_hub_secret_name: cloud-credentials
                   credentials_name: cloud-credentials
                   dpa_name: dpa-vm-policy


### PR DESCRIPTION
# Description

Update virtualization policy to install OADP based on the ocp version. 

## Related Issue

https://issues.redhat.com/browse/ACM-19866

## Changes Made

Updated `vm-config-setup` template to not setup the oadp channel by default. The channel will now be set based on the ocp version.
Updated the `acm-dr-virt-install` policy to set the oadp channel based on the ocp version, if the oadp version is not set by the user with the configmap

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
