### PR TITLE
[ACM-32481][release-2.15] Add missing deployments to MCH status tracking

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -444,6 +444,7 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEn
 	}
 	if m.Enabled(operatorsv1.Console) && ocpConsole {
 		nn = append(nn, types.NamespacedName{Name: "console-chart-console-v2", Namespace: m.Namespace})
+		nn = append(nn, types.NamespacedName{Name: "acm-cli-downloads", Namespace: m.Namespace})
 	}
 	if m.Enabled(operatorsv1.Volsync) {
 		nn = append(nn, types.NamespacedName{Name: "volsync-addon-controller", Namespace: m.Namespace})
@@ -453,6 +454,12 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEn
 	}
 	if m.Enabled(operatorsv1.ClusterPermission) {
 		nn = append(nn, types.NamespacedName{Name: "cluster-permission", Namespace: m.Namespace})
+	}
+	if m.Enabled(operatorsv1.FineGrainedRbac) || m.Enabled(operatorsv1.FineGrainedRbacPreview) {
+		nn = append(nn, types.NamespacedName{Name: "multicluster-role-assignment-controller", Namespace: m.Namespace})
+	}
+	if m.Enabled(operatorsv1.MTVIntegrationsPreview) {
+		nn = append(nn, types.NamespacedName{Name: "mtv-integrations-controller", Namespace: m.Namespace})
 	}
 	if m.Enabled(operatorsv1.EdgeManagerPreview) {
 		nn = append(nn, types.NamespacedName{Name: "flightctl-api", Namespace: m.Namespace})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -696,10 +696,12 @@ func TestUpdateMCEOverrides(t *testing.T) {
 
 func Test_GetDeploymentsForStatus(t *testing.T) {
 	tests := []struct {
-		name       string
-		mch        mchv1.MultiClusterHub
-		stsEnabled bool
-		want       int
+		name           string
+		mch            mchv1.MultiClusterHub
+		stsEnabled     bool
+		want           int
+		mustContain    []types.NamespacedName
+		mustNotContain []types.NamespacedName
 	}{
 		{
 			name:       "should get deployment status for MCH components",
@@ -723,6 +725,9 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 			},
 			stsEnabled: true,
 			want:       21,
+			mustNotContain: []types.NamespacedName{
+				{Name: "openshift-adp-controller-manager", Namespace: ClusterSubscriptionNamespace},
+			},
 		},
 		{
 			name: "should get deployment status for MCH components with STS disabled",
@@ -740,6 +745,9 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 			},
 			stsEnabled: false,
 			want:       22,
+			mustContain: []types.NamespacedName{
+				{Name: "openshift-adp-controller-manager", Namespace: ClusterSubscriptionNamespace},
+			},
 		},
 	}
 
@@ -749,8 +757,25 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				t.Errorf("failed to set default components: %v", err)
 			}
 
