### PR TITLE
Improve bundle-automation dependency handling

### DIFF
--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -86,6 +86,38 @@ def clone_repository(git_url, repo_path, branch):
         logging.error(f"Failed to clone repository: {git_url} (branch={branch}): {e}")
         raise
 
+def copy_bundle_generation_files():
+    """Copies all Python files from bundle-generation to DEST_DIR, preserving directory structure."""
+    bundle_gen_src = SCRIPTS_DIR / "bundle-generation"
+
+    # Recursively copy all .py files, preserving directory structure
+    for py_file in bundle_gen_src.rglob("*.py"):
+        relative_path = py_file.relative_to(bundle_gen_src)
+        dest_file = DEST_DIR / relative_path
+
+        # Create parent directories if needed
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(py_file, dest_file)
+        logging.debug(f"Copied {relative_path}")
+
+def cleanup_bundle_generation_files():
+    """Cleans up copied Python files and directories."""
+    bundle_gen_src = SCRIPTS_DIR / "bundle-generation"
+
+    # Clean up all copied Python files
+    for py_file in bundle_gen_src.rglob("*.py"):
+        relative_path = py_file.relative_to(bundle_gen_src)
+        copied_file = DEST_DIR / relative_path
+        if copied_file.exists():
+            copied_file.unlink()
+            logging.debug(f"Removed {relative_path}")
+
+    # Clean up empty directories (like utils/)
+    utils_dest = DEST_DIR / "utils"
+    if utils_dest.exists():
+        shutil.rmtree(utils_dest)
+        logging.debug(f"Removed utils directory")
+
 def prepare_and_execute(operation, operation_data, args):
     """Prepares and executes the operation based on the provided operation data.
 
@@ -96,22 +128,7 @@ def prepare_and_execute(operation, operation_data, args):
     """
     logging.info(f"Executing operator: {operation}")
 
-    # Copy all Python files and utils directory from bundle-generation to DEST_DIR
-    bundle_gen_src = SCRIPTS_DIR / "bundle-generation"
-
-    # Copy all .py files from bundle-generation (automatically includes helper.py and any other dependencies)
-    for py_file in bundle_gen_src.glob("*.py"):
-        shutil.copy(py_file, DEST_DIR / py_file.name)
-        logging.debug(f"Copied {py_file.name}")
-
-    # Copy utils directory if it exists
-    utils_src = bundle_gen_src / "utils"
-    utils_dest = DEST_DIR / "utils"
-    if utils_src.exists():
-        if utils_dest.exists():
-            shutil.rmtree(utils_dest)
-        shutil.copytree(utils_src, utils_dest)
-        logging.debug(f"Copied utils directory")
+    copy_bundle_generation_files()
 
     # Get the script name from the operation data (e.g., "bundle-generation/generate-charts.py")
     script_name = Path(operation_data["script"]).name
@@ -132,16 +149,7 @@ def prepare_and_execute(operation, operation_data, args):
     # Execute the script
     execute_script(script_path, operations_args)
 
-    # Clean up all copied Python files and utils directory
-    for py_file in bundle_gen_src.glob("*.py"):
-        copied_file = DEST_DIR / py_file.name
-        if copied_file.exists():
-            copied_file.unlink()
-
-    if utils_dest.exists():
-        shutil.rmtree(utils_dest)
-
-    logging.debug(f"Cleaned up copied files")
+    cleanup_bundle_generation_files()
 
 def execute_script(script_path, args):
     """Executes a Python script with arguments.

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -91,11 +91,15 @@ def copy_script_dependencies(script_path):
 
     Args:
         script_path: Path to the script (e.g., "bundle-generation/generate-charts.py" or "release/onboard-new-components.py")
+
+    Returns:
+        List of copied file paths (relative to DEST_DIR) for cleanup
     """
     # Get the parent directory (e.g., "bundle-generation" or "release")
     script_parent = Path(script_path).parent
     source_dir = SCRIPTS_DIR / script_parent
 
+    copied_files = []
     # Recursively copy all .py files, preserving directory structure
     for py_file in source_dir.rglob("*.py"):
         relative_path = py_file.relative_to(source_dir)
@@ -104,20 +108,19 @@ def copy_script_dependencies(script_path):
         # Create parent directories if needed
         dest_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(py_file, dest_file)
+        copied_files.append(relative_path)
         logging.debug(f"Copied {relative_path}")
 
-def cleanup_script_dependencies(script_path):
+    return copied_files
+
+def cleanup_script_dependencies(copied_files):
     """Cleans up copied Python files and directories.
 
     Args:
-        script_path: Path to the script (e.g., "bundle-generation/generate-charts.py" or "release/onboard-new-components.py")
+        copied_files: List of file paths (relative to DEST_DIR) to clean up
     """
-    script_parent = Path(script_path).parent
-    source_dir = SCRIPTS_DIR / script_parent
-
     # Clean up all copied Python files
-    for py_file in source_dir.rglob("*.py"):
-        relative_path = py_file.relative_to(source_dir)
+    for relative_path in copied_files:
         copied_file = DEST_DIR / relative_path
         if copied_file.exists():
             copied_file.unlink()
