### PR TITLE
[ACM-20337] ACM 2.12 upgrade to 2.13 siteconfig-controller-manager deployment temporary deletion

### DIFF
--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -1977,7 +1977,8 @@ func Test_ensureResourceVersionAlignment(t *testing.T) {
 	os.Setenv("OPERATOR_VERSION", "2.13.0")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := recon.ensureResourceVersionAlignment(tt.template, os.Getenv("OPERATOR_VERSION"))
+			currentVersion, _ := getCurrentVersion(tt.template)
+			got := recon.ensureResourceVersionAlignment(tt.template, currentVersion, os.Getenv("OPERATOR_VERSION"))
 			if got != tt.want {
 				t.Errorf("ensureResourceVersionAlignment() = %v, want: %v", got, tt.want)
 			}


### PR DESCRIPTION
# Description

When upgrading from ACM 2.12, a new label selector was added to deployment/siteconfg-controller-manager, which is an immutable field. The deployment must be deleted before the patch can be applied

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
