### PR TITLE
[ACM-20703] Set defaults for OADP stable channel 

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -26,62 +26,29 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type Values struct {
-	Global    Global    `json:"global" structs:"global"`
-	HubConfig HubConfig `json:"hubconfig" structs:"hubconfig"`
-	Org       string    `json:"org" structs:"org"`
-}
-
-type Global struct {
-	ImageOverrides       map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
-	TemplateOverrides    map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
-	PullPolicy           string               `json:"pullPolicy" structs:"pullPolicy"`
-	PullSecret           string               `json:"pullSecret" structs:"pullSecret"`
-	Namespace            string               `json:"namespace" structs:"namespace"`
-	ImageRepository      string               `json:"imageRepository" structs:"namespace"`
-	Name                 string               `json:"name" structs:"name"`
-	Channel              string               `json:"channel" structs:"channel"`
-	MinOADPChannel       string               `json:"minOADPChannel" structs:"minOADPChannel"`
-	MinOADPStableChannel string               `json:"MinOADPStableChannel" structs:"MinOADPStableChannel"`
-	InstallPlanApproval  subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
-	Source               string               `json:"source" structs:"source"`
-	SourceNamespace      string               `json:"sourceNamespace" structs:"sourceNamespace"`
-	HubSize              v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
-	APIUrl               string               `json:"apiUrl" structs:"apiUrl"`
-	Target               string               `json:"target" structs:"target"`
-	BaseDomain           string               `json:"baseDomain" structs:"baseDomain"`
-	DeployOnOCP          bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
-	StorageClassName     string               `json:"storageClassName" structs:"storageClassName"`
-	StartingCSV          string               `json:"startingCSV" structs:"startingCSV"`
-}
-
-type HubConfig struct {
-	ClusterSTSEnabled bool              `json:"clusterSTSEnabled" structs:"clusterSTSEnabled"`
-	NodeSelector      map[string]string `json:"nodeSelector" structs:"nodeSelector"`
-	ProxyConfigs      map[string]string `json:"proxyConfigs" structs:"proxyConfigs"`
-	ReplicaCount      int               `json:"replicaCount" structs:"replicaCount"`
-	Tolerations       []Toleration      `json:"tolerations" structs:"tolerations"`
-	OCPVersion        string            `json:"ocpVersion" structs:"ocpVersion"`
-	HubVersion        string            `json:"hubVersion" structs:"hubVersion"`
-	OCPIngress        string            `json:"ocpIngress" structs:"ocpIngress"`
-	SubscriptionPause string            `json:"subscriptionPause" structs:"subscriptionPause"`
-}
-
-type Toleration struct {
-	Key               string                    `json:"Key" protobuf:"bytes,1,opt,name=key"`
-	Operator          corev1.TolerationOperator `json:"Operator" protobuf:"bytes,2,opt,name=operator,casttype=TolerationOperator"`
-	Value             string                    `json:"Value" protobuf:"bytes,3,opt,name=value"`
-	Effect            corev1.TaintEffect        `json:"Effect" protobuf:"bytes,4,opt,name=effect,casttype=TaintEffect"`
-	TolerationSeconds *int64                    `json:"TolerationSeconds" protobuf:"varint,5,opt,name=tolerationSeconds"`
-}
-
 // defaults for the OADP subscription that will be created by the installer
 const (
-	defaultOADPChannel                = "stable-1.4" // This will also be the minOADPChannel (min version we expect to be installed)
-	defaultOADPStableChannel          = "stable"
-	defaultOADPName                   = "redhat-oadp-operator"
-	defaultOADPInstallPlan            = "Automatic"
-	defaultOADPCatalogSource          = "redhat-operators"
+	// defaultOADPChannel specifies the minimum OADP channel version that should be installed by default.
+	// This also represents the minimum expected version for installation.
+	// Used by ACM installed on OCP 4.18 or older
+	defaultOADPChannel = "stable-1.4"
+
+	// defaultOADPChannel specifies the minimum OADP channel version that should be installed by default.
+	// This also represents the minimum expected version for installation.
+	// Used by ACM installed on OCP 4.19 or newer
+	defaultOADPStableChannel = "stable"
+
+	// defaultOADPName is the name of the OADP operator to be created by the installer.
+	defaultOADPName = "redhat-oadp-operator"
+
+	// defaultOADPInstallPlan defines the default approval policy for the OADP subscription's install plan.
+	// Supported values are: "Automatic" or "Manual".
+	defaultOADPInstallPlan = "Automatic"
+
+	// defaultOADPCatalogSource specifies the default operator catalog source for the OADP subscription.
+	defaultOADPCatalogSource = "redhat-operators"
+
+	// defaultOADPCatalogSourceNamespace defines the default namespace where the OADP operator catalog source is located.
 	defaultOADPCatalogSourceNamespace = "openshift-marketplace"
 )
 
