### PR TITLE
ci: add release-2.17 to GitHub Actions workflow matrices

### DIFF
--- a/.github/workflows/regenerate-bundles.yml
+++ b/.github/workflows/regenerate-bundles.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.25"]
-        branch: ['main', 'release-2.11', 'release-2.12', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16']
+        branch: ['main', 'release-2.11', 'release-2.12', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/regenerate-charts.yml
+++ b/.github/workflows/regenerate-charts.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.25"]
-        branch: ['main', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16']
+        branch: ['main', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/resync-owner-file.yml
+++ b/.github/workflows/resync-owner-file.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         branch: [
+            'release-2.17',
             'release-2.16',
             'release-2.15',
             'release-2.14',

--- a/.github/workflows/update-pregenerated-charts.yml
+++ b/.github/workflows/update-pregenerated-charts.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.25"]
-        branch: ['main', 'release-2.11', 'release-2.12', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16']
+        branch: ['main', 'release-2.11', 'release-2.12', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
# Description

Add release-2.17 branch support to GitHub Actions workflows for automated chart and operator bundle regeneration, and OWNERS file syncing.

## Related Issue

N/A

## Changes Made

Updated four GitHub Actions workflow files to include release-2.17 in their branch matrices with Go 1.25:
- `.github/workflows/regenerate-bundles.yml`
- `.github/workflows/regenerate-charts.yml`
- `.github/workflows/update-pregenerated-charts.yml`
- `.github/workflows/resync-owner-file.yml`

This ensures automated workflows run for the new release-2.17 branch alongside existing supported versions (2.11-2.16).

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This is a workflow configuration change only. No code changes required. The release-2.17 branch uses Go 1.25, consistent with versions 2.11-2.16.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.