### PR TITLE
[ACM-20954] Removed hardcoded ARCH for Dockerfile.rhtap

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -22,7 +22,7 @@ COPY pkg/ pkg/
 COPY pkg/templates/ templates/
 
 # Build
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -mod=readonly -o multiclusterhub-operator main.go
+RUN CGO_ENABLED=1 go build -mod=readonly -o multiclusterhub-operator main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
# Description

To support `multi-arch` builds, this PR removes the hardcoded architecture reference from `build/Dockerfile.rhtap`, enabling flexible image builds across different platforms.

## Related Issue

https://issues.redhat.com/browse/ACM-20954

## Changes Made

Removed `GOOS=linux GOARCH=amd64` reference from `build/Dockerfile.rhtap`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
