### PR TITLE
Add repository url label to container images

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -27,6 +27,7 @@ RUN CGO_ENABLED=1 go build -mod=readonly -o multiclusterhub-operator main.go
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL org.label-schema.vendor="Red Hat" \
+      url="https://github.com/stolostron/multiclusterhub-operator" \
       org.label-schema.name="multiclusterhub-operator" \
       org.label-schema.description="Installer operator for Red Hat Advanced Cluster Management" \
       org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** release-2.15

**Components affected:** multiclusterhub-operator

**Branch details:** multiclusterhub-operator (branch: release-2.15)

**Label added:**
- url: https://github.com/stolostron/multiclusterhub-operator

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.