### PR TITLE
[ACM-20060]: modify validateUpdate() to block renaming local-cluster if the resource already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test-prep: manifests generate fmt vet envtest ## prepare to run tests.
 
 test: manifests generate fmt vet envtest ## Run tests.
 	OPERATOR_VERSION=9.9.9 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
-	  ENV_TEST="true" go test $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
+	  ENV_TEST="true" go test -v $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
 
 ##@ Build
 

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -111,6 +111,7 @@ var _ = Describe("Multiclusterhub webhook", func() {
 				Expect(k8sClient.Update(ctx, mch)).NotTo(BeNil(),
 					"AvailabilityConfig must be %v or %v, but %v was allowed", HABasic, HAHigh,
 					mch.Spec.AvailabilityConfig)
+				mch.Spec.AvailabilityConfig = ""
 			})
 
 			By("because of existing local-cluster resource", func() {

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	mce "github.com/stolostron/backplane-operator/api/v1"
-	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengineutils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -144,7 +143,6 @@ var _ = Describe("Multiclusterhub webhook", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-mce",
 					Namespace: "test-mce",
-					Labels:    map[string]string{multiclusterengineutils.MCEManagedByLabel: "true"},
 				},
 				Spec: mce.MultiClusterEngineSpec{
 					LocalClusterName: "local-cluster",

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	mce "github.com/stolostron/backplane-operator/api/v1"
+	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengineutils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -143,6 +144,7 @@ var _ = Describe("Multiclusterhub webhook", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-mce",
 					Namespace: "test-mce",
+					Labels:    map[string]string{multiclusterengineutils.MCEManagedByLabel: "true"},
 				},
 				Spec: mce.MultiClusterEngineSpec{
 					LocalClusterName: "local-cluster",

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Multiclusterhub webhook", func() {
 					},
 				}
 				Expect(k8sClient.Update(ctx, mch)).NotTo(BeNil(), "invalid components should not be permitted")
+				mch.Spec.Overrides = &Overrides{}
 			})
 			By("because of updating SeparateCertificateManagement", func() {
 				Expect(k8sClient.Get(ctx,


### PR DESCRIPTION
# Description

When updating spec.LocalClusterName, if local-cluster resource already exists, the update will be blocked.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
