### PR TITLE
Update Go to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stolostron/multiclusterhub-operator
 
-go 1.25.0
-
-toolchain go1.25.2
+go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
# Description

Update Go version from 1.25.0 to 1.25.8 to align with the discovery component and address stdlib vulnerabilities.

## Related Issue

Part of ongoing CVE remediation efforts for multiclusterhub-operator.

## Changes Made

- Updated `go.mod`: Changed Go version from `1.25.0` to `1.25.8`
- Removed `toolchain go1.25.2` directive (handled automatically by `go mod tidy`)

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have rebased my branch on top of the latest release-2.17 branch.

## Additional Notes

This change aligns the Go version in go.mod with the actual Go version used in builds. The toolchain directive is removed automatically by `go mod tidy` when the go directive matches the Go version being used.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the release-2.17 branch.