### PR TITLE
Prevent local-cluster name from exceeding 34 characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test-prep: manifests generate fmt vet envtest ## prepare to run tests.
 
 test: manifests generate fmt vet envtest ## Run tests.
 	OPERATOR_VERSION=9.9.9 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
-	  ENV_TEST="true" go test -v $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
+	  ENV_TEST="true" go test $(shell go list ./... | grep -E -v "test") -coverprofile cover.out
 
 ##@ Build
 

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -155,8 +155,8 @@ func (r *MultiClusterHub) ValidateCreate() (admission.Warnings, error) {
 }
 
 func validateLocalClusterNameLength(name string) (err error) {
-	if len(name) >= 64 {
-		return fmt.Errorf("local-cluster name must be shorter than 64 characters")
+	if len(name) >= 35 {
+		return fmt.Errorf("local-cluster name must be shorter than 35 characters")
 	}
 	return nil
 }

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -141,7 +141,6 @@ var _ = Describe("Multiclusterhub webhook", func() {
 						Code:    403,
 					},
 				}
-				// errors.New("local-cluster name must be shorter than 35 characters")
 				Expect(k8sClient.Update(ctx, mch)).To(Equal(expectedError), "local-cluster name must be less than 35 characters long")
 			})
 		})

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -120,6 +121,11 @@ var _ = Describe("Multiclusterhub webhook", func() {
 
 				mch.Spec.LocalClusterName = "updated-local-cluster"
 				Expect(k8sClient.Update(ctx, mch)).NotTo(BeNil(), "updating local-cluster name while one exists should not be permitted")
+			})
+
+			By("because the local-cluster name must be less than 35 characters long", func() {
+				mch.Spec.LocalClusterName = strings.Repeat("t", 35)
+				Expect(k8sClient.Update(ctx, mch)).NotTo(BeNil(), "local-cluster name must be less than 35 characters long")
 			})
 		})
 


### PR DESCRIPTION
# Description

Through speaking with other teams and QE, it seems that exceeding 39 characters in length (yes 39, not 34) will cause ACM installed components to fail due to how components tack on information to existing resource names, causing them to exceed the Kubernetes allowed 63 character limit. The 34 character limit is to make sure that we don't get close to that number.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
