### PR TITLE
HYPBLD-847 - fix(bundle): Rename obo-prometheus-rhel9-operator to prometheus-operator-rhel9

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -119,10 +119,10 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
-  - name: obo-prometheus-rhel9-operator
+  - name: prometheus-operator-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/obo-prometheus-rhel9-operator:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-operator-rhel9:latest
   - name: observatorium-rhel9
     from:
       kind: DockerImage
@@ -143,10 +143,6 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-config-reloader-rhel9:latest
-  - name: prometheus-operator-rhel9
-    from:
-      kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-operator-rhel9:latest
   - name: rbac-query-proxy-rhel9
     from:
       kind: DockerImage

--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -1963,7 +1963,7 @@ spec:
                 - name: OPERAND_IMAGE_NODE_EXPORTER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
                 - name: OPERAND_IMAGE_OBO_PROMETHEUS_RHEL9_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/obo-prometheus-rhel9-operator:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-operator-rhel9:latest
                 - name: OPERAND_IMAGE_OBSERVATORIUM
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
                 - name: OPERAND_IMAGE_OBSERVATORIUM_OPERATOR
@@ -2136,7 +2136,7 @@ spec:
   - name: node_exporter
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
   - name: obo_prometheus_rhel9_operator
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/obo-prometheus-rhel9-operator:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-operator-rhel9:latest
   - name: observatorium
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
   - name: observatorium_operator


### PR DESCRIPTION
The image-references entry "obo-prometheus-rhel9-operator" does not match any component in ocp-build-data. The correct delivery name is "prometheus-operator-rhel9" (from images/prometheus-operator.yml).

The "obo-" prefixed name originated from the acm-manifest-gen-config.json publish-name field, which was incorrectly used as a fallback when no matching ocp-build-data component could be found during generation.

- Rename the entry in image-references to prometheus-operator-rhel9
- Remove the resulting duplicate (prometheus_operator already mapped here)
- Update placeholder refs in the CSV template

Ref: HYPBLD-847