### PR TITLE
[ACM-28791] Fix gitops-addon cleanup Job to use image override template

### DIFF
--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/gitops-addon.addonTemplates.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/gitops-addon.addonTemplates.yaml
@@ -29,7 +29,7 @@ spec:
                   value: '{{ `{{GITOPS_OPERATOR_IMAGE}}` }}'
                 - name: ARGOCD_IMAGE
                   value: '{{ `{{ARGOCD_IMAGE}}` }}'
-                image: quay.io/stolostron/multicloud-integrations:latest
+                image: '{{ .Values.global.imageOverrides.multicloud_integrations }}'
                 imagePullPolicy: IfNotPresent
                 name: cleanup
               restartPolicy: Never


### PR DESCRIPTION
## Summary
- Fixed gitops-addon AddonTemplate cleanup Job to use templated image override instead of hardcoded :latest tag
- This ensures the cleanup Job uses SHA-pinned images like the main Deployment

Related issue: https://issues.redhat.com/browse/ACM-28791

## Problem
In ACM 2.15+, the gitops-addon AddonTemplate cleanup Job was using `quay.io/stolostron/multicloud-integrations:latest` while the Deployment correctly used the templated image override. This caused inconsistent image pinning - only the Deployment image was replaced with SHA digests.

## Root Cause
The bundle automation script in installer-dev-tools only processed Deployment manifests and skipped Job manifests when replacing image references in AddonTemplates.

## Changes
Regenerated gitops-addon template after fixing the bundle automation script to handle both Deployments and Jobs. See upstream fix: https://github.com/stolostron/installer-dev-tools/pull/127

## Test plan
- [x] Verified both cleanup Job (line 32) and Deployment (line 98) now use `{{ .Values.global.imageOverrides.multicloud_integrations }}`
- [x] Confirmed this is the only :latest tag in the pkg/templates directory
- [ ] Build and deploy to verify images are properly resolved

/cc @cameronmwall @ngraham20

🤖 Generated with [Claude Code](https://claude.com/claude-code)