### PR TITLE
[ACM-24511] Bump go version to v1.24.6 to resolve CVE-2025-47907

### DIFF
--- a/.tekton/multiclusterhub-operator-unit-test.yaml
+++ b/.tekton/multiclusterhub-operator-unit-test.yaml
@@ -48,7 +48,7 @@ spec:
               dnf -y install jq git make podman
 
               # Install golang with a given version
-              export GOVERSION=1.24.4
+              export GOVERSION=1.24.6
               curl -O -J https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
               rm -rf /usr/local/go && tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ This repository typically involves working with forks. When performing git opera
 
 ## Development Notes
 
-- Go version 1.24.4 minimum required
+- Go version 1.24.6 minimum required
 - Uses Ginkgo/Gomega for testing framework
 - Supports both Docker and Podman for container builds
 - Development testing uses mock components to avoid full OCM deployment

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multiclusterhub-operator
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-roles.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/extend-roles.yaml
@@ -173,13 +173,9 @@ spec:
               - update
               - patch
             - apiGroups:
-              - forklift.konveyor.io
+              - template.openshift.io
               resources:
-              - Migration
-              - providers
-              - plans
-              - networkmaps
-              - storagemaps
+              - templates
               verbs:
               - get
               - list
@@ -188,10 +184,22 @@ spec:
               - create
               - update
               - patch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: vm-clusterroles
+            namespace: mtv-integration
+            name: kubevirt.io-acm-mtv:admin
+          rules:
             - apiGroups:
-              - template.openshift.io
+              - forklift.konveyor.io
               resources:
-              - templates
+              - migrations
+              - providers
+              - plans
+              - networkmaps
+              - storagemaps
               verbs:
               - get
               - list
@@ -335,21 +343,29 @@ spec:
               - list
               - watch
             - apiGroups:
-              - forklift.konveyor.io
+              - template.openshift.io
               resources:
-              - Migration
-              - providers
-              - plans
-              - networkmaps
-              - storagemaps
+              - templates
               verbs:
               - get
               - list
               - watch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              rbac.open-cluster-management.io/filter: vm-clusterroles
+            namespace: mtv-integration
+            name: kubevirt.io-acm-mtv:view
+          rules:
             - apiGroups:
-              - template.openshift.io
+              - forklift.konveyor.io
               resources:
-              - templates
+              - migrations
+              - providers
+              - plans
+              - networkmaps
+              - storagemaps
               verbs:
               - get
               - list


### PR DESCRIPTION
# Description

To address CVE-2024-47907, it is recommended that we upgrade Go to version `go1.24.6`.

https://www.cve.org/CVERecord?id=CVE-2025-47907

## Related Issue

https://issues.redhat.com/browse/ACM-24511

## Changes Made

Updated `Go` version.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
