### PR TITLE
fix(bundle): Remove -rhel9 suffix from operator image placeholder

### DIFF
--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -2036,7 +2036,7 @@ spec:
                   value: 2.16.2
                 - name: OPERATOR_PACKAGE
                   value: advanced-cluster-management
-                image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator-rhel9:latest
+                image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
## Problem

Bundle generation fails with:
```
Error: No image key mapping for: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator-rhel9:latest
```

## Root Cause

CSV uses `multiclusterhub-operator-rhel9` as operator container image, but binding script expects `multiclusterhub-operator` to match existing mapping:
```bash
image_key_mappings+=("multiclusterhub-operator:multiclusterhub_operator")
```

## Solution

Change CSV operator image placeholder from:
```
multiclusterhub-operator-rhel9
```
to:
```
multiclusterhub-operator
```

Binding script will map this to final published name `multiclusterhub-rhel9` via config:
```json
{
  "image-key": "multiclusterhub_operator",
  "publish-name": "multiclusterhub-rhel9"
}
```

## Testing

After merge, snapshot PR workflow should succeed in stolostron/acm-operator-bundle.

Fixes: stolostron/acm-operator-bundle#3485