### PR TITLE
ACM-30181 Inherit TLS profile from OpenShift APIServer

### DIFF
--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -68,7 +68,7 @@ var (
 //+kubebuilder:rbac:groups="multicluster.openshift.io",resources=multiclusterengines,verbs=create;get;list;patch;update;delete;watch
 //+kubebuilder:rbac:groups=console.openshift.io;search.open-cluster-management.io,resources=consoleplugins;consolelinks;searches,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=cloudcredentials;consoles,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=config.openshift.io,resources=authentications;infrastructures,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;authentications;infrastructures,verbs=get;list;watch
 //+kubebuilder:rbac:groups="";"apps",resources=deployments;services;serviceaccounts,verbs=patch;delete;get;deletecollection
 //+kubebuilder:rbac:groups=packages.operators.coreos.com,resources=packagemanifests,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors,verbs=create;delete;get;list;watch;update;patch;deletecollection

--- a/main.go
+++ b/main.go
@@ -201,12 +201,6 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "multicloudhub-operator-lock",
-		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: 9443,
-			TLSOpts: []func(*tls.Config){func(config *tls.Config) {
-				config.MinVersion = tls.VersionTLS12
-			}},
-		}),
 		LeaderElectionNamespace: ns,
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,
@@ -216,12 +210,8 @@ func main() {
 		},
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
-	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
+	// Create uncached client early for TLS profile fetching and other setup tasks
+	ctx := context.Background()
 	uncachedClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{
 		Scheme: scheme,
 	})
@@ -230,7 +220,32 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
+	// Get TLS configuration from OpenShift APIServer profile
+	tlsProfile, err := utils.GetAPIServerTLSProfile(ctx, uncachedClient)
+	if err != nil {
+		setupLog.Error(err, "unable to get APIServer TLS profile, using default TLS 1.2")
+		// Continue with default if we can't get the profile
+		tlsProfile = &configv1.TLSProfileSpec{
+			MinTLSVersion: configv1.VersionTLS12,
+		}
+	}
+
+	minTLSVersion := utils.ConvertTLSVersion(tlsProfile.MinTLSVersion)
+	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion)
+
+	// Configure webhook server with dynamic TLS settings from OpenShift
+	mgrOptions.WebhookServer = webhook.NewServer(webhook.Options{
+		Port: 9443,
+		TLSOpts: []func(*tls.Config){func(config *tls.Config) {
+			config.MinVersion = minTLSVersion
+		}},
+	})
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
 
 	// Force OperatorCondition Upgradeable to False
 	//

--- a/main.go
+++ b/main.go
@@ -225,19 +225,39 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to get APIServer TLS profile, using default TLS 1.2")
 		// Continue with default if we can't get the profile
+		// Use Intermediate profile ciphers as secure default for TLS 1.2
 		tlsProfile = &configv1.TLSProfileSpec{
 			MinTLSVersion: configv1.VersionTLS12,
+			Ciphers: []string{
+				"TLS_AES_128_GCM_SHA256",
+				"TLS_AES_256_GCM_SHA384",
+				"TLS_CHACHA20_POLY1305_SHA256",
+				"ECDHE-ECDSA-AES128-GCM-SHA256",
+				"ECDHE-RSA-AES128-GCM-SHA256",
+				"ECDHE-ECDSA-AES256-GCM-SHA384",
+				"ECDHE-RSA-AES256-GCM-SHA384",
+				"ECDHE-ECDSA-CHACHA20-POLY1305",
+				"ECDHE-RSA-CHACHA20-POLY1305",
+				"DHE-RSA-AES128-GCM-SHA256",
+				"DHE-RSA-AES256-GCM-SHA384",
+			},
 		}
 	}
 
 	minTLSVersion := utils.ConvertTLSVersion(tlsProfile.MinTLSVersion)
-	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion)
+	cipherSuites := utils.ConvertCipherSuites(tlsProfile.Ciphers)
+	setupLog.Info("Configuring webhook server TLS", "minTLSVersion", tlsProfile.MinTLSVersion, "numericValue", minTLSVersion, "cipherCount", len(cipherSuites))
 
 	// Configure webhook server with dynamic TLS settings from OpenShift
 	mgrOptions.WebhookServer = webhook.NewServer(webhook.Options{
 		Port: 9443,
 		TLSOpts: []func(*tls.Config){func(config *tls.Config) {
 			config.MinVersion = minTLSVersion
+			// Only set CipherSuites for TLS ≤ 1.2
+			// TLS 1.3 cipher suites are managed automatically by Go
+			if minTLSVersion < tls.VersionTLS13 && len(cipherSuites) > 0 {
+				config.CipherSuites = cipherSuites
+			}
 		}},
 	})
 

