### PR TITLE
ACM-33066 Bridge OCM CA bundle into ACM console pod for PlacementDebugServer

### DIFF
--- a/controllers/components.go
+++ b/controllers/components.go
@@ -28,7 +28,10 @@ import (
 	"github.com/stolostron/multiclusterhub-operator/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -205,6 +208,9 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 
 	switch component {
 	case operatorv1.Console:
+		if err := r.ensurePlacementDebugCABundle(ctx, m); err != nil {
+			log.Error(err, "Failed to sync placement debug CA bundle")
+		}
 		return r.addPluginToConsole(m)
 
 	case operatorv1.Search:
@@ -289,6 +295,56 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 		}
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *MultiClusterHubReconciler) ensurePlacementDebugCABundle(
+	ctx context.Context, m *operatorv1.MultiClusterHub,
+) error {
+	sourceNS := "open-cluster-management-hub"
+	sourceName := "ca-bundle-configmap"
+	source := &corev1.ConfigMap{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: sourceName, Namespace: sourceNS}, source)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get OCM CA bundle ConfigMap: %w", err)
+	}
+
+	caBundle, ok := source.Data["ca-bundle.crt"]
+	if !ok || caBundle == "" {
+		return nil
+	}
+
+	targetName := "placement-debug-ca-bundle"
+	target := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName,
+			Namespace: m.GetNamespace(),
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": caBundle,
+		},
+	}
+
+	if err := ctrl.SetControllerReference(m, target, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference on placement debug CA ConfigMap: %w", err)
+	}
+
+	existing := &corev1.ConfigMap{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: targetName, Namespace: m.GetNamespace()}, existing)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.Client.Create(ctx, target)
+		}
+		return fmt.Errorf("failed to get placement debug CA ConfigMap: %w", err)
+	}
+
+	if existing.Data["ca-bundle.crt"] != caBundle {
+		existing.Data = target.Data
+		return r.Client.Update(ctx, existing)
+	}
+	return nil
 }
 
 /*

--- a/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-deployment.yaml
@@ -94,6 +94,10 @@ spec:
       - name: console-chart-console-config
         configMap:
           name: console-config
+      - name: placement-debug-ca
+        configMap:
+          name: placement-debug-ca-bundle
+          optional: true
       containers:
       - name: console
         volumeMounts:
@@ -101,6 +105,9 @@ spec:
           name: console-chart-console-certs
         - mountPath: /app/config
           name: console-chart-console-config
+        - mountPath: /var/run/secrets/placement-debug-ca
+          name: placement-debug-ca
+          readOnly: true
         image: {{ .Values.global.imageOverrides.console }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
@@ -136,6 +143,8 @@ spec:
           value: "3000"
         - name: CLUSTER_API_URL
           value: https://kubernetes.default.svc:443
+        - name: PLACEMENT_CA_BUNDLE_PATH
+          value: /var/run/secrets/placement-debug-ca/ca-bundle.crt
         - name: DISABLE_EVENTS
           value: "true"
         {{- if .Values.hubconfig.proxyConfigs }}


### PR DESCRIPTION
## Summary

- Adds `ensurePlacementDebugCABundle()` to copy the OCM CA bundle ConfigMap from `open-cluster-management-hub` to the MCH namespace
- Adds volume, volumeMount, and `PLACEMENT_CA_BUNDLE_PATH` env var to the ACM console deployment Helm chart

## Context

The PlacementDebugServer uses TLS certificates signed by the OCM CertRotationController's signing CA (via [ocm#1494](https://github.com/open-cluster-management-io/ocm/pull/1494)). The ACM console needs to trust this CA to proxy placement debug requests.

This is the ACM-side counterpart to [backplane-operator#3348](https://github.com/stolostron/backplane-operator/pull/3348), which makes the same changes for the MCE console. The console code that reads this CA and creates a custom HTTPS agent is in [console#6090](https://github.com/stolostron/console/pull/6090).

## Test plan

- [x] E2E tested on live ACM cluster: ACM console reads OCM CA from mounted path, creates custom HTTPS agent, successfully connects to PlacementDebugServer with HTTP 200
- [ ] Unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added placement debug CA bundle configuration support to the console component for enhanced certificate debugging capabilities.
  * Console deployments now support optional debug certificate bundle mounting with automatic environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->