### PR TITLE
[release-2.12] Removed hardcoded ARCH for Dockerfile.rhtap

### DIFF
--- a/.tekton/multiclusterhub-operator-acm-212-push.yaml
+++ b/.tekton/multiclusterhub-operator-acm-212-push.yaml
@@ -44,7 +44,7 @@ spec:
   - name: konflux-application-name
     value: release-acm-212 # Need to be updated for each release
   - name: slack-member-id
-    value: S05L3R4SM89 # acm-hub-install-ic, The slack member id of the current component owner.
+    value: UU77A0LC8 # @dbennett, The slack member id of the current component owner.
   pipelineRef:
     resolver: git
     params:

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -12,10 +12,6 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
 # Copy the go source
 COPY main.go main.go
 COPY api/ api/
@@ -26,8 +22,7 @@ COPY pkg/ pkg/
 COPY pkg/templates/ templates/
 
 # Build
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go mod vendor
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o multiclusterhub-operator main.go
+RUN CGO_ENABLED=1 go build -mod=readonly -o multiclusterhub-operator main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
# Description

In Konflux, because our component is built with `multi-arch` support, we need to ensure the targeted `Dockerfile.rhtap` does not hard-code the architecture type.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated build/Dockerfile.rhtap

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
