### PR TITLE
[release-2.14] Updated search-v2-operator imageMapping to include postgresql-16

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -40,7 +40,7 @@ components:
         imageMappings:
           search-v2-operator: search_v2_operator
           kube-rbac-proxy: kube_rbac_proxy
-          postgresql-13: postgresql_16
+          postgresql-16: postgresql_16
           search-indexer: search_indexer
           search-collector: search_collector
           search-v2-api: search_v2_api


### PR DESCRIPTION
# Description

In ACM 2.14, Search updated their component to use `postgresql-16`; therefore, this PR will update the `imageMapping` reference from `postgresql-13` to v16.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `search-v2-operator` `imageMapping` to include `postgresql-16`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
