### PR TITLE
Add submariner-addon deployment to status tracking (main)

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -277,6 +277,9 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEn
 	if m.Enabled(operatorsv1.Volsync) {
 		nn = append(nn, types.NamespacedName{Name: "volsync-addon-controller", Namespace: m.Namespace})
 	}
+	if m.Enabled(operatorsv1.SubmarinerAddon) {
+		nn = append(nn, types.NamespacedName{Name: "submariner-addon", Namespace: m.Namespace})
+	}
 	if m.Enabled(operatorsv1.MultiClusterObservability) {
 		nn = append(nn, types.NamespacedName{Name: "multicluster-observability-operator", Namespace: m.Namespace})
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -133,6 +133,13 @@ var _ = Describe("utility functions", func() {
 			d := GetDeploymentsForStatus(&mch, true, false)
 			Expect(len(d)).To(Equal(1))
 		})
+		It("gets deployments for status with submariner-addon enabled", func() {
+			mch := resources.EmptyMCH()
+			mch.Enable(mchv1.SubmarinerAddon)
+			d := GetDeploymentsForStatus(&mch, true, false)
+			Expect(len(d)).To(Equal(1))
+			Expect(containsDeployment(d, "submariner-addon", resources.MulticlusterhubNamespace)).To(BeTrue())
+		})
 		It("gets deployments for status with fine-grained-rbac enabled", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.FineGrainedRbac)
@@ -412,7 +419,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 			name:       "should get deployment status for MCH components",
 			mch:        resources.EmptyMCH(),
 			stsEnabled: false,
-			want:       19,
+			want:       20,
 		},
 		{
 			name: "should get deployment status for MCH components with STS enabled",
@@ -429,7 +436,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: true,
-			want:       20,
+			want:       21,
 			mustNotContain: []types.NamespacedName{
 				{Name: "openshift-adp-controller-manager", Namespace: ClusterSubscriptionNamespace},
 			},
@@ -449,7 +456,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: false,
-			want:       21,
+			want:       22,
 			mustContain: []types.NamespacedName{
 				{Name: "openshift-adp-controller-manager", Namespace: ClusterSubscriptionNamespace},
 			},


### PR DESCRIPTION
## Summary
- Add submariner-addon deployment to status tracking in GetDeploymentsForStatus
- Update tests to reflect new deployment count

## Problem
The submariner-addon component is enabled by default but its deployment status is not being tracked in the MultiClusterHub status.components field. This means the operator doesn't report whether the submariner-addon deployment is healthy/available.

## Solution
Added submariner-addon deployment tracking to GetDeploymentsForStatus function, following the same pattern as other addon controllers like volsync-addon-controller.

## Test plan
- [x] Unit tests updated and passing
- [x] Verified submariner-addon deployment name matches template

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Submariner addon deployments are now recognized and monitored when the addon component is enabled.

* **Tests**
  * Added test coverage for Submariner addon deployment detection.
  * Updated test expectations for deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->