### PR TITLE
Add list type markers to Components field in MCH CRD

### DIFF
--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -108,6 +108,8 @@ type Overrides struct {
 	// Provides optional configuration for components, the list of which can be found here: https://github.com/stolostron/multiclusterhub-operator/tree/main/docs/available-components.md
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Component Configuration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Components []ComponentConfig `json:"components,omitempty"`
 }
 

--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -322,6 +322,9 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   imagePullPolicy:
                     description: Pull policy of the MultiCluster hub images
                     type: string

--- a/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/config/crd/bases/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -322,6 +322,9 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   imagePullPolicy:
                     description: Pull policy of the MultiCluster hub images
                     type: string

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -754,17 +754,13 @@ var _ = Describe("MultiClusterHub controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			// Appending to components rather than replacing with `Disable()`
-			createdMCH.Spec.Overrides.Components = append(
-				createdMCH.Spec.Overrides.Components,
-				operatorv1.ComponentConfig{Name: operatorv1.Console, Enabled: false},
-				operatorv1.ComponentConfig{Name: operatorv1.GRC, Enabled: false},
-				operatorv1.ComponentConfig{Name: operatorv1.Insights, Enabled: false},
-				operatorv1.ComponentConfig{Name: operatorv1.Search, Enabled: false},
-				operatorv1.ComponentConfig{Name: operatorv1.ClusterLifecycle, Enabled: false},
-				operatorv1.ComponentConfig{Name: operatorv1.MultiClusterObservability, Enabled: false},
-				operatorv1.ComponentConfig{Name: operatorv1.Volsync, Enabled: false},
-			)
+			createdMCH.Disable(operatorv1.Console)
+			createdMCH.Disable(operatorv1.GRC)
+			createdMCH.Disable(operatorv1.Insights)
+			createdMCH.Disable(operatorv1.Search)
+			createdMCH.Disable(operatorv1.ClusterLifecycle)
+			createdMCH.Disable(operatorv1.MultiClusterObservability)
+			createdMCH.Disable(operatorv1.Volsync)
 
 			Expect(k8sClient.Update(ctx, createdMCH)).Should(Succeed())
 


### PR DESCRIPTION
# Description

Add `+listType=map` and `+listMapKey=name` markers to the `Components` field in the `Overrides` struct. This ensures proper merge behavior for the components array in the `MultiClusterHub` CRD.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated MCH CRD to allow only unique keys for the supported components.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
