### PR TITLE
Add MTV-integration controller Addon Template

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -190,6 +190,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - groups
+  - serviceaccounts
+  - users
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create
@@ -198,6 +206,19 @@ rules:
   - list
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -916,6 +937,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - app.k8s.io
   resources:
   - applications
@@ -1075,6 +1105,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - authorization.k8s.io
@@ -1428,6 +1460,18 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - providers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - hive.openshift.io
   resources:

--- a/pkg/templates/charts/toggle/mtv-integrations/Chart.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/Chart.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+appVersion: 2.12.0
+description: A Helm chart for multicloud mtv-integrations
+category: "Development"
+keywords:
+  - acm
+  - mtv
+  - cnv
+  - vm
+name: mtv-integrations
+verified: "RHACM"
+version: 2.12.0

--- a/pkg/templates/charts/toggle/mtv-integrations/OWNERS
+++ b/pkg/templates/charts/toggle/mtv-integrations/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- jnpacker
+- sahare
+- yiraeChristineKim
+- Ginxo
+reviewers:
+- jnpacker
+- sahare
+- yiraeChristineKim
+- Ginxo

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-addon-template.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-addon-template.yaml
@@ -1,0 +1,128 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: kubevirt-hyperconverged-operator
+spec:
+  addonName: kubevirt-hyperconverged-operator
+  registration:
+    - type: CustomSigner
+      customSigner:
+        signerName: open-cluster-management.io/kubevirt-hyperconverged-addon
+        signingCA:
+          name: kubevirt-hyperconverged-ca
+          namespace: openshift-cnv
+  agentSpec:
+    workload:
+      manifests:
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: operatorpolicy-manager
+            namespace: open-cluster-management-policies
+          rules:
+            - apiGroups: ["policy.open-cluster-management.io"]
+              resources: ["operatorpolicies"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: operatorpolicy-manager-binding
+            namespace: open-cluster-management-policies
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: operatorpolicy-manager
+          subjects:
+            - kind: ServiceAccount
+              name: klusterlet-work-sa
+              namespace: open-cluster-management-agent
+        - apiVersion: policy.open-cluster-management.io/v1beta1
+          kind: OperatorPolicy
+          metadata:
+            name: kubevirt-hyperconverged-operator
+            namespace: open-cluster-management-policies
+          spec:
+            remediationAction: enforce
+            complianceType: musthave
+            operatorGroup: # optional
+              name: openshift-cnv
+              namespace: openshift-cnv
+              targetNamespaces:
+                  - openshift-cnv
+            subscription:
+              channel: stable
+              name: kubevirt-hyperconverged
+              namespace: openshift-cnv
+            upgradeApproval: Automatic
+        - apiVersion: hco.kubevirt.io/v1beta1
+          kind: HyperConverged
+          metadata:
+            name: kubevirt-hyperconverged
+            annotations:
+              deployOVS: 'false'
+            namespace: openshift-cnv
+          spec:
+            virtualMachineOptions:
+              disableFreePageReporting: false
+              disableSerialConsoleLog: true
+            higherWorkloadDensity:
+              memoryOvercommitPercentage: 100
+            liveMigrationConfig:
+              allowAutoConverge: false
+              allowPostCopy: false
+              completionTimeoutPerGiB: 800
+              parallelMigrationsPerCluster: 5
+              parallelOutboundMigrationsPerNode: 2
+              progressTimeout: 150
+            certConfig:
+              ca:
+                duration: 48h0m0s
+                renewBefore: 24h0m0s
+              server:
+                duration: 24h0m0s
+                renewBefore: 12h0m0s
+            applicationAwareConfig:
+              allowApplicationAwareClusterResourceQuota: false
+              vmiCalcConfigName: DedicatedVirtualResources
+            featureGates:
+              deployTektonTaskResources: false
+              enableCommonBootImageImport: true
+              withHostPassthroughCPU: false
+              downwardMetrics: false
+              disableMDevConfiguration: false
+              enableApplicationAwareQuota: false
+              deployKubeSecondaryDNS: false
+              nonRoot: true
+              alignCPUs: false
+              enableManagedTenantQuota: false
+              primaryUserDefinedNetworkBinding: false
+              deployVmConsoleProxy: false
+              persistentReservation: false
+              autoResourceLimits: false
+              deployKubevirtIpamController: false
+            workloadUpdateStrategy:
+              batchEvictionInterval: 1m0s
+              batchEvictionSize: 10
+              workloadUpdateMethods:
+                - LiveMigrate
+            uninstallStrategy: BlockUninstallIfWorkloadsExist
+            resourceRequirements:
+              vmiCPUAllocationRatio: 10
+        - apiVersion: hostpathprovisioner.kubevirt.io/v1beta1
+          kind: HostPathProvisioner
+          metadata:
+            name: hostpath-provisioner
+          spec:
+            imagePullPolicy: IfNotPresent
+            storagePools:
+              - name: local
+                path: /var/hpvolumes
+                pvcTemplate:
+                  accessModes:
+                    - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 50Gi
+            workload:
+              nodeSelector:
+                kubernetes.io/os: linux

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-clustermanagementaddon.yaml
@@ -1,0 +1,20 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: kubevirt-hyperconverged-operator
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: Kubevirt Hyperconverged Operator
+    displayName: Kubevirt Hyperconverged Operator
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: kubevirt-hyperconverged-operator
+  installStrategy:
+    type: Placements
+    placements:
+    - name: openshift-cnv
+      namespace: open-cluster-management

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-global-placement.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-global-placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: openshift-cnv
+  namespace: {{ .Values.global.namespace }}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            acm/cnv-operator-install: "true"

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/global-clusterset-binding.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/global-clusterset-binding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: {{ .Values.global.namespace }}
+spec:
+  clusterSet: global

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-addon-template.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-addon-template.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: AddOnTemplate
 metadata:
@@ -27,11 +28,6 @@ spec:
               name: mtv-operator
               namespace: openshift-mtv
             upgradeApproval: Automatic
-            # removalBehavior:                  # This only works if the complianceType: mustnothave
-            #   clusterServiceVersions: Delete
-            #   customResourceDefinitions: Keep
-            #   operatorGroups: DeleteIfUnused
-            #   subscriptions: Delete
         - apiVersion: forklift.konveyor.io/v1beta1
           kind: ForkliftController
           metadata:
@@ -69,6 +65,7 @@ spec:
                   control-plane: mtv-controller
                   app.kubernetes.io/name: mtv-integrations
               spec:
+                serviceAccountName: mtv-integrations-manager
                 hostNetwork: false
                 hostPID: false
                 hostIPC: false
@@ -78,34 +75,35 @@ spec:
                   nodeAffinity:
                     requiredDuringSchedulingIgnoredDuringExecution:
                       nodeSelectorTerms:
-                      - matchExpressions:
-                        - key: kubernetes.io/arch
-                          operator: In
-                          values:
-                          - amd64
-                          - ppc64le
-                          - s390x
-                          - arm64
-                          podAntiAffinity:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                            - weight: 70
-                              podAffinityTerm:
-                                topologyKey: topology.kubernetes.io/zone
-                                labelSelector:
-                                  matchExpressions:
-                                  - key: ocm-antiaffinity-selector
-                                    operator: In
-                                    values:
-                                    - mtvintegrations
-                            - weight: 35
-                              podAffinityTerm:
-                                topologyKey: kubernetes.io/hostname
-                                labelSelector:
-                                  matchExpressions:
-                                  - key: ocm-antiaffinity-selector
-                                    operator: In
-                                    values:
-                                    - mtvintegrations
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                                - arm64
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      - weight: 70
+                        podAffinityTerm:
+                          topologyKey: topology.kubernetes.io/zone
+                          labelSelector:
+                            matchExpressions:
+                              - key: ocm-antiaffinity-selector
+                                operator: In
+                                values:
+                                  - mtvintegrations
+                      - weight: 35
+                        podAffinityTerm:
+                          topologyKey: kubernetes.io/hostname
+                          labelSelector:
+                            matchExpressions:
+                              - key: ocm-antiaffinity-selector
+                                operator: In
+                                values:
+                                  - mtvintegrations
+                {{- with .Values.hubconfig.tolerations }}
                 tolerations:
                 {{- range . }}
                 - {{ if .Key }} key: {{ .Key }} {{- end }}
@@ -114,65 +112,57 @@ spec:
                   {{ if .Effect }} effect: {{ .Effect }} {{- end }}
                   {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
                   {{- end }}
-                {{- end }}  
+                {{- end }}
                 containers:
-                - command:
-                  - /manager
-                  args:
-                    - --health-probe-bind-address=:8081
-                  image: {{ .Values.global.imageOverrides.mtv_integrations_controller}}
-                  imagePullPolicy: "{{ .Values.global.pullPolicy }}"
-                  name: mtv-integrations-controller
-                  ports:
-                    # Webhook server port.
-                    - containerPort: 9443
-                      protocol: TCP
-                      name: webhook-http
-                  securityContext:
-                    privileged: false
-                    readOnlyRootFilesystem: true
-                    allowPrivilegeEscalation: false
-                    runAsNonRoot: true
-                    capabilities:
-                      drop:
-                      - ALL
-                  livenessProbe:
-                    httpGet:
-                      path: /healthz
-                      port: 8081
-                    initialDelaySeconds: 15
-                    periodSeconds: 20
-                  readinessProbe:
-                    httpGet:
-                      path: /readyz
-                      port: 8081
-                    initialDelaySeconds: 5
-                    periodSeconds: 10
-                  # TODO(user): Configure the resources accordingly based on the project requirements.
-                  # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                  resources:
-                    # TODO(jpacker): Adjust the requests, once you see this running in the environment.
-                    requests:
-                      cpu: 10m
-                      memory: 64Mi
-                  # Webhook
-                  volumeMounts:
-                    - mountPath: /tmp/k8s-webhook-server/serving-certs
-                      name: cert
-                      readOnly: true
-                # Webhook
-                volumes: 
+                  - name: mtv-integrations-controller
+                    command:
+                      - /manager
+                    args:
+                      - --health-probe-bind-address=:8081
+                    image: {{ .Values.global.imageOverrides.mtv_integrations_controller }}
+                    imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+                    ports:
+                      - containerPort: 9443
+                        protocol: TCP
+                        name: webhook-http
+                    securityContext:
+                      privileged: false
+                      readOnlyRootFilesystem: true
+                      allowPrivilegeEscalation: false
+                      runAsNonRoot: true
+                      capabilities:
+                        drop:
+                          - ALL
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    volumeMounts:
+                      - mountPath: /tmp/k8s-webhook-server/serving-certs
+                        name: cert
+                        readOnly: true
+                volumes:
                   - name: cert
                     secret:
                       defaultMode: 420
                       secretName: mtv-plan-webhook-server-cert
+                {{- if .Values.global.pullSecret }}
                 imagePullSecrets:
-                - name: {{ .Values.global.pullSecret  }}
+                  - name: {{ .Values.global.pullSecret }}
                 {{- end }}
                 {{- with .Values.hubconfig.nodeSelector }}
                 nodeSelector:
-                {{- toYaml . | nindent 8 }}
+                {{- toYaml . | nindent 18 }}
                 {{- end }}
-                serviceAccountName: mtv-integrations-manager
-                terminationGracePeriodSeconds: 10
-        

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-addon-template.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-addon-template.yaml
@@ -1,0 +1,178 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: mtv-operator
+spec:
+  addonName: mtv-operator
+  registration:
+    - type: CustomSigner
+      customSigner:
+        signerName: open-cluster-management.io/kubevirt-hyperconverged-addon
+        signingCA:
+          name: mtv-operator-ca
+          namespace: openshift-mtv
+  agentSpec:
+    workload:
+      manifests:
+        - apiVersion: policy.open-cluster-management.io/v1beta1
+          kind: OperatorPolicy
+          metadata:
+            name: mtv-operator
+            namespace: open-cluster-management-policies
+          spec:
+            complianceType: musthave
+            remediationAction: enforce
+            subscription:
+              channel: release-v2.8
+              name: mtv-operator
+              namespace: openshift-mtv
+            upgradeApproval: Automatic
+            # removalBehavior:                  # This only works if the complianceType: mustnothave
+            #   clusterServiceVersions: Delete
+            #   customResourceDefinitions: Keep
+            #   operatorGroups: DeleteIfUnused
+            #   subscriptions: Delete
+        - apiVersion: forklift.konveyor.io/v1beta1
+          kind: ForkliftController
+          metadata:
+            name: forklift-controller
+            namespace: openshift-mtv
+          spec:
+            feature_ui_plugin: 'true'
+            feature_validation: 'true'
+            feature_volume_populator: 'true'
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: mtv-integrations-controller
+            namespace: {{ .Values.global.namespace }}
+            labels:
+              app: mtv-integrations
+              ocm-antiaffinity-selector: "mtvintegrations"
+              chart: mtv-integrations-{{ .Values.hubconfig.hubVersion }}
+              app.kubernetes.io/name: mtv-integrations
+              app.kubernetes.io/instance: mtv-integrations
+              component: "ocm-mtv-integrations-ctrl"
+              release: mtv-integrations
+          spec:
+            selector:
+              matchLabels:
+                app: mtv-integrations
+                component: "ocm-mtv-integrations-ctrl"
+                release: mtv-integrations
+            replicas: {{ .Values.hubconfig.replicaCount }}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: controller
+                labels:
+                  control-plane: mtv-controller
+                  app.kubernetes.io/name: mtv-integrations
+              spec:
+                hostNetwork: false
+                hostPID: false
+                hostIPC: false
+                securityContext:
+                  runAsNonRoot: true
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: kubernetes.io/arch
+                          operator: In
+                          values:
+                          - amd64
+                          - ppc64le
+                          - s390x
+                          - arm64
+                          podAntiAffinity:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                            - weight: 70
+                              podAffinityTerm:
+                                topologyKey: topology.kubernetes.io/zone
+                                labelSelector:
+                                  matchExpressions:
+                                  - key: ocm-antiaffinity-selector
+                                    operator: In
+                                    values:
+                                    - mtvintegrations
+                            - weight: 35
+                              podAffinityTerm:
+                                topologyKey: kubernetes.io/hostname
+                                labelSelector:
+                                  matchExpressions:
+                                  - key: ocm-antiaffinity-selector
+                                    operator: In
+                                    values:
+                                    - mtvintegrations
+                tolerations:
+                {{- range . }}
+                - {{ if .Key }} key: {{ .Key }} {{- end }}
+                  {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+                  {{ if .Value }} value: {{ .Value }} {{- end }}
+                  {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+                  {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+                  {{- end }}
+                {{- end }}  
+                containers:
+                - command:
+                  - /manager
+                  args:
+                    - --health-probe-bind-address=:8081
+                  image: {{ .Values.global.imageOverrides.mtv_integrations_controller}}
+                  imagePullPolicy: "{{ .Values.global.pullPolicy }}"
+                  name: mtv-integrations-controller
+                  ports:
+                    # Webhook server port.
+                    - containerPort: 9443
+                      protocol: TCP
+                      name: webhook-http
+                  securityContext:
+                    privileged: false
+                    readOnlyRootFilesystem: true
+                    allowPrivilegeEscalation: false
+                    runAsNonRoot: true
+                    capabilities:
+                      drop:
+                      - ALL
+                  livenessProbe:
+                    httpGet:
+                      path: /healthz
+                      port: 8081
+                    initialDelaySeconds: 15
+                    periodSeconds: 20
+                  readinessProbe:
+                    httpGet:
+                      path: /readyz
+                      port: 8081
+                    initialDelaySeconds: 5
+                    periodSeconds: 10
+                  # TODO(user): Configure the resources accordingly based on the project requirements.
+                  # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                  resources:
+                    # TODO(jpacker): Adjust the requests, once you see this running in the environment.
+                    requests:
+                      cpu: 10m
+                      memory: 64Mi
+                  # Webhook
+                  volumeMounts:
+                    - mountPath: /tmp/k8s-webhook-server/serving-certs
+                      name: cert
+                      readOnly: true
+                # Webhook
+                volumes: 
+                  - name: cert
+                    secret:
+                      defaultMode: 420
+                      secretName: mtv-plan-webhook-server-cert
+                imagePullSecrets:
+                - name: {{ .Values.global.pullSecret  }}
+                {{- end }}
+                {{- with .Values.hubconfig.nodeSelector }}
+                nodeSelector:
+                {{- toYaml . | nindent 8 }}
+                {{- end }}
+                serviceAccountName: mtv-integrations-manager
+                terminationGracePeriodSeconds: 10
+        

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-clustermanagementaddon.yaml
@@ -1,0 +1,20 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: mtv-operator
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: MTV Operator
+    displayName: MTV Operator
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: mtv-operator
+  installStrategy:
+    type: Placements
+    placements:
+    - name: openshift-mtv
+      namespace: open-cluster-management

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-global-placement.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-global-placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: openshift-mtv
+  namespace: {{ .Values.global.namespace }}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            local-cluster: "true"

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integration-webhook-service.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integration-webhook-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: mtv-plan-webhook-server-cert
+  name: mtv-plan-webhook-service
+  namespace: {{ .Values.global.namespace }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: mtv-integrations

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-clusterrole.yaml
@@ -1,0 +1,83 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  name: mtv-integrations-manager-role
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - authentication.open-cluster-management.io
+  resources:
+  - managedserviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - rbac.open-cluster-management.io
+  resources:
+  - clusterpermissions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - forklift.konveyor.io
+  resources:
+  - providers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  name: mtv-integrations-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mtv-integrations-manager-role
+subjects:
+- kind: ServiceAccount
+  name: mtv-integrations-manager
+  namespace: {{ .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-sa.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: mtv-integrations
+  name: mtv-integrations-manager
+  namespace: {{ .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-validating-config.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-validating-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: mtv-plan-webhook-validating-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: mtv-plan-webhook-service
+      namespace: {{ .Values.global.namespace }}
+      path: /validate-plan
+  failurePolicy: Fail
+  name: validate.mtv.plan
+  rules:
+  - apiGroups:
+    - forklift.konveyor.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - plans
+  sideEffects: None

--- a/pkg/templates/charts/toggle/mtv-integrations/values.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/values.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Red Hat, Inc.
+global:
+  imageOverrides:
+    mtv_integrations_controller: ""
+  templateOverrides: {}
+  namespace: default
+  pullSecret: null
+  pullPolicy: Always
+  hubSize: Small
+hubconfig:
+  nodeSelector: null
+  proxyConfigs: {}
+  replicaCount: 1
+  tolerations: []
+  ocpVersion: 4.18.0
+org: open-cluster-management

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -36,8 +36,10 @@ package main
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;create
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=secrets;namespaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 //+kubebuilder:rbac:groups="",resources=services,verbs=list
+//+kubebuilder:rbac:groups="",resources=users;groups;serviceaccounts,verbs=impersonate
 //+kubebuilder:rbac:groups="";events.k8s.io,resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=*,resources=*,verbs=*
 //+kubebuilder:rbac:groups=*,resources=*,verbs=*
@@ -85,6 +87,7 @@ package main
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=*
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions;customresourcedefinitions/finalizers,verbs=create;get;list;watch;update;patch;delete
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions;customresourcedefinitions/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups=app.k8s.io,resources=applications,verbs=list;watch
 //+kubebuilder:rbac:groups=app.k8s.io;argoproj.io,resources=applications;applications/status;applicationsets;applicationsets/status,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
@@ -112,6 +115,7 @@ package main
 //+kubebuilder:rbac:groups=authentication.k8s.io;authorization.k8s.io,resources=uids;userextras/authentication.kubernetes.io/credential-id;userextras/authentication.kubernetes.io/node-name;userextras/authentication.kubernetes.io/node-uid;userextras/authentication.kubernetes.io/pod-name;userextras/authentication.kubernetes.io/pod-uid,verbs=impersonate
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=create;delete;get
 //+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch
+//+kubebuilder:rbac:groups=authentication.open-cluster-management.io,resources=managedserviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
@@ -143,6 +147,7 @@ package main
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch;patch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=list;get;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=watch;get;list
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;managedclusters/finalizers,verbs=create;get;list;patch;update;watch
@@ -184,6 +189,7 @@ package main
 //+kubebuilder:rbac:groups=flightctl.io,resources=enrollmentrequests,verbs=get;list
 //+kubebuilder:rbac:groups=flightctl.io,resources=enrollmentrequests/approval,verbs=post
 //+kubebuilder:rbac:groups=flightctl.io,resources=repositories;fleets/templateversions,verbs=get;list
+//+kubebuilder:rbac:groups=forklift.konveyor.io,resources=providers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterclaims;clusterdeployments;clusterpools;clusterimagesets;clusterprovisions;clusterdeprovisions;machinepools,verbs=list;watch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments/status,verbs=get;watch
@@ -244,6 +250,7 @@ package main
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=rbac.open-cluster-management.io,resources=clusterpermissions,verbs=create;delete;get
 //+kubebuilder:rbac:groups=rbac.open-cluster-management.io,resources=clusterpermissions,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=rbac.open-cluster-management.io,resources=clusterpermissions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.open-cluster-management.io,resources=clusterpermissions/finalizers,verbs=update
 //+kubebuilder:rbac:groups=rbac.open-cluster-management.io,resources=clusterpermissions/status,verbs=get;patch;update
 //+kubebuilder:rbac:groups=register.open-cluster-management.io,resources=managedclusters/accept,verbs=create;delete;get;list;patch;update;watch

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -335,7 +335,7 @@ func GetTestImages() []string {
 		"VOLSYNC_MOVER_RESTIC", "VOLSYNC_MOVER_RSYNC", "CLUSTER_PERMISSION", "kube_rbac_proxy", "insights_metrics",
 		"insights_client", "search_collector", "search_indexer", "search_v2_api", "postgresql_13", "search_v2_operator",
 		"klusterlet_addon_controller", "governance_policy_propagator", "governance_policy_addon_controller",
-		"cert_policy_controller", "config_policy_controller", "governance_policy_framework_addon",
+		"cert_policy_controller", "config_policy_controller", "governance_policy_framework_addon", "mtv_integrations_controller",
 		"cluster_backup_controller", "console", "volsync_addon_controller", "multicluster_operators_application",
 		"multicloud_integrations", "multicluster_operators_channel", "multicluster_operators_subscription",
 		"multicluster_observability_operator", "cluster_permission", "siteconfig_operator", "submariner_addon", "acm_cli",
@@ -625,7 +625,6 @@ func UpdateMCEOverrides(mce *mcev1.MultiClusterEngine, mch *operatorsv1.MultiClu
 	}
 	if mch.Spec.DisableHubSelfManagement {
 		mce.Disable(operatorsv1.MCELocalCluster)
-
 	} else {
 		mce.Enable(operatorsv1.MCELocalCluster)
 	}


### PR DESCRIPTION
# Description
Integrate the MTV Integration addon template into the multiclusterhub-operator to enable managed deployment through the hub cluster.

Task Details:

Add the MTV addon toggle under pkg/templates/charts/toggle
Ensure it aligns with existing addon patterns in multiclusterhub-operator
References:

MTV addon source:
https://github.com/stolostron/mtv-integrations/tree/main/addons
Example toggle integration:
https://github.com/stolostron/multiclusterhub-operator/tree/main/pkg/templates/charts/toggle

## Related Issue

https://issues.redhat.com/browse/ACM-21706

## Changes Made

Add mtv-integration templates

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
