### PR TITLE
[ACM-33702] Skip migrated components during MCH finalization

### DIFF
--- a/controllers/lifecycle.go
+++ b/controllers/lifecycle.go
@@ -46,6 +46,13 @@ func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operat
 	}
 
 	for _, c := range operatorv1.MCHComponents {
+		// Skip components that have been migrated to MCE - MCE owns their lifecycle now.
+		// This prevents attempting to render templates that may be missing image overrides
+		// in newer ACM versions where the component has been removed from MCH.
+		if _, migrated := migratedComponentDeployments[c]; migrated {
+			continue
+		}
+
 		result, err := r.ensureNoComponent(context.TODO(), m, c, r.CacheSpec, isSTSEnabled)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

Fix ACM 5.0 uninstall failure when cleaning up cluster-permission component.

## Related Issue

https://redhat.atlassian.net/browse/ACM-33702

## Changes Made

Added migration guard to finalization loop in `controllers/lifecycle.go`:
- Skip components in `migratedComponentDeployments` map during MCH uninstall
- Matches existing pattern in reconcile loop (line 408 in `reconcile.go`)
- Prevents template render errors for components migrated to MCE in 2.17+

**Root Cause:**
During MCH uninstall, `finalizeHub` loops through all `MCHComponents` and calls `ensureNoComponent` to render templates for deletion. cluster-permission was migrated to MCE in 2.17, so its image reference was removed from MCH CSV. In ACM 5.0, `cluster_permission` key missing from `imageOverrides` map → template render fails → infinite requeue loop.

**Why cluster-permission still in MCHComponents:**
Kept for webhook validation of old MCH CRs from ACM < 2.17 that may have cluster-permission in spec.

## Screenshots (if applicable)

N/A - controller logic fix

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

**Upgrade paths handled:**
- Normal upgrade (2.16 → 2.17 → 5.0): cluster-permission already migrated, guard prevents cleanup
- EUS upgrade (2.16 → 5.0): migration cleanup runs during reconcile before finalization
- Illegal upgrade (CSV deletion 2.16 → 5.0): guard prevents render error during finalization

This fix is scoped to finalization only. Future migrated components automatically handled via `migratedComponentDeployments` map.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lifecycle management to properly handle components that have been migrated to the MultiCluster Engine, preventing unintended lifecycle operations on MCE-owned components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->