### PR TITLE
chore: disable release-2.12 automation workflows

### DIFF
--- a/.github/workflows/regenerate-bundles.yml
+++ b/.github/workflows/regenerate-bundles.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.25"]
-        branch: ['main', 'release-2.11', 'release-2.12', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
+        branch: ['main', 'release-2.11', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/resync-owner-file.yml
+++ b/.github/workflows/resync-owner-file.yml
@@ -25,7 +25,6 @@ jobs:
             'release-2.15',
             'release-2.14',
             'release-2.13',
-            'release-2.12',
             'release-2.11',
         ]
 

--- a/.github/workflows/update-pregenerated-charts.yml
+++ b/.github/workflows/update-pregenerated-charts.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.25"]
-        branch: ['main', 'release-2.11', 'release-2.12', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
+        branch: ['main', 'release-2.11', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
# Description

Removes release-2.12 from automated GitHub Actions workflows as the branch has reached end-of-life (EOL).

## Related Issue

N/A

## Changes Made

Removed `release-2.12` from matrix configurations in:
- `.github/workflows/regenerate-bundles.yml`
- `.github/workflows/update-pregenerated-charts.yml`
- `.github/workflows/resync-owner-file.yml`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

release-2.12 has reached EOL. Automated workflows will no longer run for this branch.

## Reviewers

N/A

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)