### PR TITLE
Add submariner-addon deployment to status tracking (release-2.13)

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -459,6 +459,9 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEn
 	if m.Enabled(operatorsv1.Volsync) {
 		nn = append(nn, types.NamespacedName{Name: "volsync-addon-controller", Namespace: m.Namespace})
 	}
+	if m.Enabled(operatorsv1.SubmarinerAddon) {
+		nn = append(nn, types.NamespacedName{Name: "submariner-addon", Namespace: m.Namespace})
+	}
 	if m.Enabled(operatorsv1.MultiClusterObservability) {
 		nn = append(nn, types.NamespacedName{Name: "multicluster-observability-operator", Namespace: m.Namespace})
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -698,7 +698,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 			name:       "should get deployment status for MCH components",
 			mch:        resources.EmptyMCH(),
 			stsEnabled: false,
-			want:       19,
+			want:       20,
 		},
 		{
 			name: "should get deployment status for MCH components with STS enabled",
@@ -715,7 +715,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: true,
-			want:       20,
+			want:       21,
 		},
 		{
 			name: "should get deployment status for MCH components with STS disabled",
@@ -732,7 +732,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: false,
-			want:       21,
+			want:       22,
 		},
 	}
 


### PR DESCRIPTION
# Description

Add submariner-addon deployment to status tracking in GetDeploymentsForStatus function.

## Related Issue

The submariner-addon component is enabled by default but its deployment status is not being tracked in the MultiClusterHub status.components field.

## Changes Made

- Added submariner-addon deployment to status tracking in GetDeploymentsForStatus function
- Updated test expectations to reflect new deployment count
- Follows same pattern as other addon controllers like volsync-addon-controller

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.

## Additional Notes

This ensures the operator reports whether submariner-addon deployment is healthy/available in the status field.