### PR TITLE
[release-2.11] Removed hardcoded ARCH for Dockerfile.rhtap

### DIFF
--- a/.tekton/multiclusterhub-operator-acm-211-push.yaml
+++ b/.tekton/multiclusterhub-operator-acm-211-push.yaml
@@ -39,6 +39,12 @@ spec:
     value: '[{"type": "gomod", "path": "."}]'
   - name: path-context
     value: .
+  - name: send-slack-notification
+    value: true
+  - name: konflux-application-name
+    value: release-acm-214
+  - name: slack-member-id
+    value: UU77A0LC8 # @dbennett, The slack member id of the current component owner.
   pipelineRef:
     resolver: git
     params:

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,8 +1,8 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as cloner
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as cloner
 
-RUN microdnf install git findutils
+RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.21 AS builder
@@ -11,10 +11,6 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
@@ -26,10 +22,9 @@ COPY pkg/ pkg/
 COPY pkg/templates/ templates/
 
 # Build
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go mod vendor
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o multiclusterhub-operator main.go
+RUN CGO_ENABLED=1 go build -mod=readonly -o multiclusterhub-operator main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL org.label-schema.vendor="Red Hat" \
       org.label-schema.name="multiclusterhub-operator" \


### PR DESCRIPTION
# Description

In Konflux, because our component is built with `multi-arch` support, we need to ensure the targeted `Dockerfile.rhtap` does not hard-code the architecture type.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated build/Dockerfile.rhtap

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
