### PR TITLE
Add extend-role addontemplate

### DIFF
--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-role-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-role-clustermanagementaddon.yaml
@@ -1,0 +1,20 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: acm-roles
+  annotations:
+    addon.open-cluster-management.io/lifecycle: "addon-manager"
+spec:
+  addOnMeta:
+    description: ACM Roles
+    displayName: ACM Roles
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addontemplates
+      defaultConfig:
+        name: acm-roles
+  installStrategy:
+    type: Placements
+    placements:
+    - name: acm-roles-placement
+      namespace: {{ .Values.global.namespace }}

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-role-placement.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-role-placement.yaml
@@ -1,0 +1,9 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: acm-roles-placement
+  namespace: {{ .Values.global.namespace }}
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector: {}

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-roles.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-roles.yaml
@@ -1,0 +1,356 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnTemplate
+metadata:
+  name: acm-roles
+spec:
+  addonName: acm-roles
+  agentSpec:
+    workload:
+      manifests:
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: vm-clusterroles
+            name: kubevirt.io-acm:admin
+          rules:
+            - apiGroups:
+              - k8s.cni.cncf.io
+              resources:
+              - network-attachment-definitions
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - list
+              - delete
+              - create
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              - namespaces
+              - nodes
+              - nodes/proxy
+              - nodes/exec
+              - persistentvolumeclaims
+              - persistentvolumes
+              - pods
+              - pods/exec
+              - pods/log
+              - pods/metrics
+              - services
+              - serviceaccounts
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - events.k8s.io
+              resources:
+              - events
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - datavolumes
+              - datasources
+              - dataimportcrons
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - migrations.kubevirt.io
+              resources:
+              - migrationpolicies
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - clusterview.open-cluster-management.io
+              resources:
+              - managedclusters
+              verbs:
+              - list
+              - get
+              - watch
+            - apiGroups:
+              - cluster.open-cluster-management.io
+              resources:
+              - managedclusters
+              verbs:
+              - get
+            - apiGroups:
+              - metrics.k8s.io
+              resources:
+              - pods
+              verbs:
+              - get
+              - list
+              - watch
+            - verbs:
+                - get
+                - watch
+              apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheuses/api
+              resourceNames:
+                - k8s
+            - apiGroups:
+              - clusterview.open-cluster-management.io
+              resources:
+              - kubevirtprojects
+              verbs:
+              - list
+            - apiGroups:
+              - hco.kubevirt.io
+              resources:
+              - hyperconvergeds
+              verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - snapshot.storage.k8s.io
+              resources:
+              - "*"
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - project.openshift.io
+              resources:
+              - projects
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - forklift.konveyor.io
+              resources:
+              - Migration
+              - providers
+              - plans
+              - networkmaps
+              - storagemaps
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+            - apiGroups:
+              - template.openshift.io
+              resources:
+              - templates
+              verbs:
+              - get
+              - list
+              - watch
+              - delete
+              - create
+              - update
+              - patch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: vm-clusterroles
+            name: kubevirt.io-acm:view
+          rules:
+            - apiGroups:
+              - k8s.cni.cncf.io
+              resources:
+              - network-attachment-definitions
+              verbs:
+              - get
+              - list
+            - apiGroups:
+              - ""
+              resources:
+              - configmaps
+              - namespaces
+              - nodes
+              - persistentvolumeclaims
+              - persistentvolumes
+              - pods
+              - pods/metrics
+              - pods/log
+              - services
+              - serviceaccounts
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - list
+            - apiGroups:
+              - events.k8s.io
+              resources:
+              - events
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - cdi.kubevirt.io
+              resources:
+              - datavolumes
+              - datasources
+              - dataimportcrons
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - migrations.kubevirt.io
+              resources:
+              - migrationpolicies
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - cluster.open-cluster-management.io
+              resources:
+              - managedclusters
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - clusterview.open-cluster-management.io
+              resources:
+              - managedclusters
+              verbs:
+              - list
+              - get
+              - watch
+            - apiGroups:
+              - clusterview.open-cluster-management.io
+              resources:
+              - kubevirtprojects
+              verbs:
+              - list
+            - apiGroups:
+              - metrics.k8s.io
+              resources:
+              - pods
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - hco.kubevirt.io
+              resources:
+              - hyperconvergeds
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - monitoring.coreos.com
+              verbs:
+              - get
+              - watch
+              resources:
+                - prometheuses/api
+              resourceNames:
+                - k8s
+            - apiGroups:
+              - batch
+              resources:
+              - jobs
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - snapshot.storage.k8s.io
+              resources:
+              - "*"
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - project.openshift.io
+              resources:
+              - projects
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - forklift.konveyor.io
+              resources:
+              - Migration
+              - providers
+              - plans
+              - networkmaps
+              - storagemaps
+              verbs:
+              - get
+              - list
+              - watch
+            - apiGroups:
+              - template.openshift.io
+              resources:
+              - templates
+              verbs:
+              - get
+              - list
+              - watch


### PR DESCRIPTION
# Description

The kubevirt:admin role needs to be extended (or new role created and used in addition with) to provide access to related VM resources. This includes network (NetworkAttachmentDefinition), storage (PV, PVC, DataVolumes), nodes, pods (VM pod), secrets, configmaps, etc. This list needs to be identified and agreed upon by PM and architect.

The bare minimum role should allow full VM page console access (both ACM and OCP consoles)


## Related Issue

https://issues.redhat.com/projects/ACM/issues/ACM-22869

## Changes Made

Install extend-role on hub and all managed clusters by adding AddOnTemplate, ClusterManagementAddOn, and Placement.


## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
