### PR TITLE
Bump package.yaml currentCSV to v2.16.3

### DIFF
--- a/bundle/acm-operator.package.yaml
+++ b/bundle/acm-operator.package.yaml
@@ -2,5 +2,5 @@
 packageName: advanced-cluster-management
 channels:
 - name: release-2.16
-  currentCSV: advanced-cluster-management.v2.16.0
+  currentCSV: advanced-cluster-management.v2.16.3
 defaultChannel: release-2.16


### PR DESCRIPTION
Matches the CSV version bump in PR #4322. The FBC build fails with stranded bundle v2.16.0 because the package.yaml still points to it as the channel head.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
