### PR TITLE
ACM-20337 Can't create ClusterInstance after upgrading from 2.12.x to 2.13.3

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -1002,7 +1002,7 @@ func (r *MultiClusterHubReconciler) patchSiteconfigControllerManager(ctx context
 	// when upgrading from 2.12, deployment/siteconfig-controller-manager needs to be deleted
 	// in order for the patch to work
 	if template.GetName() == "siteconfig-controller-manager" {
-		if matchCurrent, _ := regexp.MatchString("2/.12/.[0-9]+", currentVersion); matchCurrent {
+		if matchCurrent, _ := regexp.MatchString("2\\.12\\.[0-9]+", currentVersion); matchCurrent {
 			if err := r.Client.Delete(ctx, template); err != nil {
 				log.Error(err, "failed to delete siteconfig-controller-manager")
 				return err

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -832,9 +832,11 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 				log.Info("Warning: OPERATOR_VERSION environment variable is not set")
 			}
 
-			currentVersion, ok := getCurrentVersion(template)
+			currentVersion, ok := getCurrentVersion(existing)
+			log.Info("DEBUG: CURRENT VERSION: %v", currentVersion)
 
 			if !r.ensureResourceVersionAlignment(existing, currentVersion, desiredVersion) || !ok {
+				log.Info("DEBUG: UPDATING RESOURCE: %v/%v FROM VERSION %v TO VERSION %v", template.GetKind(), template.GetName(), currentVersion, desiredVersion)
 				condition := NewHubCondition(
 					operatorv1.Progressing, metav1.ConditionTrue, ComponentsUpdatingReason,
 					fmt.Sprintf("Updating %s/%s to target version: %s.", template.GetKind(),

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -833,10 +833,8 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 			}
 
 			currentVersion, ok := getCurrentVersion(existing)
-			log.Info("DEBUG: CURRENT VERSION: %v", currentVersion)
 
 			if !r.ensureResourceVersionAlignment(existing, currentVersion, desiredVersion) || !ok {
-				log.Info("DEBUG: UPDATING RESOURCE: %v/%v FROM VERSION %v TO VERSION %v", template.GetKind(), template.GetName(), currentVersion, desiredVersion)
 				condition := NewHubCondition(
 					operatorv1.Progressing, metav1.ConditionTrue, ComponentsUpdatingReason,
 					fmt.Sprintf("Updating %s/%s to target version: %s.", template.GetKind(),


### PR DESCRIPTION
# Description

The label selectors can't be applied as a template if the original exists. The original must be deleted first.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
