### PR TITLE
[ACM-24510] Bump go version to v1.23.12 to resolve CVE-2025-47907

### DIFF
--- a/.tekton/multiclusterhub-operator-unit-test.yaml
+++ b/.tekton/multiclusterhub-operator-unit-test.yaml
@@ -48,7 +48,7 @@ spec:
               dnf -y install jq git make podman
 
               # Install golang with a given version
-              export GOVERSION=1.23.4
+              export GOVERSION=1.23.12
               curl -O -J https://dl.google.com/go/go$GOVERSION.linux-amd64.tar.gz
               rm -rf /usr/local/go && tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ sub-components).
 1. Confirm the following are installed and configured on your local machine:
 
    - `docker` or `podman`
-   - `go` (version 1.23.4 minimum)
+   - `go` (version 1.23.12 minimum)
    - `python3`
    - `make`
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multiclusterhub-operator
 
-go 1.23.6
+go 1.23.12
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
# Description

To address CVE-2024-47907, it is recommended that we upgrade Go to version `go1.23.12`.

https://www.cve.org/CVERecord?id=CVE-2025-47907

## Related Issue

https://issues.redhat.com/browse/ACM-24510

## Changes Made

Updated `Go` version.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