-			if deployments := GetDeploymentsForStatus(&tt.mch, true, tt.stsEnabled); len(deployments) != tt.want {
-				t.Errorf("expected %v, got %v", len(deployments), tt.want)
+			deployments := GetDeploymentsForStatus(&tt.mch, true, tt.stsEnabled)
+
+			// Check total count
+			if len(deployments) != tt.want {
+				t.Errorf("expected %v deployments, got %v", tt.want, len(deployments))
+			}
+
+			// Verify deployments that must be present
+			for _, d := range tt.mustContain {
+				if !containsDeployment(deployments, d.Name, d.Namespace) {
+					t.Errorf("missing deployment: %s/%s", d.Namespace, d.Name)
+				}
+			}
+
+			// Verify deployments that must not be present
+			for _, d := range tt.mustNotContain {
+				if containsDeployment(deployments, d.Name, d.Namespace) {
+					t.Errorf("unexpected deployment: %s/%s", d.Namespace, d.Name)
+				}
 			}
 		})
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -214,6 +215,8 @@ var _ = Describe("utility functions", func() {
 			mch.Enable(mchv1.Console)
 			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(2))
+			Expect(containsDeployment(d, "console-chart-console-v2", resources.MulticlusterhubNamespace)).To(BeTrue())
+			Expect(containsDeployment(d, "acm-cli-downloads", resources.MulticlusterhubNamespace)).To(BeTrue())
 		})
 		It("gets deployments for status with observability enabled", func() {
 			mch := resources.EmptyMCH()
@@ -232,6 +235,20 @@ var _ = Describe("utility functions", func() {
 			mch.Enable(mchv1.ClusterPermission)
 			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(1))
+		})
+		It("gets deployments for status with fine-grained-rbac-preview enabled", func() {
+			mch := resources.EmptyMCH()
+			mch.Enable(mchv1.FineGrainedRbacPreview)
+			d := GetDeploymentsForStatus(&mch, true, false)
+			Expect(len(d)).To(Equal(1))
+			Expect(containsDeployment(d, "multicluster-role-assignment-controller", resources.MulticlusterhubNamespace)).To(BeTrue())
+		})
+		It("gets deployments for status with MTV integrations preview enabled", func() {
+			mch := resources.EmptyMCH()
+			mch.Enable(mchv1.MTVIntegrationsPreview)
+			d := GetDeploymentsForStatus(&mch, true, false)
+			Expect(len(d)).To(Equal(1))
+			Expect(containsDeployment(d, "mtv-integrations-controller", resources.MulticlusterhubNamespace)).To(BeTrue())
 		})
 		It("Sets Default Component values", func() {
 			mch := resources.EmptyMCH()
@@ -737,4 +754,14 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+// containsDeployment checks if a deployment with the given name and namespace exists in the list
+func containsDeployment(deployments []types.NamespacedName, name, namespace string) bool {
+	for _, d := range deployments {
+		if d.Name == name && d.Namespace == namespace {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -213,7 +213,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.Console)
 			d := GetDeploymentsForStatus(&mch, true, false)
-			Expect(len(d)).To(Equal(1))
+			Expect(len(d)).To(Equal(2))
 		})
 		It("gets deployments for status with observability enabled", func() {
 			mch := resources.EmptyMCH()
@@ -688,7 +688,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 			name:       "should get deployment status for MCH components",
 			mch:        resources.EmptyMCH(),
 			stsEnabled: false,
-			want:       19,
+			want:       20,
 		},
 		{
 			name: "should get deployment status for MCH components with STS enabled",
@@ -705,7 +705,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: true,
-			want:       20,
+			want:       21,
 		},
 		{
 			name: "should get deployment status for MCH components with STS disabled",
@@ -722,7 +722,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: false,
-			want:       21,
+			want:       22,
 		},
 	}
 


### PR DESCRIPTION
# Description

Backport of #3826 to release-2.15.

Fixes missing component deployments from MCH status tracking. Several deployments were being created by their respective charts but not monitored for health status, causing the MCH operator to ignore their operational state.

## Related Issue

Fixes: https://redhat.atlassian.net/browse/ACM-32481

## Changes Made

Added the following deployments to `GetDeploymentsForStatus()` in `pkg/utils/utils.go`:

1. **multicluster-role-assignment-controller** - Fine-grained RBAC component deployment
   - Added conditional check for both `FineGrainedRbac` and `FineGrainedRbacPreview` components
   - Deployment template exists at: `pkg/templates/charts/toggle/fine-grained-rbac/templates/multicluster-role-assignment-deployment.yaml`

2. **acm-cli-downloads** - ACM CLI download server deployment  
   - Added to existing Console component check alongside console-chart-console-v2
   - Deployment template exists at: `pkg/templates/charts/toggle/console/templates/acm-cli-deployment.yaml`

3. **mtv-integrations-controller** - MTV integrations controller deployment
   - Added conditional check for `MTVIntegrationsPreview` component (GA version not yet available in 2.15)
   - Deployment template exists at: `pkg/templates/charts/toggle/mtv-integrations/templates/mtv-integrations-controller-deployment.yaml`

Updated test expectations in `pkg/utils/utils_test.go` to account for additional deployments.

## Testing

- [x] All unit tests pass (`go test ./pkg/utils/`)
- [x] Test expectations updated for new deployment counts
- [x] Verified deployments exist in respective chart templates

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest release-2.15 branch.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into release-2.15 branch.