### PR TITLE
fix(bundle): Add multiclusterhub-operator to image-references

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -91,6 +91,10 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
+  - name: multiclusterhub-operator
+    from:
+      kind: DockerImage
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
   - name: multicluster-observability-addon-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
## Summary

- Add the `multiclusterhub-operator` entry to `bundle/image-references` so the ART rebaser replaces the operator's self-reference in the CSV during the operator build.

## Problem

The CSV contains a self-reference to the operator image:
```
image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
```

The ART rebaser (`_replace_internal_image_refs`) only replaces pullspecs for images listed in the `image-references` file. Since `multiclusterhub-operator` was not listed there, the `:latest` tag survived the rebase unchanged.

The downstream Konflux bundle build then tries to resolve `multiclusterhub-operator-latest` in Quay, which doesn't exist, causing:
```
error: image "quay.io/.../art-images:multiclusterhub-operator-latest" not found: manifest unknown
```

## Fix

Add the operator to `image-references` so the rebaser replaces the self-reference with a proper versioned tag during the operator build. The bundle build will then find the image under the correct versioned tag.

## Related

- openshift-eng/ocp-build-data#11536 (drops `-rhel9` suffix from the operator name to match the CSV)
- Jenkins build failure: `aos-cd-builds/build/olm_bundle_konflux #25499`

Made with [Cursor](https://cursor.com)