### PR TITLE
Fixed error log for applying templates

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -2011,7 +2011,7 @@ func (r *MultiClusterHubReconciler) logAndSetCondition(err error, message string
 	template *unstructured.Unstructured, m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 
 	log.Error(err, message, "Kind", template.GetKind(), "Name", template.GetName())
-	wrappedError := pkgerrors.Wrapf(err, "%s Kind: %s Name: %s", message, template.GetName(), template.GetKind())
+	wrappedError := pkgerrors.Wrapf(err, "%s Kind: %s Name: %s", message, template.GetKind(), template.GetName())
 
 	condType := fmt.Sprintf("%v: %v (Kind:%v)", operatorv1.ComponentFailure, template.GetName(),
 		template.GetKind())


### PR DESCRIPTION
# Description

When a template fails to apply, the error log displays the resource details in the wrong order:
```bash
multiclusterhub_controller_test.go:2125: failed: failed to update resource Kind: flightctl-api- Name: ClusterRoleBinding: apply patches are not supported in the fake client. Follow https://github.com/kubernetes/kubernetes/issues/115598 for the current status
multiclusterhub_controller_test.go:2125: failed: failed to update resource Kind: flightctl-api- Name: ClusterRole: apply patches are not supported in the fake client. Follow https://github.com/kubernetes/kubernetes/issues/115598 for the current status
```
This PR updates the error logging to display resource information in the correct order for better clarity.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Fixed logging in the `logAndSetCondition` func.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
