### PR TITLE
[ACM-20865] Exclude fine-grained-rbac-preview policies from backup and restore

### DIFF
--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/binding-policy-virt-rbac-placementbinding.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/binding-policy-virt-rbac-placementbinding.yaml
@@ -3,6 +3,7 @@ kind: PlacementBinding
 metadata:
   labels:
     open-cluster-management.io/policy-cnv: virt-rbac
+    velero.io/exclude-from-backup: 'true'
   name: binding-policy-virt-rbac
   namespace: open-cluster-management-global-set
 placementRef:

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/placement-policy-virt-rbac-placement.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/placement-policy-virt-rbac-placement.yaml
@@ -3,6 +3,7 @@ kind: Placement
 metadata:
   labels:
     open-cluster-management.io/policy-cnv: virt-rbac
+    velero.io/exclude-from-backup: 'true'
   name: placement-policy-virt-rbac
   namespace: open-cluster-management-global-set
 spec:

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-hub-oauth-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-hub-oauth-clusterrole.yaml
@@ -1,6 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    velero.io/exclude-from-backup: 'true'
   name: open-cluster-management:policy-hub-oauth
 rules:
 - apiGroups:

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-hub-oauth-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-hub-oauth-clusterrolebinding.yaml
@@ -1,6 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    velero.io/exclude-from-backup: 'true'
   name: policy-hub-oauth-clusterrolebinding
   namespace: open-cluster-management-global-set
 roleRef:

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-hub-oauth-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-hub-oauth-serviceaccount.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    velero.io/exclude-from-backup: 'true'
   name: policy-hub-oauth
   namespace: open-cluster-management-global-set

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-virt-clusterroles-policy.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-virt-clusterroles-policy.yaml
@@ -8,6 +8,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST SP 800-53
   labels:
     open-cluster-management.io/policy-cnv: virt-rbac
+    velero.io/exclude-from-backup: 'true'
   name: policy-virt-clusterroles
   namespace: open-cluster-management-global-set
 spec:

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-virt-oauth-policy.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/policy-virt-oauth-policy.yaml
@@ -8,6 +8,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST SP 800-53
   labels:
     open-cluster-management.io/policy-cnv: virt-rbac
+    velero.io/exclude-from-backup: 'true'
   name: policy-virt-oauth
   namespace: open-cluster-management-global-set
 spec:


### PR DESCRIPTION
# Description

This update ensures that policy resources created by MCH in the ACM namespaces are excluded from backup and restore operations by applying the label `velero.io/exclude-from-backup: 'true'` to their manifests. Since these resources are used as `placeholders`, they need to be excluded from the `fine-grained-rbac` chart.

## Related Issue

https://issues.redhat.com/browse/ACM-20865

## Changes Made

Added `velero.io/exclude-from-backup: 'true'` label to `fine-grained-rbac-preview` resources.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 @sahare 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
