### PR TITLE
fix: add collectorconfigs RBAC to search-v2-operator clusterrole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1487,6 +1487,13 @@ rules:
 - apiGroups:
   - search.open-cluster-management.io
   resources:
+  - collectorconfigs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
   - searches
   verbs:
   - get

--- a/pkg/templates/charts/toggle/search-v2-operator/templates/search-v2-operator-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/search-v2-operator/templates/search-v2-operator-clusterrole.yaml
@@ -206,6 +206,13 @@ rules:
 - apiGroups:
   - search.open-cluster-management.io
   resources:
+  - collectorconfigs/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - search.open-cluster-management.io
+  resources:
   - searches
   verbs:
   - get

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -266,6 +266,7 @@ package main
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=delete;get;list;update;watch
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host;routes/status,verbs=get;list;create;update;delete;deletecollection;watch;create
+//+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=collectorconfigs/status,verbs=patch;update
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches,verbs=list;watch
 //+kubebuilder:rbac:groups=search.open-cluster-management.io,resources=searches/finalizers,verbs=update


### PR DESCRIPTION
The search-v2-operator now manages collectorconfigs/status (added in search-v2-operator PR https://github.com/stolostron/search-v2-operator/pull/726 and https://github.com/stolostron/search-v2-operator/pull/728) but the MCH-managed clusterrole was missing these permissions, causing MCH to get stuck in Installing status.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted cluster-level access for search-related components: replaced broader permissions on search resources with a narrower ability to patch and update collector configuration status, reducing the permission scope for managing search functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->