### PR TITLE
Fixed image key mapping for postgres-16

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -40,7 +40,7 @@ components:
         imageMappings:
           search-v2-operator: search_v2_operator
           kube-rbac-proxy: kube_rbac_proxy
-          postgresql-13: postgresql_16
+          postgresql-16: postgresql_16
           search-indexer: search_indexer
           search-collector: search_collector
           search-v2-api: search_v2_api


### PR DESCRIPTION
# Description

To ensure successful bundle automation, we need to update the `imagekey` reference for the `Postgres` image:

```bash
2025-07-24 18:01:54 pkrvmpptgkbjq6m root[2186] INFO Fixing image references in container 'env' section in deployments and values.yaml ...
2025-07-24 18:01:54 pkrvmpptgkbjq6m root[2186] CRITICAL No image key mapping provided for imageKey: postgresql-16
2025-07-24 18:01:54 pkrvmpptgkbjq6m root[2172] ERROR Script bundle-generation/bundles-to-charts.py failed with exit code 1
make: *** [Makefile.dev:62: regenerate-charts-from-bundles] Error 1
```

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated the `imagekey` reference for `postgres-16`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
