### PR TITLE
[Do-Not-Merge] Update base images from RHEL9 to RHEL10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY pkg/templates/ templates/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o multiclusterhub-operator main.go
 
 # Use ubi minimal base image to package the multiclusterhub-operator binary
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/multiclusterhub-operator /usr/local/bin/multiclusterhub-operator
 COPY --from=builder /workspace/templates/ /usr/local/templates/

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as cloner
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest as cloner
 
 RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts
@@ -28,7 +28,7 @@ COPY pkg/templates/ templates/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o multiclusterhub-operator main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL org.label-schema.vendor="Red Hat" \
       org.label-schema.name="multiclusterhub-operator" \

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,11 +1,11 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as cloner
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest as cloner
 
 RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_10_1.25 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -27,21 +27,21 @@ COPY LICENSE LICENSE
 # Build
 RUN CGO_ENABLED=1 go build -mod=readonly -o multiclusterhub-operator main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL org.label-schema.vendor="Red Hat" \
       url="https://github.com/stolostron/multiclusterhub-operator" \
       org.label-schema.name="multiclusterhub-operator" \
       org.label-schema.description="Installer operator for Red Hat Advanced Cluster Management" \
       org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
-      name="rhacm2/multiclusterhub-rhel9" \
+      name="rhacm2/multiclusterhub-rhel10" \
       summary="MultiClusterHub installer for Red Hat Advanced Cluster Management" \
       description="Installer operator for Red Hat Advanced Cluster Management" \
       io.k8s.display-name="MultiClusterHub operator" \
       io.k8s.description="Installer operator for Red Hat Advanced Cluster Management" \
       com.redhat.component="multiclusterhub-operator-container" \
       io.openshift.tags="data,images" \
-      cpe="cpe:/a:redhat:acm:2.17::el9"
+      cpe="cpe:/a:redhat:acm:2.17::el10"
 
 WORKDIR /
 COPY --from=builder /workspace/multiclusterhub-operator /usr/local/bin/multiclusterhub-operator


### PR DESCRIPTION
## Summary
- Updated all Dockerfiles to use ubi10/ubi-minimal base images (previously ubi9)
- Updated golang builder image to rhel_10_1.25 (previously rhel_9_1.25)
- Updated container labels: rhel9 → rhel10, el9 → el10

## Test plan
- [ ] Verify Docker builds complete successfully
- [ ] Test operator deployment with new RHEL10 base images
- [ ] Confirm no runtime issues with UBI10 minimal base

/cc @cameronmwall @ngraham20

🤖 Generated with [Claude Code](https://claude.com/claude-code)