### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for multiclusterhub-operator-acm-214

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -36,6 +36,7 @@ LABEL org.label-schema.vendor="Red Hat" \
       io.k8s.display-name="MultiClusterHub operator" \
       io.k8s.description="Installer operator for Red Hat Advanced Cluster Management" \
       com.redhat.component="multiclusterhub-operator-container" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       io.openshift.tags="data,images"
 
 WORKDIR /


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
