### PR TITLE
Add webhook warnings for deprecated annotations and spec fields

### DIFF
--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -229,12 +229,12 @@ var _ = Describe("Multiclusterhub webhook", func() {
 					Name:      "test-warnings",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"mch-pause":              "true",
-						"mch-imageRepository":    "quay.io/test",
-						"mch-imageOverridesCM":   "test-cm",
-						"ignoreOCPVersion":       "true",
-						"mch-kubeconfig":         "test-kubeconfig",
-						"some-other-annotation":  "value",
+						"mch-pause":             "true",
+						"mch-imageRepository":   "quay.io/test",
+						"mch-imageOverridesCM":  "test-cm",
+						"ignoreOCPVersion":      "true",
+						"mch-kubeconfig":        "test-kubeconfig",
+						"some-other-annotation": "value",
 					},
 				},
 				Spec: MultiClusterHubSpec{
@@ -268,12 +268,12 @@ var _ = Describe("Multiclusterhub webhook", func() {
 					Namespace: "default",
 				},
 				Spec: MultiClusterHubSpec{
-					LocalClusterName:               "test-cluster",
-					Hive:                           &HiveConfigSpec{},
-					CustomCAConfigmap:              "test-ca",
-					EnableClusterBackup:            true,
-					EnableClusterProxyAddon:        true,
-					SeparateCertificateManagement:  true,
+					LocalClusterName:              "test-cluster",
+					Hive:                          &HiveConfigSpec{},
+					CustomCAConfigmap:             "test-ca",
+					EnableClusterBackup:           true,
+					EnableClusterProxyAddon:       true,
+					SeparateCertificateManagement: true,
 				},
 			}
 

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -221,6 +221,127 @@ var _ = Describe("Multiclusterhub webhook", func() {
 			Expect(k8sClient.Create(ctx, mch)).To(Succeed())
 		})
 	})