@@ -423,7 +390,6 @@ func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval,
 		} else {
 			channel = defaultOADPChannel
 		}
-
 	}
 
 	if sub.InstallPlanApproval != "" {

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 
 	loader "helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -32,25 +33,26 @@ type Values struct {
 }
 
 type Global struct {
-	ImageOverrides      map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
-	TemplateOverrides   map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
-	PullPolicy          string               `json:"pullPolicy" structs:"pullPolicy"`
-	PullSecret          string               `json:"pullSecret" structs:"pullSecret"`
-	Namespace           string               `json:"namespace" structs:"namespace"`
-	ImageRepository     string               `json:"imageRepository" structs:"namespace"`
-	Name                string               `json:"name" structs:"name"`
-	Channel             string               `json:"channel" structs:"Channel"`
-	MinOADPChannel      string               `json:"minOADPChannel" structs:"minOADPChannel"`
-	InstallPlanApproval subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
-	Source              string               `json:"source" structs:"source"`
-	SourceNamespace     string               `json:"sourceNamespace" structs:"sourceNamespace"`
-	HubSize             v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
-	APIUrl              string               `json:"apiUrl" structs:"apiUrl"`
-	Target              string               `json:"target" structs:"target"`
-	BaseDomain          string               `json:"baseDomain" structs:"baseDomain"`
-	DeployOnOCP         bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
-	StorageClassName    string               `json:"storageClassName" structs:"storageClassName"`
-	StartingCSV         string               `json:"startingCSV" structs:"startingCSV"`
+	ImageOverrides       map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
+	TemplateOverrides    map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
+	PullPolicy           string               `json:"pullPolicy" structs:"pullPolicy"`
+	PullSecret           string               `json:"pullSecret" structs:"pullSecret"`
+	Namespace            string               `json:"namespace" structs:"namespace"`
+	ImageRepository      string               `json:"imageRepository" structs:"namespace"`
+	Name                 string               `json:"name" structs:"name"`
+	Channel              string               `json:"channel" structs:"channel"`
+	MinOADPChannel       string               `json:"minOADPChannel" structs:"minOADPChannel"`
+	MinOADPStableChannel string               `json:"MinOADPStableChannel" structs:"MinOADPStableChannel"`
+	InstallPlanApproval  subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
+	Source               string               `json:"source" structs:"source"`
+	SourceNamespace      string               `json:"sourceNamespace" structs:"sourceNamespace"`
+	HubSize              v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
+	APIUrl               string               `json:"apiUrl" structs:"apiUrl"`
+	Target               string               `json:"target" structs:"target"`
+	BaseDomain           string               `json:"baseDomain" structs:"baseDomain"`
+	DeployOnOCP          bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
+	StorageClassName     string               `json:"storageClassName" structs:"storageClassName"`
+	StartingCSV          string               `json:"startingCSV" structs:"startingCSV"`
 }
 
 type HubConfig struct {
@@ -75,11 +77,12 @@ type Toleration struct {
 
 // defaults for the OADP subscription that will be created by the installer
 const (
-	defaultOADPChannel         = "stable-1.4" // This will also be the minOADPChannel (min version we expect to be installed)
-	defaultOADPName            = "redhat-oadp-operator"
-	defaultOADPInstallPlan     = "Automatic"
-	defaultOADPSource          = "redhat-operators"
-	defaultOADPSourceNamespace = "openshift-marketplace"
+	defaultOADPChannel                = "stable-1.4" // This will also be the minOADPChannel (min version we expect to be installed)
+	defaultOADPStableChannel          = "stable"
+	defaultOADPName                   = "redhat-oadp-operator"
+	defaultOADPInstallPlan            = "Automatic"
+	defaultOADPCatalogSource          = "redhat-operators"
+	defaultOADPCatalogSourceNamespace = "openshift-marketplace"
 )
 
 var log = logf.Log.WithName("reconcile")
@@ -381,6 +384,7 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 	values.Global.Name, values.Global.Channel, values.Global.InstallPlanApproval, values.Global.Source, values.Global.SourceNamespace, values.Global.StartingCSV = GetOADPConfig(mch)
 
 	values.Global.MinOADPChannel = defaultOADPChannel
+	values.Global.MinOADPStableChannel = defaultOADPStableChannel
 
 	// TODO: Define all overrides
 }
@@ -408,7 +412,18 @@ func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval,
 	if sub.Channel != "" {
 		channel = sub.Channel
 	} else {
-		channel = defaultOADPChannel
+		ocpVersion := os.Getenv("ACM_HUB_OCP_VERSION")
+		isOCP419orNewer := strings.HasPrefix(ocpVersion, "4.19") ||
+			strings.HasPrefix(ocpVersion, "4.2") ||
+			strings.HasPrefix(ocpVersion, "4.3")
+
+		if isOCP419orNewer {
+			// use stable channel for OCP 2.19 or newer
+			channel = defaultOADPStableChannel
+		} else {
+			channel = defaultOADPChannel
+		}
+
 	}
 
 	if sub.InstallPlanApproval != "" {
@@ -420,13 +435,13 @@ func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval,
 	if sub.CatalogSource != "" {
 		source = sub.CatalogSource
 	} else {
-		source = defaultOADPSource
+		source = defaultOADPCatalogSource
 	}
 
 	if sub.CatalogSourceNamespace != "" {
 		sourceNamespace = sub.CatalogSourceNamespace
 	} else {
-		sourceNamespace = defaultOADPSourceNamespace
+		sourceNamespace = defaultOADPCatalogSourceNamespace
 	}
 
 	if sub.StartingCSV != "" {

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -364,11 +364,11 @@ func TestOADPAnnotation(t *testing.T) {
 		t.Error("Cluster Backup missing OADP overrides for install plan")
 	}
 
-	if test4 != defaultOADPSource {
+	if test4 != defaultOADPCatalogSource {
 		t.Error("Cluster Backup missing OADP overrides for source")
 	}
 
-	if test5 != defaultOADPSourceNamespace {
+	if test5 != defaultOADPCatalogSourceNamespace {
 		t.Error("Cluster Backup missing OADP overrides for source namespace")
 	}
 

--- a/pkg/rendering/values.go
+++ b/pkg/rendering/values.go
@@ -1,0 +1,57 @@
+// Copyright Contributors to the Open Cluster Management project
+package renderer
+
+import (
+	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Values struct {
+	Global    Global    `json:"global" structs:"global"`
+	HubConfig HubConfig `json:"hubconfig" structs:"hubconfig"`
+	Org       string    `json:"org" structs:"org"`
+}
+
+type Global struct {
+	ImageOverrides       map[string]string    `json:"imageOverrides" structs:"imageOverrides"`
+	TemplateOverrides    map[string]string    `json:"templateOverrides" structs:"templateOverrides"`
+	PullPolicy           string               `json:"pullPolicy" structs:"pullPolicy"`
+	PullSecret           string               `json:"pullSecret" structs:"pullSecret"`
+	Namespace            string               `json:"namespace" structs:"namespace"`
+	ImageRepository      string               `json:"imageRepository" structs:"namespace"`
+	Name                 string               `json:"name" structs:"name"`
+	Channel              string               `json:"channel" structs:"channel"`
+	MinOADPChannel       string               `json:"minOADPChannel" structs:"minOADPChannel"`
+	MinOADPStableChannel string               `json:"MinOADPStableChannel" structs:"MinOADPStableChannel"`
+	InstallPlanApproval  subv1alpha1.Approval `json:"installPlanApproval" structs:"installPlanApproval"`
+	Source               string               `json:"source" structs:"source"`
+	SourceNamespace      string               `json:"sourceNamespace" structs:"sourceNamespace"`
+	HubSize              v1.HubSize           `json:"hubSize" structs:"hubSize" yaml:"hubSize"`
+	APIUrl               string               `json:"apiUrl" structs:"apiUrl"`
+	Target               string               `json:"target" structs:"target"`
+	BaseDomain           string               `json:"baseDomain" structs:"baseDomain"`
+	DeployOnOCP          bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
+	StorageClassName     string               `json:"storageClassName" structs:"storageClassName"`
+	StartingCSV          string               `json:"startingCSV" structs:"startingCSV"`
+}
+
+type HubConfig struct {
+	ClusterSTSEnabled bool              `json:"clusterSTSEnabled" structs:"clusterSTSEnabled"`
+	NodeSelector      map[string]string `json:"nodeSelector" structs:"nodeSelector"`
+	ProxyConfigs      map[string]string `json:"proxyConfigs" structs:"proxyConfigs"`
+	ReplicaCount      int               `json:"replicaCount" structs:"replicaCount"`
+	Tolerations       []Toleration      `json:"tolerations" structs:"tolerations"`
+	OCPVersion        string            `json:"ocpVersion" structs:"ocpVersion"`
+	HubVersion        string            `json:"hubVersion" structs:"hubVersion"`
+	OCPIngress        string            `json:"ocpIngress" structs:"ocpIngress"`
+	SubscriptionPause string            `json:"subscriptionPause" structs:"subscriptionPause"`
+}
+
+type Toleration struct {
+	Key               string                    `json:"Key" protobuf:"bytes,1,opt,name=key"`
+	Operator          corev1.TolerationOperator `json:"Operator" protobuf:"bytes,2,opt,name=operator,casttype=TolerationOperator"`
+	Value             string                    `json:"Value" protobuf:"bytes,3,opt,name=value"`
+	Effect            corev1.TaintEffect        `json:"Effect" protobuf:"bytes,4,opt,name=effect,casttype=TaintEffect"`
+	TolerationSeconds *int64                    `json:"TolerationSeconds" protobuf:"varint,5,opt,name=tolerationSeconds"`
+}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
@@ -37,11 +37,7 @@ metadata:
     "helm.sh/hook-weight": "-1"
     "helm.sh/resource-policy": delete
 spec:
-  {{- if (hasPrefix "4.19" .Values.hubconfig.ocpVersion) }}
-  channel: {{ .Values.global.channel15 }}
-  {{- else }}
   channel: {{ .Values.global.channel }}
-  {{- end }}
   config:
     resources: {}
 {{- with .Values.hubconfig.nodeSelector }}

--- a/pkg/templates/charts/toggle/cluster-backup/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/values.yaml
@@ -12,7 +12,7 @@ global:
     cluster_backup_controller: ""
   templateOverrides: {}
   name: redhat-oadp-operator
-  channel: stable-2.4
+  channel: stable-1.4
   minOADPChannel: stable-1.4
   minOADPStableChannel: stable
   installPlanApproval: Automatic

--- a/pkg/templates/charts/toggle/cluster-backup/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/values.yaml
@@ -12,8 +12,8 @@ global:
     cluster_backup_controller: ""
   templateOverrides: {}
   name: redhat-oadp-operator
-  channel: stable-1.4
   minOADPChannel: stable-1.4
+  minOADPStableChannel: stable
   installPlanApproval: Automatic
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/pkg/templates/charts/toggle/cluster-backup/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/values.yaml
@@ -12,6 +12,7 @@ global:
     cluster_backup_controller: ""
   templateOverrides: {}
   name: redhat-oadp-operator
+  channel: stable-2.4
   minOADPChannel: stable-1.4
   minOADPStableChannel: stable
   installPlanApproval: Automatic


### PR DESCRIPTION
# Description

Updating the `cluster-backup` chart to support `channel15` for OCP 4.19 and later has introduced issues during deployment, causing the `cluster-backup` component to stall during installation on the cluster. This PR will fix the issue and allow for `cluster-backup` to be deployed properly.

## Related Issue

https://issues.redhat.com/browse/ACM-20703

## Changes Made

Updated `cluster-backup` chart.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

/hold