### PR TITLE
[release-2.16][ACM-29816] Fix MCH stuck in Pending state due to stale Progressing condition

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -184,6 +184,7 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 		if !hubPruning(status) && !utils.IsPaused(hub) {
 			available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
 			SetHubCondition(&status, *available)
+			RemoveHubCondition(&status, operatorsv1.Progressing)
 		} else {
 			// only add unavailable status if complete status already present
 			if HubConditionPresent(status, operatorsv1.Complete) {

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -421,8 +421,8 @@ func TestStaleProgressingConditionRemoval(t *testing.T) {
 		status := &operatorsv1.MultiClusterHubStatus{
 			CurrentVersion: version.Version,
 			Components: map[string]operatorsv1.StatusCondition{
-				"console":    available,
-				"search":     available,
+				"console":       available,
+				"search":        available,
 				"local-cluster": available,
 			},
 			HubConditions: []operatorsv1.HubCondition{
@@ -471,8 +471,8 @@ func TestStaleProgressingConditionRemoval(t *testing.T) {
 		status := operatorsv1.MultiClusterHubStatus{
 			CurrentVersion: version.Version,
 			Components: map[string]operatorsv1.StatusCondition{
-				"console":    available,
-				"search":     available,
+				"console":       available,
+				"search":        available,
 				"local-cluster": available,
 			},
 			HubConditions: []operatorsv1.HubCondition{


### PR DESCRIPTION
# Description

When all hub components are available and the hub reaches Complete status, remove any stale Progressing condition to allow proper phase transition to Running state.

Previously, stale Progressing conditions with status=False could persist in the hub status, causing aggregatePhase() to incorrectly keep the hub in Pending state even when all components were ready. The hubDeployFailing() check only verified the condition's reason (FailedDeployingComponent) but not whether the condition was actually active (status=True).

This fix ensures that when the hub reaches Complete status with all components ready, any Progressing condition is removed, allowing the phase to properly transition to Running.

## Related Issue

https://issues.redhat.com/browse/ACM-29816

## Changes Made

- Pruning Progressing Hub Condition after ACM reaches a Running state.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
