### PR TITLE
support restoring a vm in a different ns

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-restore.yaml
@@ -85,6 +85,9 @@ spec:
               {{ `{{- $vmUIDsProp := (cat  $restoreClusterID "_" "vmsUID") | replace " " ""}}` }}
               {{ `{{- $vmUIDs := fromConfigMap $ns $cls_restore_configmap_name $vmUIDsProp }}` }}
 
+              {{ `{{- $nsMappingProp := (cat  $restoreClusterID "_" "namespaceMapping") | replace " " ""}}` }}
+              {{ `{{- $nsMapping := fromConfigMap $ns $cls_restore_configmap_name $nsMappingProp }}` }}
+
               {{ `{{- /* vms_ns gives the list of all namespaces where VM exist  */ -}}` }}
               {{ `{{ $vms_ns := " " }}` }}
               {{ `{{- /* vms_ns gives the list of all VM names  */ -}}` }}
@@ -124,6 +127,17 @@ spec:
                 spec:
                   backupName: {{ `{{ $backupName }}` }}
                   restorePVs: true
+                  {{ `{{ if not (eq $nsMapping " ") }}` }}
+                  namespaceMapping:
+                    {{ `{{- range $ns_map := split " " $nsMapping }}` }}
+                    {{ `{{ if not (eq $ns_map "") }}` }}
+                    {{ `{{- $vm_ns_list := splitn "=" 2 $ns_map }}` }}
+                    {{ `{{- $vm_namespace_old := $vm_ns_list._0 }}` }}
+                    {{ `{{- $vm_namespace_new := $vm_ns_list._1 }}` }}
+                    {{ `{{ $vm_namespace_old }}` }}: {{ `{{ $vm_namespace_new }}` }}
+                    {{ `{{- end }}` }}
+                    {{ `{{- end }}` }}
+                  {{ `{{- end }}` }}
                   {{ `{{ if not (eq $vms_ns " ") }}` }}
                   includedNamespaces:
                     {{ `{{- range $vms_namespace := split " " $vms_ns }}` }}


### PR DESCRIPTION
# Description

Allow restoring a vm in a different namespace

## Related Issue

https://issues.redhat.com/browse/ACM-19860

## Changes Made

Updated restore operation 
- restore-config ConfigMap has a new optional property that can be used to provide a ns mapping for a cluster restore action: `clusterID_namespaceMapping: backup-ns-1=restore-ns-1 backup-ns-2=restore-ns-2`
- updated the restore policy to create a `namespaceMapping:` spec section if above is present

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
