### PR TITLE
[ACM-19115] Improved storage class name handling for PVC and StatefulSet resources

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -273,11 +273,12 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	/*
-		In ACM 2.13, we are required to get the default storage class name for the Edge Management (aka Flight-Control)
+		In ACM 2.13, we are required to get the default storage class name for the Edge Manager (aka Flight-Control)
 		component. To ensure that we can pass the default storage class, we will store it as an environment variable.
 	*/
-	if err := r.SetDefaultStorageClassName(ctx); err != nil {
-		r.Log.Error(err, "failed to get StorageClass resources")
+	if result, err = r.SetDefaultStorageClassName(ctx, multiClusterHub); err != nil {
+		r.Log.Error(err, "failed to set the default StorageClass name")
+		return ctrl.Result{}, err
 	}
 
 	// Check if the multiClusterHub instance is marked to be deleted, which is
@@ -841,21 +842,56 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 			}
 
 			/*
-				In ACM 2.13 we are applying a PersistentVolumeClaim (PVC) for Edge Management. When the PVC is created,
-				we cannot patch the resource if there is a new storageClass available. The user would need to delete the
-				pre-existing PVC and allow MCH to recreate a new version with the latest default storageClass version.
+				In ACM 2.13 we are applying a PersistentVolumeClaim (PVC) and StatefulSet (STS) for Edge Manager.
+				When the PVC is created, we cannot patch the resource if there is a new storageClass available.
+				The user would need to delete the pre-existing PVC and allow MCH to recreate a new version with the
+				latest default storageClass version.
 			*/
 			if existing.GetKind() == "PersistentVolumeClaim" {
 				storageClassName, found, err := unstructured.NestedString(existing.Object, "spec", "storageClassName")
 				if err != nil {
-					r.Log.Error(err, "failed to retrieve storageClassName from PVC", "Name", existing.GetName())
+					log.Error(err, "failed to retrieve storageClassName from PVC", "Name", existing.GetName())
 					return ctrl.Result{}, err
 				}
 
 				if found && storageClassName != os.Getenv(helpers.DefaultStorageClassName) {
-					r.Log.Info("Storage class mismatch default. To update, delete the existing PVC",
-						"Name", existing.GetName())
+					log.Info(
+						"To update the PVC with a new StorageClass, delete the existing PVC to allow it to be recreated.",
+						"Name", existing.GetName(), "CurrentStorageClass", storageClassName,
+						"NewStorageClass", os.Getenv(helpers.DefaultStorageClassName))
 					return ctrl.Result{}, nil
+				}
+			} else if existing.GetKind() == "StatefulSet" {
+				volumeClaimTemplates, found, err := unstructured.NestedSlice(existing.Object, "spec",
+					"volumeClaimTemplates")
+
+				if err != nil {
+					log.Error(err, "failed to retrieve volumeClaimTemplates from StatefulSet", "Name",
+						existing.GetName())
+					return ctrl.Result{}, err
+				}
+
+				if found {
+					// Loop through each volumeClaimTemplate to verify that the storage class name remains unchanged.
+					for i, volumeClaimTemplate := range volumeClaimTemplates {
+						// Extract the storageClassName from each volumeClaimTemplate
+						storageClassName, found, err := unstructured.NestedString(
+							volumeClaimTemplate.(map[string]interface{}), "spec", "storageClassName")
+
+						if err != nil {
+							log.Error(err, "failed to retrieve storageClassName from volumeClaimTemplate", "Index", i,
+								"Name", existing.GetName())
+							return ctrl.Result{}, err
+						}
+
+						if found && storageClassName != os.Getenv(helpers.DefaultStorageClassName) {
+							log.Info(
+								"To update the STS with a new StorageClass, delete the existing STS to allow it to be recreated.",
+								"Name", existing.GetName(), "CurrentStorageClass", storageClassName,
+								"NewStorageClass", os.Getenv(helpers.DefaultStorageClassName))
+							return ctrl.Result{}, nil
+						}
+					}
 				}
 			}
 
@@ -1283,73 +1319,69 @@ func (r *MultiClusterHubReconciler) ensureNoInternalHubComponent(ctx context.Con
 	return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 }
 
