### PR TITLE
HYPBLD-847 - fix(bundle): Remove version template vars from art.yaml

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,12 +1,4 @@
 ---
-updates:
-- file: "manifests/advanced-cluster-management.clusterserviceversion.yaml"
-  update_list:
-  - search: "advanced-cluster-management.v2.16.0"
-    replacement: "advanced-cluster-management.v{version}"
-  - search: "version: 2.16.0"
-    replacement: "version: {version}"
-
 external-images:
 - name: configmap_reloader
   search: "image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest"


### PR DESCRIPTION
Doozer processes the entire art.yaml as a Python format string via str.format(). The {version} placeholders in the update_list replacement fields cause a KeyError because doozer does not provide a 'version' variable in its format arguments.

CSV version fields (spec.version, metadata.name) are handled automatically by doozer's built-in update-csv mechanism configured in ocp-build-data, so explicit version replacements in art.yaml are not needed.

Ref: HYPBLD-847