### PR TITLE
[ACM-18824] Added security-context-constraints override to flight-control chart config

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -17,9 +17,12 @@
         redis-7-c9s: redis_7_c9s
       inclusions:
         - "pullSecretOverride"
-      skipRBACOverrides: true
+      escape-template-variables: []
       updateChartVersion: false # the chart version will be retrieved from trimmed branch name, e.g. backplane-2.4 -> 2.4
-      escape-template-variables:
-
-
-
+      security-context-constraints:
+        - kind: "Deployment"
+          name: flightctl-db
+          containers:
+            - name: flightctl-db
+              readOnlyRootFilesystem: false
+      skipRBACOverrides: true


### PR DESCRIPTION
# Description

Added `security-context-constraints` to `flight-control` chart to ensure that the `flightctl-db` deployment is not overridden for `readOnlyRootFilesystem`.

## Related Issue

https://issues.redhat.com/browse/ACM-18824

## Changes Made

Added `security-context-constraints` to `flight-control` config.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
