### PR TITLE
ACM-33704: Add webhook validation to block MTV when local-cluster is disabled

### DIFF
--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -143,7 +143,7 @@ func (r *MultiClusterHub) ValidateCreate(ctx context.Context, obj *MultiClusterH
 	}
 
 	// Validate that cnv-mtv-integrations is not enabled when disableHubSelfManagement is true
-	if err := validateMTVAndSelfManagement(r); err != nil {
+	if err := validateMTVAndSelfManagement(obj); err != nil {
 		return warnings, err
 	}
 
@@ -234,7 +234,7 @@ func (r *MultiClusterHub) ValidateUpdate(ctx context.Context, oldObj, newObj *Mu
 	}
 
 	// Validate that cnv-mtv-integrations is not enabled when disableHubSelfManagement is true
-	if err := validateMTVAndSelfManagement(r); err != nil {
+	if err := validateMTVAndSelfManagement(newObj); err != nil {
 		return warnings, err
 	}
 

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -142,6 +142,11 @@ func (r *MultiClusterHub) ValidateCreate(ctx context.Context, obj *MultiClusterH
 		return warnings, err
 	}
 
+	// Validate that cnv-mtv-integrations is not enabled when disableHubSelfManagement is true
+	if err := validateMTVAndSelfManagement(r); err != nil {
+		return warnings, err
+	}
+
 	multiClusterHubList := &MultiClusterHubList{}
 	if err := Client.List(context.Background(), multiClusterHubList); err != nil {
 		return warnings, fmt.Errorf("unable to list MultiClusterHubs: %s", err)
@@ -226,6 +231,11 @@ func (r *MultiClusterHub) ValidateUpdate(ctx context.Context, oldObj, newObj *Mu
 				return warnings, fmt.Errorf("invalid componentconfig: %s is not a known component", c.Name)
 			}
 		}
+	}
+
+	// Validate that cnv-mtv-integrations is not enabled when disableHubSelfManagement is true
+	if err := validateMTVAndSelfManagement(r); err != nil {
+		return warnings, err
 	}
 
 	// Block changing localClusterName if ManagdCluster with label `local-cluster = true` exists
@@ -377,6 +387,20 @@ func ValidatingWebhook(namespace string) *admissionregistration.ValidatingWebhoo
 			},
 		},
 	}
+}
+
+// validateMTVAndSelfManagement returns an error if cnv-mtv-integrations is enabled
+// while disableHubSelfManagement is true, as this combination is unsupported
+// and will cause the MCH to be stuck in Pending.
+func validateMTVAndSelfManagement(r *MultiClusterHub) error {
+	if r.Spec.DisableHubSelfManagement && r.Enabled(MTVIntegrations) {
+		return fmt.Errorf(
+			"cannot enable %s while disableHubSelfManagement is true; "+
+				"the local-cluster must be enabled for MTV integrations to function",
+			MTVIntegrations,
+		)
+	}
+	return nil
 }
 
 func contains(list []string, s string) bool {

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -378,6 +378,78 @@ var _ = Describe("Multiclusterhub webhook", func() {
 			Expect(validateOLMAnnotations(ctx, mch)).To(Succeed())
 		})
 	})
