### PR TITLE
[ACM-22089] Updated image key references for flightctl component

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -1,4 +1,4 @@
-acm-release-version: '2.14'
+acm-release-version: '2.15'
 components:
   - repo_name: "flight-control"
     github_ref: "https://github.com/flightctl/flightctl.git"
@@ -8,12 +8,15 @@ components:
         chart-path: "deploy/helm/flightctl"
         always-or-toggle: "toggle"
         imageMappings:
-          flightctl-worker: flightctl_worker
-          flightctl-periodic: flightctl_periodic
+          alertmanager: alertmanager
+          flightctl-alertmanager-proxy: flightctl_alertmanager_proxy
+          flightctl-alert-exporter: flightctl_alert_exporter
           flightctl-api: flightctl_api
-          flightctl-ui: flightctl_ui
-          flightctl-ocp-ui: flightctl_ocp_ui
           flightctl-cli-artifacts: flightctl_cli_artifacts
+          flightctl-ocp-ui: flightctl_ocp_ui
+          flightctl-periodic: flightctl_periodic
+          flightctl-ui: flightctl_ui
+          flightctl-worker: flightctl_worker
           origin-cli: origin_cli
           postgresql-16-c9s: postgresql_16
           redis-7-c9s: redis_7_c9s

--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -1,4 +1,4 @@
-acm-release-version: '2.14'
+acm-release-version: '2.15'
 components:
   - repo_name: multicloud-operators-subscription
     github_ref: "https://github.com/stolostron/multicloud-operators-subscription.git"

--- a/pkg/templates/charts/toggle/flight-control/values.yaml
+++ b/pkg/templates/charts/toggle/flight-control/values.yaml
@@ -3,6 +3,9 @@ global:
   baseDomain: ''
   hubSize: Small
   imageOverrides:
+    alertmanager: ''
+    flightctl_alert_exporter: ''
+    flightctl_alertmanager_proxy: ''
     flightctl_api: ''
     flightctl_cli_artifacts: ''
     flightctl_ocp_ui: ''

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -341,6 +341,7 @@ func GetTestImages() []string {
 		"multicluster_observability_operator", "cluster_permission", "siteconfig_operator", "submariner_addon", "acm_cli",
 		"flightctl_worker", "flightctl_periodic", "flightctl_api", "flightctl_ui", "flightctl_ocp_ui",
 		"flightctl_cli_artifacts", "postgresql_12_c8s", "postgresql_12", "postgresql_16", "origin_cli", "redis_7_c9s",
+		"alertmanager", "flightctl_alertmanager_proxy", "flightctl_alert_exporter",
 	}
 }
 


### PR DESCRIPTION
# Description

To fix the error in the regenerate chart automation, this PR adds the missing image key references for the `Flightctl` component:

```yaml
alertmanager: alertmanager
flightctl-alertmanager-proxy: flightctl_alertmanager_proxy
flightctl-alert-exporter: flightctl_alert_exporter
```

## Related Issue

https://issues.redhat.com/browse/ACM-22089

## Changes Made

Added new image key references to MCH.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
