### PR TITLE
ACM-24965 Adjust console deployment timeouts

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -154,13 +154,13 @@ spec:
             path: /readinessProbe
             port: 3000
             scheme: HTTPS
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         livenessProbe:
           httpGet:
             path: /livenessProbe
             port: 3000
             scheme: HTTPS
-          timeoutSeconds: 5
+          timeoutSeconds: 10
           initialDelaySeconds: 10
       {{- if .Values.global.pullSecret }}
       imagePullSecrets:


### PR DESCRIPTION
## Description

Increases liveness and readiness probe timeouts for the console deployment to avoid CLBO during periods of heavy load

## Related Issue

https://issues.redhat.com/browse/ACM-24965

## Changes Made

Timeouts increased from 5 to 10 seconds. We are also pursuing performance improvements, but this will serve as a backstop if those are not sufficient.

## Checklist

- [X] I have tested the changes locally and they are functioning as expected.
- [X] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
