### PR TITLE
Split into Hub Roles and Managed Roles

### DIFF
--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-roles.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-roles.yaml
@@ -173,13 +173,9 @@ spec:
               - update
               - patch
             - apiGroups:
-              - forklift.konveyor.io
+              - template.openshift.io
               resources:
-              - Migration
-              - providers
-              - plans
-              - networkmaps
-              - storagemaps
+              - templates
               verbs:
               - get
               - list
@@ -188,10 +184,22 @@ spec:
               - create
               - update
               - patch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: vm-clusterroles
+            namespace: mtv-integration
+            name: kubevirt.io-acm-mtv:admin
+          rules:
             - apiGroups:
-              - template.openshift.io
+              - forklift.konveyor.io
               resources:
-              - templates
+              - migrations
+              - providers
+              - plans
+              - networkmaps
+              - storagemaps
               verbs:
               - get
               - list
@@ -335,21 +343,29 @@ spec:
               - list
               - watch
             - apiGroups:
-              - forklift.konveyor.io
+              - template.openshift.io
               resources:
-              - Migration
-              - providers
-              - plans
-              - networkmaps
-              - storagemaps
+              - templates
               verbs:
               - get
               - list
               - watch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: vm-clusterroles
+            namespace: mtv-integration
+            name: kubevirt.io-acm-mtv:view
+          rules:
             - apiGroups:
-              - template.openshift.io
+              - forklift.konveyor.io
               resources:
-              - templates
+              - migrations
+              - providers
+              - plans
+              - networkmaps
+              - storagemaps
               verbs:
               - get
               - list


### PR DESCRIPTION
MTV roles should be restricted to the mtv-integrations namespace to ensure proper isolation and limit unnecessary cluster-wide access.

# Description

Based on recent discussion, the migration role should be separated from the main VM extended role. The migration role will primarily be used on the hub, while the extended VM role will remain for managed cluster operations. Additionally, MTV roles should be restricted to the mtv-integrations namespace to ensure proper isolation and limit unnecessary cluster-wide access.

## Related Issue

https://issues.redhat.com/browse/ACM-24967

## Changes Made

Split into Hub Roles and Managed Roles

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
