### PR TITLE
[ACM-25297] Updated MCH to not set enableClusterBackup upon creation

### DIFF
--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -66,8 +66,8 @@ type MultiClusterHubSpec struct {
 	Hive *HiveConfigSpec `json:"hive,omitempty"`
 
 	// (Deprecated) Configuration options for ingress management
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Management",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	Ingress IngressSpec `json:"ingress,omitempty"`
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Management",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	Ingress *IngressSpec `json:"ingress,omitempty"`
 
 	// Developer Overrides
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Developer Overrides",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
@@ -92,7 +92,7 @@ type MultiClusterHubSpec struct {
 	// (Deprecated) Enable cluster backup
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enable Cluster Backup",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +optional
-	EnableClusterBackup bool `json:"enableClusterBackup"`
+	EnableClusterBackup bool `json:"enableClusterBackup,omitempty"`
 
 	// The name of the local-cluster resource
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Local Cluster Name",xDescriptors={"urn:alm:descriptor:io.kubernetes:text","urn:alm:descriptor:com.tectonic.ui:advanced"}

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -499,7 +499,11 @@ func (in *MultiClusterHubSpec) DeepCopyInto(out *MultiClusterHubSpec) {
 		*out = new(HiveConfigSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	in.Ingress.DeepCopyInto(&out.Ingress)
+	if in.Ingress != nil {
+		in, out := &in.Ingress, &out.Ingress
+		*out = new(IngressSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Overrides != nil {
 		in, out := &in.Overrides, &out.Overrides
 		*out = new(Overrides)

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2025-10-15T17:44:09Z"
+    createdAt: "2025-10-21T14:45:31Z"
     description: Open management of Openshift and Kubernetes clusters
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -91,7 +91,7 @@ spec:
         displayName: Ingress Management
         path: ingress
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: The name of the local-cluster resource
         displayName: Local Cluster Name
         path: localClusterName
@@ -827,6 +827,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - argoproj.io
+          resources:
+          - appprojects
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -1344,7 +1352,7 @@ spec:
           - update
           - watch
         - apiGroups:
-          - monitoring.coreos.com
+          - monitoring.rhobs
           resources:
           - scrapeconfigs
           verbs:

--- a/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/multiclusterhub-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ spec:
         displayName: Ingress Management
         path: ingress
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: The name of the local-cluster resource
         displayName: Local Cluster Name
         path: localClusterName

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	utils "github.com/stolostron/multiclusterhub-operator/pkg/utils"
@@ -155,7 +154,7 @@ func (r *MultiClusterHubReconciler) CheckDeprecatedFieldUsage(m *operatorv1.Mult
 		isPresent bool
 	}{
 		{"hive", m.Spec.Hive != nil},
-		{"ingress", !reflect.DeepEqual(m.Spec.Ingress, operatorv1.IngressSpec{})},
+		{"ingress", m.Spec.Ingress != nil},
 		{"customCAConfigmap", m.Spec.CustomCAConfigmap != ""},
 		{"enableClusterBackup", m.Spec.EnableClusterBackup},
 		{"enableClusterProxyAddon", m.Spec.EnableClusterProxyAddon},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -224,7 +224,7 @@ func CoreToUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) 
 
 // MchIsValid Checks if the optional default parameters need to be set
 func MchIsValid(m *operatorsv1.MultiClusterHub) bool {
-	invalid := len(m.Spec.Ingress.SSLCiphers) == 0 || !operatorsv1.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig)
+	invalid := (m.Spec.Ingress == nil || len(m.Spec.Ingress.SSLCiphers) == 0) || !operatorsv1.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig)
 	return !invalid
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -396,7 +396,7 @@ func TestMchIsValid(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "test"},
 		Spec: mchv1.MultiClusterHubSpec{
 			ImagePullSecret: "test",
-			Ingress: mchv1.IngressSpec{
+			Ingress: &mchv1.IngressSpec{
 				SSLCiphers: []string{"foo", "bar", "baz"},
 			},
 			AvailabilityConfig: mchv1.HAHigh,


### PR DESCRIPTION
# Description

In an earlier release, the `enableClusterBackup` field was deprecated, but it was still being included in the MCH CR during creation. This PR ensures the field is no longer added or set to `false` when the MCH CR is created.

## Related Issue

https://issues.redhat.com/browse/ACM-25297

## Changes Made

Updated the `enableClusterBackup` field configuration to make it hidden.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