--- a/main.go
+++ b/main.go
@@ -198,9 +198,9 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "multicloudhub-operator-lock",
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "multicloudhub-operator-lock",
 		LeaderElectionNamespace: ns,
 		LeaseDuration:           &leaseDuration,
 		RenewDeadline:           &renewDeadline,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,14 +4,18 @@
 package utils
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -425,5 +429,59 @@ func IsCommunityMode() bool {
 	} else {
 		// other option is "stolostron"
 		return true
+	}
+}
+
+// GetAPIServerTLSProfile retrieves the TLS security profile from the OpenShift APIServer resource.
+// Returns the TLSProfileSpec containing minTLSVersion and ciphers.
+// If no profile is set, returns the default Intermediate profile.
+func GetAPIServerTLSProfile(ctx context.Context, cl client.Client) (*configv1.TLSProfileSpec, error) {
+	// If running in unit test mode, return default Intermediate profile
+	if val, ok := os.LookupEnv(UnitTestEnvVar); ok && val == "true" {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+
+	apiServer := &configv1.APIServer{}
+	err := cl.Get(ctx, types.NamespacedName{Name: "cluster"}, apiServer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get APIServer resource: %w", err)
+	}
+
+	// If no TLS profile is set, use the default (Intermediate)
+	if apiServer.Spec.TLSSecurityProfile == nil {
+		return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+	}
+
+	profile := apiServer.Spec.TLSSecurityProfile
+
+	// For predefined profiles (Old, Intermediate, Modern), use the map
+	if profileSpec, ok := configv1.TLSProfiles[profile.Type]; ok {
+		return profileSpec, nil
+	}
+
+	// For custom profile, return the inline spec
+	if profile.Type == configv1.TLSProfileCustomType && profile.Custom != nil {
+		return &profile.Custom.TLSProfileSpec, nil
+	}
+
+	// Fallback to Intermediate if something unexpected
+	return configv1.TLSProfiles[configv1.TLSProfileIntermediateType], nil
+}
+
+// ConvertTLSVersion converts OpenShift TLSProtocolVersion string to crypto/tls uint16 constant.
+// Returns tls.VersionTLS12 as default if the version string is not recognized.
+func ConvertTLSVersion(version configv1.TLSProtocolVersion) uint16 {
+	switch version {
+	case configv1.VersionTLS10:
+		return tls.VersionTLS10
+	case configv1.VersionTLS11:
+		return tls.VersionTLS11
+	case configv1.VersionTLS12:
+		return tls.VersionTLS12
+	case configv1.VersionTLS13:
+		return tls.VersionTLS13
+	default:
+		// Default to TLS 1.2 for safety
+		return tls.VersionTLS12
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -485,3 +485,51 @@ func ConvertTLSVersion(version configv1.TLSProtocolVersion) uint16 {
 		return tls.VersionTLS12
 	}
 }
+
+// ConvertCipherSuites converts OpenShift cipher suite names (OpenSSL format) to crypto/tls uint16 constants.
+// TLS 1.3 cipher suites are managed automatically by Go and cannot be configured, so they are filtered out.
+// Only returns cipher suites applicable to TLS ≤ 1.2.
+func ConvertCipherSuites(cipherNames []string) []uint16 {
+	// Mapping from OpenSSL cipher names to crypto/tls constants
+	// Only includes cipher suites that exist in Go's crypto/tls package
+	cipherMap := map[string]uint16{
+		// TLS 1.2 ECDHE ciphers (GCM and ChaCha20)
+		"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+
+		// TLS 1.2 ECDHE ciphers (CBC)
+		"ECDHE-RSA-AES128-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-RSA-AES128-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-ECDSA-AES128-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE-ECDSA-AES128-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE-RSA-AES256-SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE-ECDSA-AES256-SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+
+		// RSA ciphers
+		"AES128-GCM-SHA256": tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"AES256-GCM-SHA384": tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"AES128-SHA256":     tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"AES128-SHA":        tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"AES256-SHA":        tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"DES-CBC3-SHA":      tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	}
+
+	var result []uint16
+	for _, name := range cipherNames {
+		// Skip TLS 1.3 cipher suites (they start with TLS_ prefix and are auto-managed)
+		if len(name) > 4 && name[:4] == "TLS_" {
+			continue
+		}
+
+		if cipher, ok := cipherMap[name]; ok {
+			result = append(result, cipher)
+		}
+		// Silently skip unsupported cipher suites - Go may not support all OpenSSL ciphers
+	}
+
+	return result
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"crypto/tls"
 	"os"
 	"reflect"
 	"testing"
@@ -489,4 +490,85 @@ func containsDeployment(deployments []types.NamespacedName, name, namespace stri
 		}
 	}
 	return false
+}
+
+func TestConvertCipherSuites(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		want   []uint16
+		wantOk bool
+	}{
+		{
+			name:   "TLS 1.2 ECDHE-RSA ciphers",
+			input:  []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+			wantOk: true,
+		},
+		{
+			name:   "TLS 1.2 ECDHE-ECDSA ciphers",
+			input:  []string{"ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-CHACHA20-POLY1305"},
+			want:   []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256},
+			wantOk: true,
+		},
+		{
+			name:   "TLS 1.3 ciphers are filtered out",
+			input:  []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "ECDHE-RSA-AES128-GCM-SHA256"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantOk: true,
+		},
+		{
+			name:   "All TLS 1.3 ciphers filtered",
+			input:  []string{"TLS_AES_128_GCM_SHA256", "TLS_CHACHA20_POLY1305_SHA256"},
+			want:   []uint16{},
+			wantOk: true,
+		},
+		{
+			name:   "Unknown cipher silently ignored",
+			input:  []string{"UNKNOWN-CIPHER", "ECDHE-RSA-AES128-GCM-SHA256"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantOk: true,
+		},
+		{
+			name:   "Empty input",
+			input:  []string{},
+			want:   []uint16{},
+			wantOk: true,
+		},
+		{
+			name:   "CBC ciphers",
+			input:  []string{"ECDHE-RSA-AES128-SHA256", "AES128-SHA"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+			wantOk: true,
+		},
+		{
+			name:   "DHE ciphers not supported (silently ignored)",
+			input:  []string{"DHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256"},
+			want:   []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantOk: true,
+		},
+		{
+			name:   "3DES cipher",
+			input:  []string{"DES-CBC3-SHA"},
+			want:   []uint16{tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA},
+			wantOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertCipherSuites(tt.input)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("ConvertCipherSuites() returned %d ciphers, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ConvertCipherSuites()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -4,18 +4,22 @@
 package utils
 
 import (
+	"context"
 	"crypto/tls"
 	"os"
 	"reflect"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mchv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	resources "github.com/stolostron/multiclusterhub-operator/test/unit-tests"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -567,6 +571,145 @@ func TestConvertCipherSuites(t *testing.T) {
 			for i := range got {
 				if got[i] != tt.want[i] {
 					t.Errorf("ConvertCipherSuites()[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetAPIServerTLSProfile(t *testing.T) {
+	// Create scheme with necessary types
+	scheme := runtime.NewScheme()
+	_ = configv1.AddToScheme(scheme)
+
+	tests := []struct {
+		name        string
+		apiServer   *configv1.APIServer
+		unitTest    bool
+		expectError bool
+		wantProfile *configv1.TLSProfileSpec
+	}{
+		{
+			name:        "unit test mode returns intermediate",
+			unitTest:    true,
+			expectError: false,
+			wantProfile: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+		},
+		{
+			name: "nil TLS profile returns intermediate",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       configv1.APIServerSpec{},
+			},
+			expectError: false,
+			wantProfile: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+		},
+		{
+			name: "old profile type",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileOldType,
+					},
+				},
+			},
+			expectError: false,
+			wantProfile: configv1.TLSProfiles[configv1.TLSProfileOldType],
+		},
+		{
+			name: "intermediate profile type",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileIntermediateType,
+					},
+				},
+			},
+			expectError: false,
+			wantProfile: configv1.TLSProfiles[configv1.TLSProfileIntermediateType],
+		},
+		{
+			name: "modern profile type",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileModernType,
+					},
+				},
+			},
+			expectError: false,
+			wantProfile: configv1.TLSProfiles[configv1.TLSProfileModernType],
+		},
+		{
+			name: "custom profile type",
+			apiServer: &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+								MinTLSVersion: configv1.VersionTLS13,
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+			wantProfile: &configv1.TLSProfileSpec{
+				Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+				MinTLSVersion: configv1.VersionTLS13,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment for unit test mode
+			if tt.unitTest {
+				os.Setenv(UnitTestEnvVar, "true")
+				defer os.Unsetenv(UnitTestEnvVar)
+			} else {
+				os.Unsetenv(UnitTestEnvVar)
+			}
+
+			// Create fake client
+			var objs []runtime.Object
+			if tt.apiServer != nil {
+				objs = append(objs, tt.apiServer)
+			}
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+			// Call function
+			got, err := GetAPIServerTLSProfile(context.Background(), cl)
+
+			// Check error expectation
+			if tt.expectError && err == nil {
+				t.Errorf("GetAPIServerTLSProfile() expected error but got none")
+				return
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("GetAPIServerTLSProfile() unexpected error: %v", err)
+				return
+			}
+
+			// Compare profiles
+			if !tt.expectError {
+				if got == nil {
+					t.Errorf("GetAPIServerTLSProfile() returned nil profile")
+					return
+				}
+				if got.MinTLSVersion != tt.wantProfile.MinTLSVersion {
+					t.Errorf("GetAPIServerTLSProfile() MinTLSVersion = %v, want %v",
+						got.MinTLSVersion, tt.wantProfile.MinTLSVersion)
+				}
+				if !reflect.DeepEqual(got.Ciphers, tt.wantProfile.Ciphers) {
+					t.Errorf("GetAPIServerTLSProfile() Ciphers = %v, want %v",
+						got.Ciphers, tt.wantProfile.Ciphers)
 				}
 			}
 		})


### PR DESCRIPTION
Removes hardcoded TLS 1.2 from webhook server. Fetches TLS profile dynamically from OpenShift APIServer resource. Defaults to Intermediate if not set.

Related: ACM-30181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook TLS configuration is now determined at startup from the cluster API server TLS profile with a safe fallback, improving compatibility.

* **New Features**
  * Parse API server TLS profiles to derive minimum TLS version and cipher suites; apply these to webhook TLS settings.

* **Tests**
  * Added unit tests for cipher-suite translation/filtering and TLS profile handling.

* **Chores**
  * RBAC permissions updated to include API server resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->