### PR TITLE
[ACM-32732] Improve UserPreference CRD description quality

### DIFF
--- a/pkg/templates/crds/console/user-preference-crd.yaml
+++ b/pkg/templates/crds/console/user-preference-crd.yaml
@@ -1,10 +1,8 @@
 # Copyright (c) 2020 Red Hat, Inc.
-
 # Copyright Contributors to the Open Cluster Management project
 
-# Dynamic user preference data
 # The CR will be created with the name of the user who will access the information
-# CR will hold info such as saved searches, homepage, search history etc.
+# CR will hold user defined saved searches for the ACM Search page.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -23,23 +21,32 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: >-
+            UserPreference stores user defined saved search data for the search UI. The resource name identifies the user;
           type: object
           properties:
             spec:
+              description: Desired user preference data managed by the console.
               type: object
               properties:
-                savedSearches: # Saved user searches to be displayed on main search page
+                savedSearches:
+                  description: Saved searches shown on the ACM Search home page.
                   type: array
                   items:
+                    description: One saved search, including display metadata and query text.
                     type: object
                     properties:
                       id:
+                        description: Stable identifier for this saved search.
                         type: string
                       searchText:
+                        description: Query or filter text executed when the saved search runs.
                         type: string
                       name:
+                        description: Short label shown for this saved search in the UI.
                         type: string
                       description:
+                        description: Optional longer text describing the saved search.
                         type: string
   # either Namespaced or Cluster
   scope: Cluster
@@ -50,36 +57,3 @@ spec:
     singular: userpreference
     # kind is normally the CamelCased singular type. Your resource manifests use this.
     kind: UserPreference
-
-  # TODO Need to see if we can have a non-structural schema that leaves this CR dynamica to new user preferences?
-  # validation:
-  #   openAPIV3Schema:
-  #     type: object
-  #     properties:
-  #       spec:
-  #         type: object
-  #         properties:
-  #           savedSearches: # Saved user searches to be displayed on main search page
-  #             type: array
-  #             items:
-  #               type: object
-  #               properties:
-  #                 id:
-  #                   type: string
-  #                 searchText:
-  #                   type: string
-  #                 name:
-  #                   type: string
-  #                 description:
-  #                   type: string
-  #           homepage: # User is able to set a homepage that creates a link on header icon
-  #             type: string
-
-  #           TODO - implement recent search history data for recomended searches
-  #           searchHistory:
-  #             type: array
-  #             items:
-  #               type: object
-  #               properties:
-  #                 searchText:
-  #                   type: string 


### PR DESCRIPTION
# Description

UserPreference CRD does not contain any description fields.

## Related Issue

https://redhat.atlassian.net/browse/ACM-32732

## Changes Made

This PR adds the description fields to the openAPIV3Schema.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced schema documentation for the UserPreference Custom Resource Definition with improved descriptions of saved searches and related fields, clarifying their structure and purpose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->