@@ -140,7 +143,7 @@ def prepare_and_execute(operation, operation_data, args):
     logging.info(f"Executing operator: {operation}")
 
     script_path = operation_data["script"]
-    copy_script_dependencies(script_path)
+    copied_files = copy_script_dependencies(script_path)
 
     # Get the script name from the operation data (e.g., "bundle-generation/generate-charts.py")
     script_name = Path(script_path).name
@@ -161,7 +164,7 @@ def prepare_and_execute(operation, operation_data, args):
     # Execute the script
     execute_script(script_file, operations_args)
 
-    cleanup_script_dependencies(script_path)
+    cleanup_script_dependencies(copied_files)
 
 def execute_script(script_path, args):
     """Executes a Python script with arguments.

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -86,13 +86,19 @@ def clone_repository(git_url, repo_path, branch):
         logging.error(f"Failed to clone repository: {git_url} (branch={branch}): {e}")
         raise
 
-def copy_bundle_generation_files():
-    """Copies all Python files from bundle-generation to DEST_DIR, preserving directory structure."""
-    bundle_gen_src = SCRIPTS_DIR / "bundle-generation"
+def copy_script_dependencies(script_path):
+    """Copies all Python files from the script's directory to DEST_DIR, preserving directory structure.
+
+    Args:
+        script_path: Path to the script (e.g., "bundle-generation/generate-charts.py" or "release/onboard-new-components.py")
+    """
+    # Get the parent directory (e.g., "bundle-generation" or "release")
+    script_parent = Path(script_path).parent
+    source_dir = SCRIPTS_DIR / script_parent
 
     # Recursively copy all .py files, preserving directory structure
-    for py_file in bundle_gen_src.rglob("*.py"):
-        relative_path = py_file.relative_to(bundle_gen_src)
+    for py_file in source_dir.rglob("*.py"):
+        relative_path = py_file.relative_to(source_dir)
         dest_file = DEST_DIR / relative_path
 
         # Create parent directories if needed
@@ -100,13 +106,18 @@ def copy_bundle_generation_files():
         shutil.copy(py_file, dest_file)
         logging.debug(f"Copied {relative_path}")
 
-def cleanup_bundle_generation_files():
-    """Cleans up copied Python files and directories."""
-    bundle_gen_src = SCRIPTS_DIR / "bundle-generation"
+def cleanup_script_dependencies(script_path):
+    """Cleans up copied Python files and directories.
+
+    Args:
+        script_path: Path to the script (e.g., "bundle-generation/generate-charts.py" or "release/onboard-new-components.py")
+    """
+    script_parent = Path(script_path).parent
+    source_dir = SCRIPTS_DIR / script_parent
 
     # Clean up all copied Python files
-    for py_file in bundle_gen_src.rglob("*.py"):
-        relative_path = py_file.relative_to(bundle_gen_src)
+    for py_file in source_dir.rglob("*.py"):
+        relative_path = py_file.relative_to(source_dir)
         copied_file = DEST_DIR / relative_path
         if copied_file.exists():
             copied_file.unlink()
@@ -128,11 +139,12 @@ def prepare_and_execute(operation, operation_data, args):
     """
     logging.info(f"Executing operator: {operation}")
 
-    copy_bundle_generation_files()
+    script_path = operation_data["script"]
+    copy_script_dependencies(script_path)
 
     # Get the script name from the operation data (e.g., "bundle-generation/generate-charts.py")
