### PR TITLE
[ACM-34942] Fix template rendering for migrated component deletion

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -54,8 +54,16 @@ type CacheSpec struct {
 	TemplateOverridesCM string
 }
 
-var migratedComponentDeployments = map[string]string{
-	operatorv1.ClusterPermission: "cluster-permission",
+type MigratedComponentInfo struct {
+	DeploymentName string
+	ImageKey       string
+}
+
+var migratedComponentDeployments = map[string]MigratedComponentInfo{
+	operatorv1.ClusterPermission: {
+		DeploymentName: "cluster-permission",
+		ImageKey:       "cluster_permission",
+	},
 }
 
 /*

--- a/controllers/components.go
+++ b/controllers/components.go
@@ -267,8 +267,21 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 		}
 	}
 
+	// For migrated components, inject dummy image to allow template rendering for deletion
+	imageOverrides := cachespec.ImageOverrides
+	if migratedInfo, isMigrated := migratedComponentDeployments[component]; isMigrated {
+		// Create a copy to avoid modifying the original cache
+		imageOverrides = make(map[string]string)
+		for k, v := range cachespec.ImageOverrides {
+			imageOverrides[k] = v
+		}
+		// Inject dummy image for render (actual image doesn't matter since we're deleting)
+		imageOverrides[migratedInfo.ImageKey] = "quay.io/stolostron/placeholder:deletion"
+		r.Log.Info("Injected dummy image for migrated component deletion", "Component", component, "ImageKey", migratedInfo.ImageKey)
+	}
+
 	// Renders all templates from charts
-	templates, errs := renderer.RenderChart(chartLocation, m, cachespec.ImageOverrides, cachespec.TemplateOverrides,
+	templates, errs := renderer.RenderChart(chartLocation, m, imageOverrides, cachespec.TemplateOverrides,
 		isSTSEnabled)
 
 	if len(errs) > 0 {

--- a/controllers/deletetemplate_test.go
+++ b/controllers/deletetemplate_test.go
@@ -274,10 +274,14 @@ func TestPruneMigratedComponents_RespectsDeleteRequeue(t *testing.T) {
 	// Create a deployment that will be stuck terminating
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "cluster-permission-deploy",
+			Name:              "cluster-permission",
 			Namespace:         "open-cluster-management",
 			DeletionTimestamp: &metav1.Time{Time: time.Now()},
 			Finalizers:        []string{"stuck-finalizer"},
+			Labels: map[string]string{
+				"installer.name":      "test-mch",
+				"installer.namespace": "open-cluster-management",
+			},
 		},
 	}
 
@@ -291,7 +295,9 @@ func TestPruneMigratedComponents_RespectsDeleteRequeue(t *testing.T) {
 		Client: cl,
 		Log:    ctrl.Log.WithName("test"),
 		CacheSpec: CacheSpec{
-			ImageOverrides:    map[string]string{},
+			ImageOverrides: map[string]string{
+				"cluster_permission": "quay.io/stolostron/cluster-permission:test",
+			},
 			TemplateOverrides: map[string]string{},
 		},
 	}


### PR DESCRIPTION
# Description

Fix template rendering failure during migrated component deletion. When cluster-permission migrated from MCH to MCE, deletion of old MCH namespace resources fails because image key removed from CSV but template still references it.

## Related Issue

https://redhat.atlassian.net/browse/ACM-34942

## Changes Made

**Root Cause:**
- `ensureNoComponent` renders templates to discover resources for deletion
- cluster-permission migrated to MCE in 2.17
- Image key `cluster_permission` removed from CSV (commit a0affa76)
- Template references `.Values.global.imageOverrides.cluster_permission`
- Key missing from map → render fails with "map has no entry for key" → deletion blocked

**Solution:**
- Add `MigratedComponentInfo` struct tracking deployment name and image key
- Update `migratedComponentDeployments` map to include image keys
- Inject dummy image into imageOverrides copy before `RenderChart` for migrated components
- Actual image value doesn't matter during deletion - only need valid reference to satisfy template

**Files Changed:**
- `controllers/common.go`: Added struct and updated map
- `controllers/components.go`: Inject dummy image before render for migrated components

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Error fixed:
```
template: cluster-permission/templates/cluster-permission.yaml:52:26: executing "cluster-permission/templates/cluster-permission.yaml" at <.Values.global.imageOverrides.cluster_permission>: map has no entry for key "cluster_permission"
```

Pattern reusable for future component migrations - just add entry to `migratedComponentDeployments` map with image key.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.