### PR TITLE
fix(bundle): remove operator self-reference from image-references

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -115,10 +115,6 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-role-assignment-rhel9:latest
-  - name: multiclusterhub-operator-rhel9
-    from:
-      kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator-rhel9:latest
   - name: node-exporter-rhel9
     from:
       kind: DockerImage

--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -1960,8 +1960,6 @@ spec:
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-subscription-rhel9:latest
                 - name: OPERAND_IMAGE_MULTICLUSTER_ROLE_ASSIGNMENT
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-role-assignment-rhel9:latest
-                - name: OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator-rhel9:latest
                 - name: OPERAND_IMAGE_NODE_EXPORTER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
                 - name: OPERAND_IMAGE_OBO_PROMETHEUS_RHEL9_OPERATOR


### PR DESCRIPTION
The bundle's image-references and CSV env vars included multiclusterhub-operator-rhel9 as an operand image, but the operator should not reference itself in its own bundle. Doozer has no image key mapping for the parent operator in the bundle context, causing:

  Error: No image key mapping for: .../multiclusterhub-operator-rhel9:latest

The operator container image is already defined in the CSV deployment spec (line 2041) and gets pinned by doozer's update-csv process separately from the operand images in image-references.

Removes:
- multiclusterhub-operator-rhel9 entry from bundle/image-references
- OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR env var from the CSV template

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
