### PR TITLE
ACM-21533 Require 4.19.1 due to OpenShift console crash on 4.19.0

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-plugin.yaml
@@ -12,7 +12,7 @@ spec:
       namespace: {{ .Values.global.namespace }}
       port: 3000
     type: Service
-  {{- if semverCompare ">=4.19.0" .Values.hubconfig.ocpVersion }}
+  {{- if semverCompare ">=4.19.1" .Values.hubconfig.ocpVersion }}
   contentSecurityPolicy:
     - directive: 'ConnectSrc'
       values:


### PR DESCRIPTION
# Description

Bug in CSP implementation in OpenShift 4.19.0 means we should only enable the feature for 4.19.1
https://issues.redhat.com/browse/OCPBUGS-55928

## Related Issue

https://issues.redhat.com/browse/ACM-21533

## Changes Made

Update version for conditional rendering of CSP in ACM ConsolePlugin resource to 4.19.1 from 4.19.0

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