+
+	Context("Deprecated annotation and field warnings", func() {
+		It("Should return warnings for deprecated annotations", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-warnings",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"mch-pause":              "true",
+						"mch-imageRepository":    "quay.io/test",
+						"mch-imageOverridesCM":   "test-cm",
+						"ignoreOCPVersion":       "true",
+						"mch-kubeconfig":         "test-kubeconfig",
+						"some-other-annotation":  "value",
+					},
+				},
+				Spec: MultiClusterHubSpec{
+					LocalClusterName: "test-cluster",
+				},
+			}
+
+			warnings := checkDeprecatedAnnotations(mch)
+			Expect(len(warnings)).To(Equal(5), "Should have 5 warnings for deprecated annotations")
+
+			// Check that all deprecated annotations are warned about
+			warningText := strings.Join(warnings, " ")
+			Expect(warningText).To(ContainSubstring("mch-pause"))
+			Expect(warningText).To(ContainSubstring("mch-imageRepository"))
+			Expect(warningText).To(ContainSubstring("mch-imageOverridesCM"))
+			Expect(warningText).To(ContainSubstring("ignoreOCPVersion"))
+			Expect(warningText).To(ContainSubstring("mch-kubeconfig"))
+
+			// Check that warnings mention the replacement annotations
+			Expect(warningText).To(ContainSubstring("installer.open-cluster-management.io/pause"))
+			Expect(warningText).To(ContainSubstring("installer.open-cluster-management.io/image-repository"))
+			Expect(warningText).To(ContainSubstring("installer.open-cluster-management.io/image-overrides-configmap"))
+			Expect(warningText).To(ContainSubstring("installer.open-cluster-management.io/ignore-ocp-version"))
+			Expect(warningText).To(ContainSubstring("installer.open-cluster-management.io/kubeconfig"))
+		})
+
+		It("Should return warnings for deprecated spec fields", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-spec-warnings",
+					Namespace: "default",
+				},
+				Spec: MultiClusterHubSpec{
+					LocalClusterName:               "test-cluster",
+					Hive:                           &HiveConfigSpec{},
+					CustomCAConfigmap:              "test-ca",
+					EnableClusterBackup:            true,
+					EnableClusterProxyAddon:        true,
+					SeparateCertificateManagement:  true,
+				},
+			}
+
+			warnings := checkDeprecatedAnnotations(mch)
+			Expect(len(warnings)).To(Equal(5), "Should have 5 warnings for deprecated spec fields")
+
+			warningText := strings.Join(warnings, " ")
+			Expect(warningText).To(ContainSubstring("spec.hive"))
+			Expect(warningText).To(ContainSubstring("spec.customCAConfigmap"))
+			Expect(warningText).To(ContainSubstring("spec.enableClusterBackup"))
+			Expect(warningText).To(ContainSubstring("spec.enableClusterProxyAddon"))
+			Expect(warningText).To(ContainSubstring("spec.separateCertificateManagement"))
+		})
+
+		It("Should return combined warnings for both annotations and spec fields", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-combined-warnings",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"mch-pause": "true",
+					},
+				},
+				Spec: MultiClusterHubSpec{
+					LocalClusterName:    "test-cluster",
+					Hive:                &HiveConfigSpec{},
+					EnableClusterBackup: true,
+				},
+			}
+
+			warnings := checkDeprecatedAnnotations(mch)
+			Expect(len(warnings)).To(Equal(3), "Should have 3 warnings (1 annotation + 2 spec fields)")
+		})
+
+		It("Should return no warnings for resources without deprecated fields", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-no-warnings",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"installer.open-cluster-management.io/pause": "true",
+						"some-other-annotation":                      "value",
+					},
+				},
+				Spec: MultiClusterHubSpec{
+					LocalClusterName: "test-cluster",
+				},
+			}
+
+			warnings := checkDeprecatedAnnotations(mch)
+			Expect(len(warnings)).To(Equal(0), "Should have no warnings")
+		})
+
+		It("Should return no warnings when annotations are nil", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-nil-annotations",
+					Namespace: "default",
+				},
+				Spec: MultiClusterHubSpec{
+					LocalClusterName: "test-cluster",
+				},
+			}
+
+			warnings := checkDeprecatedAnnotations(mch)
+			Expect(len(warnings)).To(Equal(0), "Should have no warnings when annotations are nil")
+		})
+	})
 })
 
 // re-defining the function here to avoid a import cycle

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -160,7 +160,7 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 }
 
 func (r *MultiClusterHubReconciler) CheckDeprecatedFieldUsage(m *operatorv1.MultiClusterHub) {
-	a := m.GetAnnotations()
+	// Check for deprecated spec fields only (annotations are now handled by webhook)
 	df := []struct {
 		name      string
 		isPresent bool
@@ -171,21 +171,11 @@ func (r *MultiClusterHubReconciler) CheckDeprecatedFieldUsage(m *operatorv1.Mult
 		{"enableClusterBackup", m.Spec.EnableClusterBackup},
 		{"enableClusterProxyAddon", m.Spec.EnableClusterProxyAddon},
 		{"separateCertificateManagement", m.Spec.SeparateCertificateManagement},
-		{utils.DeprecatedAnnotationIgnoreOCPVersion, a[utils.DeprecatedAnnotationIgnoreOCPVersion] != ""},
-		{utils.DeprecatedAnnotationImageOverridesCM, a[utils.DeprecatedAnnotationImageOverridesCM] != ""},
-		{utils.DeprecatedAnnotationImageRepo, a[utils.DeprecatedAnnotationImageRepo] != ""},
-		{utils.DeprecatedAnnotationKubeconfig, a[utils.DeprecatedAnnotationKubeconfig] != ""},
-		{utils.DeprecatedAnnotationMCHPause, a[utils.DeprecatedAnnotationMCHPause] != ""},
-	}
-
-	if r.DeprecatedFields == nil {
-		r.DeprecatedFields = make(map[string]bool)
 	}
 
 	for _, f := range df {
-		if f.isPresent && !r.DeprecatedFields[f.name] {
+		if f.isPresent {
 			r.Log.Info(fmt.Sprintf("Warning: %s field usage is deprecated in operator.", f.name))
-			r.DeprecatedFields[f.name] = true
 		}
 	}
 }

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -158,24 +158,3 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 	log.Info("No updates to defaults detected")
 	return ctrl.Result{}, nil
 }
-
-func (r *MultiClusterHubReconciler) CheckDeprecatedFieldUsage(m *operatorv1.MultiClusterHub) {
-	// Check for deprecated spec fields only (annotations are now handled by webhook)
-	df := []struct {
-		name      string
-		isPresent bool
-	}{
-		{"hive", m.Spec.Hive != nil},
-		{"ingress", m.Spec.Ingress != nil},
-		{"customCAConfigmap", m.Spec.CustomCAConfigmap != ""},
-		{"enableClusterBackup", m.Spec.EnableClusterBackup},
-		{"enableClusterProxyAddon", m.Spec.EnableClusterProxyAddon},
-		{"separateCertificateManagement", m.Spec.SeparateCertificateManagement},
-	}
-
-	for _, f := range df {
-		if f.isPresent {
-			r.Log.Info(fmt.Sprintf("Warning: %s field usage is deprecated in operator.", f.name))
-		}
-	}
-}

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -31,13 +31,12 @@ import (
 
 // MultiClusterHubReconciler reconciles a MultiClusterHub object
 type MultiClusterHubReconciler struct {
-	Client           client.Client
-	UncachedClient   client.Client
-	CacheSpec        CacheSpec
-	Scheme           *runtime.Scheme
-	Log              logr.Logger
-	UpgradeableCond  utils.Condition
-	DeprecatedFields map[string]bool
+	Client          client.Client
+	UncachedClient  client.Client
+	CacheSpec       CacheSpec
+	Scheme          *runtime.Scheme
+	Log             logr.Logger
+	UpgradeableCond utils.Condition
 }
 
 const (

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -68,9 +68,6 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	multiClusterHub.Status.HubConditions = filterOutConditionWithSubstring(multiClusterHub.Status.HubConditions,
 		string(operatorv1.ComponentFailure))
 
-	// Check if any deprecated fields are present within the multiClusterHub spec.
-	r.CheckDeprecatedFieldUsage(multiClusterHub)
-
 	// Check to see if upgradeable
 	upgrade, err := r.setOperatorUpgradeableStatus(ctx, multiClusterHub)
 	if err != nil {


### PR DESCRIPTION
# Description

Add `checkDeprecatedAnnotations` function to the MCH webhook that returns admission warnings when deprecated annotations or spec fields are used. This helps users migrate from old annotation names and deprecated spec fields to current supported configurations.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

- Add constants for current and deprecated annotation keys in webhook
- Implement `checkDeprecatedAnnotations` to warn about both deprecated annotations and spec fields
- Update `ValidateCreate` and `ValidateUpdate` to collect and return warnings
- Remove `DeprecatedFields` map from `MultiClusterHubReconciler` struct
- Simplify `CheckDeprecatedFieldUsage` to only check spec fields (for logs)

Deprecated annotations that now generate warnings:
- `ignoreOCPVersion` -> `installer.open-cluster-management.io/ignore-ocp-version`
- `mch-imageOverridesCM` -> `installer.open-cluster-management.io/image-overrides-configmap`
- `mch-imageRepository` -> `installer.open-cluster-management.io/image-repository`
- `mch-kubeconfig` -> `installer.open-cluster-management.io/kubeconfig
`- `mch-pause` -> `installer.open-cluster-management.io/pause`

Deprecated spec fields that now generate warnings:
- `spec.hive`
- `spec.ingress`
- `spec.customCAConfigmap`
- `spec.enableClusterBackup`
- `spec.enableClusterProxyAddon`
- `spec.separateCertificateManagement`

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.