### PR TITLE
use OADP stable for any OCP version newer than 4.19

### DIFF
--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -376,12 +376,11 @@ func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval,
 	} else {
 
 		ocpVersion := os.Getenv("ACM_HUB_OCP_VERSION")
-		isOCP419orNewer := strings.HasPrefix(ocpVersion, "4.19") ||
-			strings.HasPrefix(ocpVersion, "4.2") ||
-			strings.HasPrefix(ocpVersion, "4.3")
+		isOCP419orNewer := ocpVersion == "" || strings.HasPrefix(ocpVersion, "4.19") ||
+			!strings.HasPrefix(ocpVersion, "4.1")
 
 		if isOCP419orNewer {
-			// use stable channel for OCP 2.19 or newer
+			// use stable channel for OCP 4.19 or newer, or unknown ocp version
 			channel = defaultOADPStableChannel
 		} else {
 			channel = defaultOADPChannel

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -350,6 +350,14 @@ func TestOADPAnnotation(t *testing.T) {
 	}
 
 	// These should all be the defaults (no overrides)
+	// no ACM_HUB_OCP_VERSION set, should return stable channel
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
+	if test2 != defaultOADPStableChannel {
+		t.Error("Cluster Backup missing OADP overrides for 1.4 channel on unknown version of ocp")
+	}
+
+	// fake the ocp version to 4.18.0, it should result in stable-1.4 channel
+	os.Setenv("ACM_HUB_OCP_VERSION", "4.18.0")
 	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
 
 	if test1 != defaultOADPName {
@@ -357,7 +365,7 @@ func TestOADPAnnotation(t *testing.T) {
 	}
 
 	if test2 != defaultOADPChannel {
-		t.Error("Cluster Backup missing OADP overrides for channel")
+		t.Error("Cluster Backup missing OADP overrides for 1.4 channel on ocp 4.18")
 	}
 
 	if test3 != defaultOADPInstallPlan {
@@ -375,4 +383,19 @@ func TestOADPAnnotation(t *testing.T) {
 	if test6 != "" {
 		t.Error("Cluster Backup Defaulted to something other than \"\"")
 	}
+
+	// fake the ocp version to 4.30.0, it should result in stable channel
+	os.Setenv("ACM_HUB_OCP_VERSION", "4.30.0")
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
+	if test2 != defaultOADPStableChannel {
+		t.Error("Cluster Backup missing OADP overrides for stable channel on ocp 4.30")
+	}
+
+	// fake the ocp version to something starting with anything other than 1.4, it should result in stable channel
+	os.Setenv("ACM_HUB_OCP_VERSION", "5.1.0")
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
+	if test2 != defaultOADPStableChannel {
+		t.Error("Cluster Backup missing OADP overrides for stable channel on ocp 5.1.0")
+	}
+
 }

--- a/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/acm-dr-virt-install.yaml
@@ -108,14 +108,8 @@ spec:
                       namespace: "open-cluster-management-backup"
             {{ `{{hub else hub}}` }}
               {{ `{{- $oadp_channel := "stable-1.4" }}` }}
-              {{ `{{- $ocp_version := "" }}` }}
-              {{ `{{- $cluster_version := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version")  }}` }}
-              {{ `{{- if eq $cluster_version.metadata.name  "version" }}` }}
-                {{ `{{- range $hist := $cluster_version.status.history}}` }}
-                  {{ `{{- $ocp_version = $hist.version }}` }}
-                {{ `{{- end }}` }}
-              {{ `{{- end }}` }}
-              {{ `{{ if or (hasPrefix "4.19" $ocp_version) (hasPrefix "4.2" $ocp_version) }}` }}
+              {{ `{{- $ocp_version := fromClusterClaim "version.openshift.io" }}` }}
+              {{ `{{ if or (eq $ocp_version "") (hasPrefix "4.19" $ocp_version) (not (hasPrefix "4.1" $ocp_version)) }}` }}
               {{ `{{- $oadp_channel = "stable" }}` }}
               {{ `{{- end }}` }}
               {{ `{{ if hasPrefix "4.12" $ocp_version }}` }}
@@ -286,14 +280,8 @@ spec:
 
             {{ `{{- /* inferre the oadp channel from the cluster ocp version */ -}}` }}
             {{ `{{- $oadp_channel := "stable-1.4" }}` }}
-            {{ `{{- $ocp_version := "" }}` }}
-            {{ `{{- $cluster_version := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version")  }}` }}
-            {{ `{{- if eq $cluster_version.metadata.name  "version" }}` }}
-              {{ `{{- range $hist := $cluster_version.status.history}}` }}
-                {{ `{{- $ocp_version = $hist.version }}` }}
-              {{ `{{- end }}` }}
-            {{ `{{- end }}` }}
-            {{ `{{ if or (hasPrefix "4.19" $ocp_version) (hasPrefix "4.2" $ocp_version) }}` }}
+            {{ `{{- $ocp_version := fromClusterClaim "version.openshift.io" }}` }}
+            {{ `{{ if or (eq $ocp_version "") (hasPrefix "4.19" $ocp_version) (not (hasPrefix "4.1" $ocp_version)) }}` }}
             {{ `{{- $oadp_channel = "stable" }}` }}
             {{ `{{- end }}` }}
             {{ `{{ if hasPrefix "4.12" $ocp_version }}` }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml
@@ -415,14 +415,8 @@ spec:
           severity: high
           object-templates-raw: |
             {{ `{{- $ch := "stable-1.4" }}` }}
-            {{ `{{- $ocp_version := "" }}` }}
-            {{ `{{- $cluster_version := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version")  }}` }}
-            {{ `{{- if eq $cluster_version.metadata.name  "version" }}` }}
-              {{ `{{- range $hist := $cluster_version.status.history}}` }}
-                {{ `{{- $ocp_version = $hist.version }}` }}
-              {{ `{{- end }}` }}
-            {{ `{{- end }}` }}
-            {{ `{{ if or (hasPrefix "4.19" $ocp_version) (hasPrefix "4.2" $ocp_version) }}` }}
+            {{ `{{- $ocp_version := fromClusterClaim "version.openshift.io" }}` }}
+            {{ `{{ if or (eq $ocp_version "") (hasPrefix "4.19" $ocp_version) (not (hasPrefix "4.1" $ocp_version)) }}` }}
             {{ `{{- $ch = "stable" }}` }}
             {{ `{{- end }}` }}
             {{ `{{- range $ss := (lookup "operators.coreos.com/v1alpha1" "Subscription" "open-cluster-management-backup" "").items }}` }}


### PR DESCRIPTION
# Description

Update OADP channel validation to support any OCP version newer than OCP 4.19

These versions should all be using the OADP stable channel

## Related Issue

https://issues.redhat.com/browse/ACM-23453

## Changes Made

Updated oadp-channel-validation template from the pkg/templates/charts/toggle/cluster-backup/templates/hub-backup-pod.yaml ; this validates the OADP version
Updated install-oadp-copy-config template from acm-dr-virt-install policy to install OADP based on OCP version
Updated pkg/rendering/renderer.go to set the OADP install channel to stable if OCP version is newer than 4.19 

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