+
+	Context("MTV and self-management validation", func() {
+		It("Should return error when MTV is enabled and disableHubSelfManagement is true", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mtv-selfmgmt",
+					Namespace: "default",
+				},
+				Spec: MultiClusterHubSpec{
+					DisableHubSelfManagement: true,
+					Overrides: &Overrides{
+						Components: []ComponentConfig{
+							{Name: MTVIntegrations, Enabled: true},
+						},
+					},
+				},
+			}
+			err := validateMTVAndSelfManagement(mch)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(MTVIntegrations))
+			Expect(err.Error()).To(ContainSubstring("disableHubSelfManagement"))
+		})
+
+		It("Should return nil when MTV is enabled and disableHubSelfManagement is false", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mtv-ok",
+					Namespace: "default",
+				},
+				Spec: MultiClusterHubSpec{
+					DisableHubSelfManagement: false,
+					Overrides: &Overrides{
+						Components: []ComponentConfig{
+							{Name: MTVIntegrations, Enabled: true},
+						},
+					},
+				},
+			}
+			Expect(validateMTVAndSelfManagement(mch)).To(Succeed())
+		})
+
+		It("Should return nil when disableHubSelfManagement is true but MTV is not enabled", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-selfmgmt-no-mtv",
+					Namespace: "default",
+				},
+				Spec: MultiClusterHubSpec{
+					DisableHubSelfManagement: true,
+				},
+			}
+			Expect(validateMTVAndSelfManagement(mch)).To(Succeed())
+		})
+
+		It("Should return nil when MTV is explicitly disabled and disableHubSelfManagement is true", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mtv-disabled-selfmgmt",
+					Namespace: "default",
+				},
+				Spec: MultiClusterHubSpec{
+					DisableHubSelfManagement: true,
+					Overrides: &Overrides{
+						Components: []ComponentConfig{
+							{Name: MTVIntegrations, Enabled: false},
+						},
+					},
+				},
+			}
+			Expect(validateMTVAndSelfManagement(mch)).To(Succeed())
+		})
+	})
 })
 
 // re-defining the function here to avoid a import cycle

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -37,6 +37,29 @@ var _ = Describe("Multiclusterhub webhook", func() {
 			})
 		})
 
+		It("Should fail to create multiclusterhub with MTV enabled and local-cluster disabled", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-mtv-no-local", multiClusterHubName),
+					Namespace: "default",
+				},
+				Spec: MultiClusterHubSpec{
+					DisableHubSelfManagement: true,
+					Overrides: &Overrides{
+						Components: []ComponentConfig{
+							{
+								Name:    MTVIntegrations,
+								Enabled: true,
+							},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, mch)
+			Expect(err).To(HaveOccurred(), "MTV should not be enabled when disableHubSelfManagement is true")
+			Expect(err.Error()).To(ContainSubstring(MTVIntegrations))
+		})
+
 		It("Should fail to create multiclusterhub", func() {
 			By("because of invalid AvailabilityConfig", func() {
 				mch := &MultiClusterHub{
@@ -69,6 +92,25 @@ var _ = Describe("Multiclusterhub webhook", func() {
 				}
 				Expect(k8sClient.Create(ctx, mch)).NotTo(BeNil(), "Invalid components not allowed in config")
 			})
+		})
+
+		It("Should fail to update multiclusterhub to disable local-cluster when MTV is enabled", func() {
+			mch := &MultiClusterHub{}
+			Expect(k8sClient.Get(ctx,
+				types.NamespacedName{Name: multiClusterHubName, Namespace: "default"}, mch)).To(Succeed())
+
+			mch.Spec.DisableHubSelfManagement = true
+			mch.Spec.Overrides = &Overrides{
+				Components: []ComponentConfig{
+					{
+						Name:    MTVIntegrations,
+						Enabled: true,
+					},
+				},
+			}
+			err := k8sClient.Update(ctx, mch)
+			Expect(err).To(HaveOccurred(), "disabling local-cluster should be blocked when MTV is enabled")
+			Expect(err.Error()).To(ContainSubstring(MTVIntegrations))
 		})
 
 		It("Should fail to update multiclusterhub", func() {


### PR DESCRIPTION

## Summary

- Adds webhook validation in both `ValidateCreate` and `ValidateUpdate` to prevent enabling `cnv-mtv-integrations` while `disableHubSelfManagement` is true, and vice versa. This combination is unsupported and causes the MCH to be stuck in Pending.

## Testing

- Unit tests: 30/30 passing (2 new tests added)
- Smoketested on live OCP 4.19 cluster with custom ACM 2.17 catalog:
  - Enabling MTV + disabling local-cluster simultaneously → **blocked**
  - Enabling MTV first, then disabling local-cluster → **blocked**
  - Enabling MTV with local-cluster still on → **allowed**

Fixes: https://issues.redhat.com/browse/ACM-33704


🐨 Generated with Crush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented validation to prevent enabling MTV Integrations when hub self-management is disabled, ensuring the system rejects incompatible configurations during cluster creation and updates.

* **Tests**
  * Added test cases validating MTV integration constraints are properly enforced when attempting to disable hub self-management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->