### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/build/Dockerfile.art
+++ b/build/Dockerfile.art
@@ -1,0 +1,58 @@
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest as cloner
+
+RUN microdnf install -y git findutils
+COPY hack/scripts hack/scripts
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+
+# Enable automatic Go toolchain downloads
+ENV GOTOOLCHAIN=auto
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+
+# Copy required files
+COPY pkg/templates/ templates/
+
+# Copy license
+COPY LICENSE LICENSE
+
+# Build
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod=readonly -o multiclusterhub-operator main.go
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+LABEL org.label-schema.vendor="Red Hat" \
+      url="https://github.com/stolostron/multiclusterhub-operator" \
+      org.label-schema.name="multiclusterhub-operator" \
+      org.label-schema.description="Installer operator for Red Hat Advanced Cluster Management" \
+      org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+      name="rhacm2/multiclusterhub-rhel9" \
+      summary="MultiClusterHub installer for Red Hat Advanced Cluster Management" \
+      description="Installer operator for Red Hat Advanced Cluster Management" \
+      io.k8s.display-name="MultiClusterHub operator" \
+      io.k8s.description="Installer operator for Red Hat Advanced Cluster Management" \
+      com.redhat.component="multiclusterhub-operator-container" \
+      io.openshift.tags="data,images" \
+      cpe="cpe:/a:redhat:acm:2.16::el9"
+
+WORKDIR /
+COPY --from=builder /workspace/multiclusterhub-operator /usr/local/bin/multiclusterhub-operator
+COPY --from=builder /workspace/templates/ /usr/local/templates/
+
+# Add license
+COPY --from=builder /workspace/LICENSE /licenses/
+
+USER 65532:65532
+
+ENTRYPOINT ["multiclusterhub-operator"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)