### PR TITLE
Change probes to check for outgoing connection to port 443

### DIFF
--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-application.yaml
@@ -70,7 +70,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - ls
+            - /bin/sh
+            - -c
+            - grep -q ":01BB 01" /proc/net/tcp
           initialDelaySeconds: 30
           periodSeconds: 30
 {{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}
@@ -83,7 +85,9 @@ spec:
         readinessProbe:
           exec:
             command:
-            - ls
+            - /bin/sh
+            - -c
+            - grep -q ":01BB 01" /proc/net/tcp
           initialDelaySeconds: 15
           periodSeconds: 15
 {{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}
@@ -143,7 +147,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - ls
+            - /bin/sh
+            - -c
+            - grep -q ":01BB 01" /proc/net/tcp
           initialDelaySeconds: 15
           periodSeconds: 15
 {{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}
@@ -156,7 +162,9 @@ spec:
         readinessProbe:
           exec:
             command:
-            - ls
+            - /bin/sh
+            - -c
+            - grep -q ":01BB 01" /proc/net/tcp
           initialDelaySeconds: 15
           periodSeconds: 15
 {{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}
@@ -216,7 +224,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - ls
+            - /bin/sh
+            - -c
+            - grep -q ":01BB 01" /proc/net/tcp
           initialDelaySeconds: 15
           periodSeconds: 15
 {{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}
@@ -233,7 +243,9 @@ spec:
         readinessProbe:
           exec:
             command:
-            - ls
+            - /bin/sh
+            - -c
+            - grep -q ":01BB 01" /proc/net/tcp
           initialDelaySeconds: 15
           periodSeconds: 15
 {{- if and .Values.hubconfig.probeConfig (hasKey .Values.hubconfig.probeConfig "timeoutSeconds") }}


### PR DESCRIPTION
JIRA: ACM-33885

# Description

Changes probes from ls to grep for 443 on tcp socket

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.
ACM-33885

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

Changes probes from ls to grep for 443 on tcp socket

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container health check probes for multicloud operators components to improve monitoring reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->