-    script_name = Path(operation_data["script"]).name
-    script_path = DEST_DIR / script_name
+    script_name = Path(script_path).name
+    script_file = DEST_DIR / script_name
 
     operations_args = operation_data.get("args", "").format(
         pipeline_repo=args.pipeline_repo,
@@ -147,9 +159,9 @@ def prepare_and_execute(operation, operation_data, args):
         operations_args += " --config {}".format(args.config)
 
     # Execute the script
-    execute_script(script_path, operations_args)
+    execute_script(script_file, operations_args)
 
-    cleanup_bundle_generation_files()
+    cleanup_script_dependencies(script_path)
 
 def execute_script(script_path, args):
     """Executes a Python script with arguments.

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -86,49 +86,6 @@ def clone_repository(git_url, repo_path, branch):
         logging.error(f"Failed to clone repository: {git_url} (branch={branch}): {e}")
         raise
 
-def copy_scripts(script_dependencies):
-    """Copies necessary scripts from the temporary directory.
-
-    Args:
-        script_dependencies (_type_): _description_
-    """
-    for dependency in script_dependencies:
-        src = SCRIPTS_DIR / dependency
-        dest = DEST_DIR / Path(dependency).name
-
-        if not src.exists():
-            logging.error(f"Required script or directory {src} not found.")
-            sys.exit(1)
-
-        if src.is_dir():
-            shutil.copytree(src, dest, dirs_exist_ok=True)
-            logging.debug(f"Copied directory {src} to {dest}")
-
-        else:
-            shutil.copy(src, dest)
-            logging.debug(f"Copied file {src} to {dest}")
-
-def cleanup_scripts(script_dependencies):
-    """Cleans up copied scripts from the destination directory.
-
-    Args:
-        script_dependencies (_type_): _description_
-    """
-    for script in script_dependencies:
-        # If the script is in a subdirectory like 'utils/', construct the path properly
-        dest = DEST_DIR / Path(script).name
-
-        # Check if the destination path is a directory or a file
-        if dest.exists():
-            if dest.is_dir():
-                # If the destination is a directory (e.g., utils/), remove it and its contents
-                shutil.rmtree(dest)
-                logging.debug(f"Removed directory {dest}")
-            else:
-                # If the destination is a file, unlink it
-                dest.unlink(missing_ok=True)
-                logging.debug(f"Removed file {dest}")
-
 def prepare_and_execute(operation, operation_data, args):
     """Prepares and executes the operation based on the provided operation data.
 
@@ -139,16 +96,33 @@ def prepare_and_execute(operation, operation_data, args):
     """
     logging.info(f"Executing operator: {operation}")
 
-    script = Path(operation_data["script"])
-    script_dependencies = [script, str(script.parent / "utils")]
-    copy_scripts(script_dependencies)
+    # Copy all Python files and utils directory from bundle-generation to DEST_DIR
+    bundle_gen_src = SCRIPTS_DIR / "bundle-generation"
+
+    # Copy all .py files from bundle-generation (automatically includes helper.py and any other dependencies)
+    for py_file in bundle_gen_src.glob("*.py"):
+        shutil.copy(py_file, DEST_DIR / py_file.name)
+        logging.debug(f"Copied {py_file.name}")
+
+    # Copy utils directory if it exists
+    utils_src = bundle_gen_src / "utils"
+    utils_dest = DEST_DIR / "utils"
+    if utils_src.exists():
+        if utils_dest.exists():
+            shutil.rmtree(utils_dest)
+        shutil.copytree(utils_src, utils_dest)
+        logging.debug(f"Copied utils directory")
+
+    # Get the script name from the operation data (e.g., "bundle-generation/generate-charts.py")
+    script_name = Path(operation_data["script"]).name
+    script_path = DEST_DIR / script_name
 
     operations_args = operation_data.get("args", "").format(
         pipeline_repo=args.pipeline_repo,
         pipeline_branch=args.pipeline_branch,
         bundle=getattr(args, 'bundle', '../acm-operator-bundle')
     ) if "args" in operation_data else ""
-    
+
     if args.component:
         operations_args += " --component {}".format(args.component)
 
@@ -156,32 +130,40 @@ def prepare_and_execute(operation, operation_data, args):
         operations_args += " --config {}".format(args.config)
 
     # Execute the script
-    execute_script(script, operations_args)
+    execute_script(script_path, operations_args)
 
-    # Clean up the copied scripts
-    cleanup_scripts(script_dependencies)
+    # Clean up all copied Python files and utils directory
+    for py_file in bundle_gen_src.glob("*.py"):
+        copied_file = DEST_DIR / py_file.name
+        if copied_file.exists():
+            copied_file.unlink()
 
-def execute_script(script, args):
+    if utils_dest.exists():
+        shutil.rmtree(utils_dest)
+
+    logging.debug(f"Cleaned up copied files")
+
+def execute_script(script_path, args):
     """Executes a Python script with arguments.
 
     Args:
-        script (_type_): _description_
-        args (_type_): _description_
+        script_path (Path): Path to the script to execute
+        args (str): Command-line arguments for the script
     """
-    script_path = DEST_DIR / Path(script).name
-
     if not script_path.exists():
         logging.error(f"Script {script_path} not found.")
         sys.exit(1)
 
+    # Set PYTHONPATH to include the bundle-automation directory so imports work
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(DEST_DIR) + os.pathsep + env.get('PYTHONPATH', '')
+
     command = ["python3", str(script_path)] + args.split()
     try:
-        subprocess.run(command, check=True)
+        subprocess.run(command, check=True, env=env)
     except subprocess.CalledProcessError as e:
-        logging.error(f"Script {script} failed with exit code {e.returncode}")
+        logging.error(f"Script {script_path.name} failed with exit code {e.returncode}")
         sys.exit(e.returncode)
-    finally:
-        script_path.unlink(missing_ok=True)  # Clean up after execution
 
 def main(args):
     """_summary_


### PR DESCRIPTION
## Summary

Refactors `hack/bundle-automation/generate-shell.py` to automatically copy all Python files from the installer-dev-tools bundle-generation directory using glob patterns, eliminating the need for manual dependency tracking.

## Changes

- Use `*.py` glob pattern to automatically copy all Python files from bundle-generation
- Remove manual dependency tracking (no longer need to list helper.py, etc.)
- Remove unused `copy_scripts()` and `cleanup_scripts()` functions
- Add PYTHONPATH environment variable for proper imports
- Simplify code: 59 deletions, 41 additions

## Benefits

- Automatically includes new dependencies (e.g., helper.py from installer-dev-tools #142)
- Reduces maintenance burden
- Prevents ModuleNotFoundError issues when new shared utilities are added

## Dependencies

Required for OWNERS file automation feature being added in stolostron/installer-dev-tools#142

/cc @cameronmwall @ngraham20