### PR TITLE
[release-2.14] Fix submariner-addon status check nesting in Volsync condition

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -396,9 +396,9 @@ func GetDeployments(m *operatorsv1.MultiClusterHub) []types.NamespacedName {
 	nn := []types.NamespacedName{}
 	if m.Enabled(operatorsv1.Volsync) {
 		nn = append(nn, types.NamespacedName{Name: "volsync-addon-controller", Namespace: m.Namespace})
+	}
 	if m.Enabled(operatorsv1.SubmarinerAddon) {
 		nn = append(nn, types.NamespacedName{Name: "submariner-addon", Namespace: m.Namespace})
-	}
 	}
 	if m.Enabled(operatorsv1.Insights) {
 		nn = append(nn, types.NamespacedName{Name: "insights-client", Namespace: m.Namespace})
@@ -461,9 +461,9 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEn
 	}
 	if m.Enabled(operatorsv1.Volsync) {
 		nn = append(nn, types.NamespacedName{Name: "volsync-addon-controller", Namespace: m.Namespace})
+	}
 	if m.Enabled(operatorsv1.SubmarinerAddon) {
 		nn = append(nn, types.NamespacedName{Name: "submariner-addon", Namespace: m.Namespace})
-	}
 	}
 	if m.Enabled(operatorsv1.MultiClusterObservability) {
 		nn = append(nn, types.NamespacedName{Name: "multicluster-observability-operator", Namespace: m.Namespace})


### PR DESCRIPTION
# Description

Fixes incorrect nesting of SubmarinerAddon status check inside Volsync conditional block. SubmarinerAddon deployments were only tracked when Volsync was enabled, causing submariner-addon to be missing from status checks when Volsync was disabled.

## Related Issue

Related to original PRs that introduced submariner-addon status tracking.

## Changes Made

- Un-nested SubmarinerAddon check from Volsync conditional in `GetDeployments()`
- Un-nested SubmarinerAddon check from Volsync conditional in `GetDeploymentsForStatus()`
- Each addon now has independent enable check

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This is a backport fix for release-2.14. The same bug exists in release-2.15 and is being fixed in parallel PR.

## Reviewers

/cc @reviewers

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the release-2.14 branch.