### PR TITLE
Added escape-template-variables to mtv-integrations chart to fix automation

### DIFF
--- a/hack/bundle-automation/charts-config.yaml
+++ b/hack/bundle-automation/charts-config.yaml
@@ -63,4 +63,6 @@ components:
           - "CLUSTER_NAME"
           - "HUB_KUBECONFIG"
           - "INSTALL_NAMESPACE"
+          - "LIVE_NETWORK_KEY"
+          - "LIVE_NETWORK_VALUE"
         auto-install-for-all-clusters: true

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-config-addondeploymentconfig.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/cnv-config-addondeploymentconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: cnv-config
+  namespace: '{{ .Values.global.namespace }}'
+spec:
+  agentInstallNamespace: openshift-cnv
+  customizedVariables:
+  - name: LIVE_NETWORK_KEY
+  - name: LIVE_NETWORK_VALUE

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/kubevirt-hyperconverged-operator-addontemplate.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/kubevirt-hyperconverged-operator-addontemplate.yaml
@@ -126,6 +126,7 @@ spec:
             parallelMigrationsPerCluster: 5
             parallelOutboundMigrationsPerNode: 2
             progressTimeout: 150
+            '{{ `{{LIVE_NETWORK_KEY}}` }}': '{{ `{{LIVE_NETWORK_VALUE}}` }}'
           resourceRequirements:
             vmiCPUAllocationRatio: 10
           uninstallStrategy: BlockUninstallIfWorkloadsExist

--- a/pkg/templates/charts/toggle/mtv-integrations/templates/kubevirt-hyperconverged-operator-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/mtv-integrations/templates/kubevirt-hyperconverged-operator-clustermanagementaddon.yaml
@@ -18,3 +18,8 @@ spec:
       name: kubevirt-hyperconverged-operator
     group: addon.open-cluster-management.io
     resource: addontemplates
+  - defaultConfig:
+      name: cnv-config
+      namespace: '{{ .Values.global.namespace }}'
+    group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs


### PR DESCRIPTION
# Description

Currently, our automation is failing due to an unescaped variable in the `mtv-integrations` chart:

```bash
 2025-10-01T12:11:11.487Z	INFO	reconcile	error rendering chart: mtv-integrations-mtv
2025-10-01T12:11:11.487Z	INFO	reconcile	parse error at (mtv-integrations-mtv/templates/kubevirt-hyperconverged-operator-addontemplate.yaml:129): function "LIVE_NETWORK_KEY" not defined
panic: ([]error) 0xc0007fa840
```

This PR escapes the relevant variables to resolve the rendering issue and prevent the automation from failing.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `charts-config.yaml` to fix automation failure.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
