### PR TITLE
fix(bundle): Remove hardcoded OPERATOR_VERSION/OPERATOR_PACKAGE env vars

### DIFF
--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -2032,10 +2032,6 @@ spec:
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/ose_kube_rbac_proxy:latest
                 - name: OPERAND_IMAGE_VOLSYNC
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync:latest
-                - name: OPERATOR_VERSION
-                  value: 2.16.2
-                - name: OPERATOR_PACKAGE
-                  value: advanced-cluster-management
                 image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
## Problem

Bundle generation fails with:
```
Error: Deployment/container multiclusterhub-operator:multiclusterhub-operator already defines env var OPERATOR_VERSION
```

## Root Cause

CSV hardcodes:
```yaml
- name: OPERATOR_VERSION
  value: 2.16.2
- name: OPERATOR_PACKAGE
  value: advanced-cluster-management
```

But binding script (`create-bound-bundle.py`) expects to inject these dynamically:
```python
injected_env_vars = {
   "OPERATOR_VERSION": csv_vers,
   "OPERATOR_PACKAGE": csv_pkg
}
if ev_name not in env_var_map:
   # inject
else:
   die("already defines env var")
```

## Solution

Remove hardcoded env vars from CSV. Let binding script inject with correct bundle version.

## Testing

After merge, snapshot PR workflow should succeed.

Follow-up to #4255