### PR TITLE
[ACM-24924] Fixed multicloud-operators-subscription escaped template variables list

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -18,12 +18,14 @@ components:
           - ARGOCD_AGENT_MODE
           - ARGOCD_AGENT_SERVER_ADDRESS
           - ARGOCD_AGENT_SERVER_PORT
+          - ARGOCD_AGENT_UNINSTALL
           - GITOPS_OPERATOR_IMAGE
           - GITOPS_OPERATOR_NAMESPACE
           - GITOPS_IMAGE
           - GITOPS_NAMESPACE
           - REDIS_IMAGE
           - RECONCILE_SCOPE
+          - UNINSTALL
         exclusions:
           - readOnlyRootFilesystem
 

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/gitops-addon.addonTemplates.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/gitops-addon.addonTemplates.yaml
@@ -42,8 +42,8 @@ spec:
                   value: '{{ `{{REDIS_IMAGE}}` }}'
                 - name: RECONCILE_SCOPE
                   value: '{{ `{{RECONCILE_SCOPE}}` }}'
-                - name: ACTION
-                  value: '{{ `{{ACTION}}` }}'
+                - name: UNINSTALL
+                  value: '{{ `{{UNINSTALL}}` }}'
                 - name: ARGOCD_AGENT_ENABLED
                   value: '{{ `{{ARGOCD_AGENT_ENABLED}}` }}'
                 - name: ARGOCD_AGENT_IMAGE
@@ -54,6 +54,8 @@ spec:
                   value: '{{ `{{ARGOCD_AGENT_SERVER_PORT}}` }}'
                 - name: ARGOCD_AGENT_MODE
                   value: '{{ `{{ARGOCD_AGENT_MODE}}` }}'
+                - name: ARGOCD_AGENT_UNINSTALL
+                  value: '{{ `{{ARGOCD_AGENT_UNINSTALL}}` }}'
                 image: '{{ .Values.global.imageOverrides.multicloud_integrations }}'
                 imagePullPolicy: IfNotPresent
                 name: gitops-addon

--- a/pkg/templates/crds/multicloud-operators-subscription/apps.open-cluster-management.io_gitopsclusters_crd_v1beta1.yaml
+++ b/pkg/templates/crds/multicloud-operators-subscription/apps.open-cluster-management.io_gitopsclusters_crd_v1beta1.yaml
@@ -65,10 +65,6 @@ spec:
                 description: GitOpsAddon defines the configuration for the GitOps
                   addon.
                 properties:
-                  action:
-                    description: Action specifies the action to be performed by the
-                      GitOps operator. Default is empty.
-                    type: string
                   argoCDAgent:
                     description: ArgoCDAgent defines the configuration for the ArgoCD
                       agent.
@@ -100,6 +96,13 @@ spec:
                         description: ServerPort specifies the ArgoCD server port for
                           the agent. Default is empty.
                         type: string
+                      uninstall:
+                        default: false
+                        description: |-
+                          Uninstall indicates whether to uninstall only the ArgoCD agent component. Default is false.
+                          When set to true, only the agent component is uninstalled while keeping the gitopsAddon.
+                          This is different from GitOpsAddonSpec.Uninstall which removes everything.
+                        type: boolean
                     type: object
                   enabled:
                     default: false
@@ -138,6 +141,13 @@ spec:
                     description: RedisImage specifies the Redis container image. Default
                       is empty.
                     type: string
+                  uninstall:
+                    default: false
+                    description: |-
+                      Uninstall indicates whether to uninstall the gitopsaddon. Default is false.
+                      When set to true, performs uninstall operations instead of install.
+                      When uninstall is true, OverrideExistingConfigs is automatically set to true.
+                    type: boolean
                 type: object
               managedServiceAccountRef:
                 description: ManagedServiceAccountRef defines managed service account


### PR DESCRIPTION
# Description

To resolve the issue with the `regenerate-charts-operator-bundles` job for the main branch, we need to include the extra `escaped-template-variables` for the `multicloud-operators-subscription` component.

```bash
 2025-10-03T12:02:22.649Z	INFO	reconcile	error rendering chart: multicloud-operators-subscription
2025-10-03T12:02:22.649Z	INFO	reconcile	parse error at (multicloud-operators-subscription/templates/gitops-addon.addonTemplates.yaml:46): function "UNINSTALL" not defined
panic: ([]error) 0xc0003b0990
````

## Related Issue

https://issues.redhat.com/browse/ACM-24924

## Changes Made

Added additional `escaped-template-variables` to the `multicloud-operators-subscription` component.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
