### PR TITLE
[release-2.12] Fix config.yaml structure for sync-template-vars script

### DIFF
--- a/hack/bundle-automation/config.yaml
+++ b/hack/bundle-automation/config.yaml
@@ -1,56 +1,57 @@
+acm-release-version: '2.12'
+components:
+  - repo_name: multicloud-operators-subscription
+    github_ref: "https://github.com/stolostron/multicloud-operators-subscription.git"
+    branch: "release-2.12"
+    operators:
+      - name: multicloud-operators-subscription
+        bundlePath: "deploy/olm-catalog/multicluster-operators-subscription/manifests/"
+        imageMappings:
+          multicluster-operators-subscription: multicluster_operators_subscription
+          multicloud-integrations: multicloud_integrations
+          multicluster-operators-application: multicluster_operators_application
+          multicluster-operators-channel: multicluster_operators_channel
+        exclusions:
+          - readOnlyRootFilesystem
 
-- repo_name: multicloud-operators-subscription
-  github_ref: "https://github.com/stolostron/multicloud-operators-subscription.git"
-  branch: "release-2.12"
-  operators:
-    - name: multicloud-operators-subscription
-      bundlePath: "deploy/olm-catalog/multicluster-operators-subscription/manifests/"
-      imageMappings:
-        multicluster-operators-subscription: multicluster_operators_subscription
-        multicloud-integrations: multicloud_integrations
-        multicluster-operators-application: multicluster_operators_application
-        multicluster-operators-channel: multicluster_operators_channel
-      exclusions:
-        - readOnlyRootFilesystem
+  - repo_name: multicluster-observability-operator
+    github_ref: "https://github.com/stolostron/multicluster-observability-operator.git"
+    branch: "release-2.12"
+    operators:
+      - name: multicluster-observability-operator
+        bundlePath: "operators/multiclusterobservability/bundle/manifests/"
+        imageMappings:
+          multicluster-observability-operator: multicluster_observability_operator
 
-- repo_name: multicluster-observability-operator
-  github_ref: "https://github.com/stolostron/multicluster-observability-operator.git"
-  branch: "release-2.12"
-  operators:
-    - name: multicluster-observability-operator
-      bundlePath: "operators/multiclusterobservability/bundle/manifests/"
-      imageMappings:
-        multicluster-observability-operator: multicluster_observability_operator
+  - repo_name: search-v2-operator
+    github_ref: "https://github.com/stolostron/search-v2-operator.git"
+    branch: "release-2.12"
+    operators:
+      - name: search-v2-operator
+        bundlePath: "bundle/manifests/"
+        imageMappings:
+          search-v2-operator: search_v2_operator
+          kube-rbac-proxy: kube_rbac_proxy
+          postgresql-13: postgresql_13
+          search-indexer: search_indexer
+          search-collector: search_collector
+          search-v2-api: search_v2_api
 
-- repo_name: search-v2-operator
-  github_ref: "https://github.com/stolostron/search-v2-operator.git"
-  branch: "release-2.12"
-  operators:
-    - name: search-v2-operator
-      bundlePath: "bundle/manifests/"
-      imageMappings:
-        search-v2-operator: search_v2_operator
-        kube-rbac-proxy: kube_rbac_proxy
-        postgresql-13: postgresql_13
-        search-indexer: search_indexer
-        search-collector: search_collector
-        search-v2-api: search_v2_api
+  - repo_name: siteconfig
+    github_ref: "https://github.com/stolostron/siteconfig.git"
+    branch: "release-2.12"
+    operators:
+      - name: siteconfig-operator
+        bundlePath: "bundle/manifests/"
+        imageMappings:
+          kube-rbac-proxy: kube_rbac_proxy
+          siteconfig-operator: siteconfig_operator
 
-- repo_name: siteconfig
-  github_ref: "https://github.com/stolostron/siteconfig.git"
-  branch: "release-2.12"
-  operators:
-    - name: siteconfig-operator
-      bundlePath: "bundle/manifests/"
-      imageMappings:
-        kube-rbac-proxy: kube_rbac_proxy
-        siteconfig-operator: siteconfig_operator
-
-- repo_name: submariner-addon
-  github_ref: "https://github.com/stolostron/submariner-addon.git"
-  branch: "release-2.12"
-  operators:
-    - name: submariner-addon
-      bundlePath: "deploy/olm-catalog/manifests/"
-      imageMappings:
-        submariner-addon: submariner_addon
+  - repo_name: submariner-addon
+    github_ref: "https://github.com/stolostron/submariner-addon.git"
+    branch: "release-2.12"
+    operators:
+      - name: submariner-addon
+        bundlePath: "deploy/olm-catalog/manifests/"
+        imageMappings:
+          submariner-addon: submariner_addon


### PR DESCRIPTION
# Description

The sync-template-vars.sh script expects config.yaml to have a 'components' key, but the file was using a root-level array structure. This caused the error: 'Error: cannot index array with components (strconv.ParseInt: parsing components: invalid syntax)'

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Updated `config.yaml` to wrap the array in a `components:` key and added `acm-release-version` header to match the expected structure.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
