### PR TITLE
set defaults for oadp stable channel

### DIFF
--- a/pkg/rendering/values.go
+++ b/pkg/rendering/values.go
@@ -14,25 +14,26 @@ type Values struct {
 }
 
 type Global struct {
-	ImageOverrides      map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
-	TemplateOverrides   map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
-	PullPolicy          string               `json:"pullPolicy" structs:"pullPolicy"`
-	PullSecret          string               `json:"pullSecret" structs:"pullSecret"`
-	Namespace           string               `json:"namespace" structs:"namespace"`
-	ImageRepository     string               `json:"imageRepository" structs:"namespace"`
-	Name                string               `json:"name" structs:"name"`
-	Channel             string               `json:"channel" structs:"channel"`
-	MinOADPChannel      string               `json:"minOADPChannel" structs:"minOADPChannel"`
-	InstallPlanApproval subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
-	Source              string               `json:"source" structs:"source"`
-	SourceNamespace     string               `json:"sourceNamespace" structs:"sourceNamespace"`
-	HubSize             v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
-	APIUrl              string               `json:"apiUrl" structs:"apiUrl"`
-	Target              string               `json:"target" structs:"target"`
-	BaseDomain          string               `json:"baseDomain" structs:"baseDomain"`
-	DeployOnOCP         bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
-	StorageClassName    string               `json:"storageClassName" structs:"storageClassName"`
-	StartingCSV         string               `json:"startingCSV" structs:"startingCSV"`
+	ImageOverrides       map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
+	TemplateOverrides    map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
+	PullPolicy           string               `json:"pullPolicy" structs:"pullPolicy"`
+	PullSecret           string               `json:"pullSecret" structs:"pullSecret"`
+	Namespace            string               `json:"namespace" structs:"namespace"`
+	ImageRepository      string               `json:"imageRepository" structs:"namespace"`
+	Name                 string               `json:"name" structs:"name"`
+	Channel              string               `json:"channel" structs:"channel"`
+	MinOADPChannel       string               `json:"minOADPChannel" structs:"minOADPChannel"`
+	MinOADPStableChannel string               `json:"MinOADPStableChannel" structs:"MinOADPStableChannel"`
+	InstallPlanApproval  subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
+	Source               string               `json:"source" structs:"source"`
+	SourceNamespace      string               `json:"sourceNamespace" structs:"sourceNamespace"`
+	HubSize              v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
+	APIUrl               string               `json:"apiUrl" structs:"apiUrl"`
+	Target               string               `json:"target" structs:"target"`
+	BaseDomain           string               `json:"baseDomain" structs:"baseDomain"`
+	DeployOnOCP          bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
+	StorageClassName     string               `json:"storageClassName" structs:"storageClassName"`
+	StartingCSV          string               `json:"startingCSV" structs:"startingCSV"`
 }
 
 type HubConfig struct {

--- a/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
@@ -37,11 +37,7 @@ metadata:
     "helm.sh/hook-weight": "-1"
     "helm.sh/resource-policy": delete
 spec:
-  {{- if or (hasPrefix "4.19" .Values.hubconfig.ocpVersion) (hasPrefix "4.2" .Values.hubconfig.ocpVersion) }}
-  channel: stable
-  {{- else }}
   channel: {{ .Values.global.channel }}
-  {{- end }}
   config:
     resources: {}
 {{- with .Values.hubconfig.nodeSelector }}

--- a/pkg/templates/charts/toggle/cluster-backup/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/values.yaml
@@ -12,8 +12,8 @@ global:
     cluster_backup_controller: ""
   templateOverrides: {}
   name: redhat-oadp-operator
-  channel: stable-1.4
   minOADPChannel: stable-1.4
+  minOADPStableChannel: stable
   installPlanApproval: Automatic
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
# Description

OADP annotation should overwrite chart settings when using OCP 4.19 or higher

## Related Issue

https://issues.redhat.com/browse/ACM-20211

## Changes Made

- Created a new var minOADPStableChannel = stable
- Updated func GetOADPConfig and if the channel is not set, use minOADPStableChannel if ocp version is 4.19 or newer
- Removed channel from the backup chart values.yaml to get the default value, based on ocp version
- On the subscription, set 
```
spec:
  channel: {{ .Values.global.channel }}
```
## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
