### PR TITLE
[ACM-21611] Fixed error in release version logs

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -1998,7 +1998,7 @@ func (r *MultiClusterHubReconciler) ensureResourceVersionAlignment(template *uns
 
 	if currentVersion != desiredVersion {
 		log.Info("Resource version mismatch detected; attempting to update resource",
-			"Kind", template.GetName(), "Name", template.GetKind(),
+			"Kind", template.GetKind(), "Name", template.GetName(),
 			"CurrentVersion", currentVersion, "DesiredVersion", desiredVersion)
 
 		return false


### PR DESCRIPTION
# Description

During the MCH operator upgrade, the logs that check release versions mistakenly print the resource's `Kind` instead of its `Name`. This PR will correct those logs.

```bash
2025-06-17T18:53:11.144Z INFO reconcile Resource version mismatch detected; attempting to update resource {"Kind": "hypershift-addon", "Name": "ManagedClusterAddOn", "CurrentVersion": "2.8.2", "DesiredVersion": "2.9.0-111"}
2025-06-17T18:53:11.161Z INFO reconcile Resource version mismatch detected; attempting to update resource {"Kind": "open-cluster-management:console:readonly-clusterimagesets", "Name": "ClusterRoleBinding", "CurrentVersion": "2.8.2", "DesiredVersion": "2.9.0-111"}
```

## Related Issue

https://issues.redhat.com/browse/ACM-21611

## Changes Made

Updated release version logs during operator upgrade.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