-/*
-UpdateEnvVar updates an environment variable with a new value and log the change.
-It only updates the environment variable if the new value is different from the previous value.
-*/
-func UpdateEnvVar(envVar, newValue, prevValue string) error {
-	if prevValue != newValue {
-		if err := os.Setenv(envVar, newValue); err != nil {
-			log.Error(err, "failed to set environment variable %s", envVar)
-			return err
-		}
-		log.Info(fmt.Sprintf("%s updated: %s", envVar, newValue))
-	}
-	return nil
-}
-
 func (r *MultiClusterHubReconciler) GetDefaultStorageClassName(storageClasses storagev1.StorageClassList) string {
-	var storageClassName string
-
 	for _, sc := range storageClasses.Items {
 		if annotations := sc.GetAnnotations(); annotations != nil {
-			if strings.EqualFold(annotations[utils.AnnotationDefaultStorageClass], "true") {
-				// Return default storage class name
+			if strings.EqualFold(annotations[utils.AnnotationKubeDefaultStorageClass], "true") {
 				return sc.GetName()
 			}
 		}
-
-		if storageClassName == "" {
-			storageClassName = sc.GetName()
-		}
 	}
-	return storageClassName
+
+	if len(storageClasses.Items) > 1 {
+		log.Info("Warning: Multiple non-default storage classes found. A default storage class needs to be declared.")
+	}
+	return ""
 }
 
-func (r *MultiClusterHubReconciler) SetDefaultStorageClassName(ctx context.Context) error {
+func (r *MultiClusterHubReconciler) SetDefaultStorageClassName(ctx context.Context, m *operatorv1.MultiClusterHub) (
+	ctrl.Result, error) {
+
+	// Retrieve the default storage class name from the environment variable, if set.
+	envStorageClass := os.Getenv(helpers.DefaultStorageClassName)
+
+	/*
+	   Check if the MultiClusterHub instance contains a default storage class annotation.
+	   If the annotation is present and different from the environment variable, override it.
+	*/
+	if overrideStorageClass := utils.GetDefaultStorageClassOverride(m); overrideStorageClass != "" &&
+		overrideStorageClass != envStorageClass {
+
+		if err := os.Setenv(helpers.DefaultStorageClassName, overrideStorageClass); err != nil {
+			log.Error(err, "unable to set the default StorageClass environment variable from annotation",
+				helpers.DefaultStorageClassName, overrideStorageClass)
+
+			return ctrl.Result{}, err
+		}
+
+		log.Info("Applied default StorageClass annotation override",
+			"StorageClassName", overrideStorageClass)
+		return ctrl.Result{}, nil
+	}
+
+	// If no annotation override is found, we need to discover the default storage class from the cluster.
 	storageClasses := storagev1.StorageClassList{}
-
-	// Fetch previously set storage class (fallback).
-	currentStorageClass := os.Getenv(helpers.DefaultStorageClassName)
-
 	if err := r.Client.List(ctx, &storageClasses); err != nil {
 		if errors.IsNotFound(err) {
-			r.Log.Info("No StorageClass resources found.")
-			return nil
+			r.Log.Info("No StorageClass resources found in the cluster. Skipping default StorageClass update")
+			return ctrl.Result{}, nil
 		}
 
-		if currentStorageClass != "" {
-			r.Log.Error(err, "failed to list StorageClasses. Retaining previous storage class.",
-				"storageClassName", currentStorageClass)
-		}
-		return err
+		r.Log.Error(err, "failed to list StorageClass resources")
+		return ctrl.Result{}, err
 	}
 
-	if storageClassName := r.GetDefaultStorageClassName(storageClasses); storageClassName != "" {
-		if err := UpdateEnvVar(helpers.DefaultStorageClassName, storageClassName, currentStorageClass); err != nil {
-			return err
+	// Retrieve the default storage class from the cluster's StorageClass resources.
+	if defaultStorageClass := r.GetDefaultStorageClassName(storageClasses); defaultStorageClass != "" &&
+		defaultStorageClass != envStorageClass {
+		if err := os.Setenv(helpers.DefaultStorageClassName, defaultStorageClass); err != nil {
+			return ctrl.Result{}, err
 		}
-		return nil
-	}
 
-	// No storage classes found at all
-	if currentStorageClass != "" {
-		if err := os.Unsetenv(helpers.DefaultStorageClassName); err != nil {
-			return err
-		}
-		r.Log.Info(fmt.Sprintf("No StorageClass available. Unsetting %s value", helpers.DefaultStorageClassName))
+		log.Info("Default StorageClassName set from cluster resources",
+			"Name", defaultStorageClass)
 	}
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Context, m *operatorv1.MultiClusterHub) (

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -80,10 +80,16 @@ var (
 	AnnotationHubSize = "installer.open-cluster-management.io/hub-size"
 
 	/*
-		AnnotationDefaultStorageClass is an annotation used in the cluster to determine the default storage class
+		AnnotationDefaultStorageClass is an annotation used to set the default storage class name for multiclusterhub
+		operand resources to use.
+	*/
+	AnnotationDefaultStorageClass = "installer.open-cluster-management.io/default-storage-class"
+
+	/*
+		AnnotationKubeDefaultStorageClass is an annotation used in the cluster to determine the default storage class
 		resource.
 	*/
-	AnnotationDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
+	AnnotationKubeDefaultStorageClass = "storageclass.kubernetes.io/is-default-class"
 )
 
 /*
@@ -175,6 +181,14 @@ func getAnnotationOrDefaultForMap(old, new map[string]string, primaryKey, deprec
 	}
 
 	return oldValue == newValue
+}
+
+/*
+GetDefaultStorageClassOverride returns the name of the storage class that MCH should use as the
+default override.
+*/
+func GetDefaultStorageClassOverride(instance *operatorsv1.MultiClusterHub) string {
+	return getAnnotation(instance, AnnotationDefaultStorageClass)
 }
 
 /*

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -305,6 +305,20 @@ func Test_GetOADPAnnotationOverrides(t *testing.T) {
 	})
 }
 
+func Test_GetDefaultStorageClassOverride(t *testing.T) {
+	t.Run("Get Default storage class annotation override for MCH", func(t *testing.T) {
+		mch := &operatorsv1.MultiClusterHub{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AnnotationDefaultStorageClass: "gp3-csi",
+			}},
+		}
+		want := "gp3-csi"
+		if got := GetDefaultStorageClassOverride(mch); got != want {
+			t.Errorf("GetDefaultStorageClassOverride(mch) = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestShouldIgnoreOCPVersion(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# Description

Setting a custom storage class name for StatefulSet and PersistentVolumeClaim resources through an environment variable (DEFAULT_STORAGE_CLASS_NAME) is not working as expected. The default storage class name always takes precedence, overriding any custom setting, and leading to StatefulSet resources application failure.

This PR will add the missing logic for the StatefulSet resources and ensure that the environment variable that is set is not getting overridden.

## Related Issue

https://issues.redhat.com/browse/ACM-19115

## Changes Made

Updated storage class name logic in the operator controller.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
