### PR TITLE
Remove unused OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR env var

### DIFF
--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -1960,8 +1960,6 @@ spec:
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-subscription-rhel9:latest
                 - name: OPERAND_IMAGE_MULTICLUSTER_ROLE_ASSIGNMENT
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-role-assignment-rhel9:latest
-                - name: OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator-rhel9:latest
                 - name: OPERAND_IMAGE_NODE_EXPORTER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
                 - name: OPERAND_IMAGE_OBO_PROMETHEUS_RHEL9_OPERATOR


### PR DESCRIPTION
# Description

Removes the unused OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR environment variable from the CSV that was causing bundle generation failures.

## Related Issue

Fixes acm-operator-bundle CI failure in PR stolostron/acm-operator-bundle#3474

## Changes Made

- Removed OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR env var from bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml

## Root Cause Analysis

The operator does not reference its own image at runtime:
- No Jobs/Pods are spawned using the operator's image
- Grepped entire codebase - zero usage of OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR
- Operator deployment image already specified in CSV spec.install.spec.deployments
- image-references retains the operator image for ART ImageStream builds (correct)

The env var was added in PR #4248 but serves no purpose. When bundle generation tried to map this placeholder image reference to a SHA digest, it failed because there's no mapping defined for it (and shouldn't be one for an unused reference).

## Testing

Bundle generation in acm-operator-bundle should now succeed once this merges.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have rebased my branch on top of the latest release-2.16 branch.

## Reviewers

/cc @smithbw88