### PR TITLE
[ACM-20648] Updated logic to support generic preview component pruning

### DIFF
--- a/api/v1/multiclusterhub_methods.go
+++ b/api/v1/multiclusterhub_methods.go
@@ -108,6 +108,12 @@ var MCEComponents = []string{
 	MCEServerFoundation,
 }
 
+/*
+PreviewToStable maps each preview component to its corresponding stable replacement.
+This mapping is used to enable the stable component when the preview version is pruned.
+*/
+var PreviewToStable = map[string]string{}
+
 var MCECRDs = []ResourceGVK{
 	{
 		Group:   "addon.open-cluster-management.io",

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -1874,6 +1874,24 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 		updateNecessary = true
 	}
 
+	// Automatically replace and prune preview components.
+	// If a preview component is enabled and a stable equivalent exists,
+	// enable the stable version. Then, regardless of status, prune the preview.
+	for preview, stable := range operatorv1.PreviewToStable {
+		if m.Enabled(preview) {
+			log.Info("Stable component version enabled due to preview being enabled",
+				"preview", preview,
+				"stable", stable,
+			)
+			m.Enable(stable)
+		}
+
+		if m.Prune(preview) {
+			log.Info("Pruning preview component", "preview", preview)
+			updateNecessary = true
+		}
+	}
+
 	if utils.DeduplicateComponents(m) {
 		updateNecessary = true
 	}


### PR DESCRIPTION
# Description

As we onboard `tech-preview` components into ACM/MCE, it's important to ensure a smooth transition to `stable` and GA status. Specifically, we need to safely remove the `-preview` version while maintaining the necessary configuration for the new stable component required by our CR. This PR introduces a generic solution to handle the duplication involved in pruning and enabling individual components within our operator.

## Related Issue

https://issues.redhat.com/browse/ACM-20648

## Changes Made

Improved controller logic to more effectively manage the transition from `preview` to `stable` components.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Related logs
```bash
2025-05-08T15:01:28.408Z INFO reconcile Stable component version enabled due to preview being enabled {"preview": "cluster-api-preview", "stable": "cluster-api"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "cluster-api-preview"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "cluster-api-provider-aws-preview"}
2025-05-08T15:01:28.408Z INFO reconcile Stable component version enabled due to preview being enabled {"preview": "hypershift-preview", "stable": "hypershift"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "hypershift-preview"}
2025-05-08T15:01:28.408Z INFO reconcile Stable component version enabled due to preview being enabled {"preview": "image-based-install-operator-preview", "stable": "image-based-install-operator"}
2025-05-08T15:01:28.408Z INFO reconcile Pruning preview component {"preview": "image-based-install-operator-preview"}
```

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
