### PR TITLE
Disable edge-manager-preview component in ACM 2.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Build the multiclusterhub-operator binary
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -191,8 +191,8 @@ func (r *MultiClusterHub) ValidateUpdate(old runtime.Object) (admission.Warnings
 			if !ValidComponent(c, MCHComponents) {
 				return nil, fmt.Errorf("invalid componentconfig: %s is not a known component", c.Name)
 			}
-			// Block enabling edge-manager-preview component
-			if c.Name == EdgeManagerPreview && c.Enabled {
+			// Block enabling edge-manager-preview component (allow if already enabled)
+			if c.Name == EdgeManagerPreview && c.Enabled && !oldObj.Enabled(EdgeManagerPreview) {
 				return nil, fmt.Errorf("the Edge Manager tech preview component is no longer supported as of ACM 2.13. " +
 					"It is disabled in ACM 2.14, remains available for installation only in ACM 2.15.0, " +
 					"and has been removed from ACM 2.15.1, ACM 2.16.0, and later releases")

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -191,7 +191,7 @@ func (r *MultiClusterHub) ValidateUpdate(old runtime.Object) (admission.Warnings
 				return nil, fmt.Errorf("invalid componentconfig: %s is not a known component", c.Name)
 			}
 			// Block enabling edge-manager-preview component (allow if already enabled)
-			if c.Name == EdgeManagerPreview && c.Enabled && !oldObj.Enabled(EdgeManagerPreview) {
+			if c.Name == EdgeManagerPreview && c.Enabled && !oldMCH.Enabled(EdgeManagerPreview) {
 				return nil, fmt.Errorf("Red Hat Edge Manager can now be installed directly from the OpenShift operator hub. " +
 					"The tech preview versions included with ACM are no longer supported and cannot be enabled")
 			}

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -130,6 +130,12 @@ func (r *MultiClusterHub) ValidateCreate() (admission.Warnings, error) {
 			if !ValidComponent(c, MCHComponents) {
 				return nil, fmt.Errorf("invalid component config: %s is not a known component", c.Name)
 			}
+			// Block edge-manager-preview component
+			if c.Name == EdgeManagerPreview {
+				return nil, fmt.Errorf("the Edge Manager tech preview component is no longer supported as of ACM 2.13. " +
+					"It is disabled in ACM 2.14, remains available for installation only in ACM 2.15.0, " +
+					"and has been removed from ACM 2.15.1, ACM 2.16.0, and later releases")
+			}
 		}
 	}
 
@@ -184,6 +190,12 @@ func (r *MultiClusterHub) ValidateUpdate(old runtime.Object) (admission.Warnings
 		for _, c := range r.Spec.Overrides.Components {
 			if !ValidComponent(c, MCHComponents) {
 				return nil, fmt.Errorf("invalid componentconfig: %s is not a known component", c.Name)
+			}
+			// Block enabling edge-manager-preview component
+			if c.Name == EdgeManagerPreview && c.Enabled {
+				return nil, fmt.Errorf("the Edge Manager tech preview component is no longer supported as of ACM 2.13. " +
+					"It is disabled in ACM 2.14, remains available for installation only in ACM 2.15.0, " +
+					"and has been removed from ACM 2.15.1, ACM 2.16.0, and later releases")
 			}
 		}
 	}

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -132,9 +132,8 @@ func (r *MultiClusterHub) ValidateCreate() (admission.Warnings, error) {
 			}
 			// Block edge-manager-preview component
 			if c.Name == EdgeManagerPreview {
-				return nil, fmt.Errorf("the Edge Manager tech preview component is no longer supported as of ACM 2.13. " +
-					"It is disabled in ACM 2.14, remains available for installation only in ACM 2.15.0, " +
-					"and has been removed from ACM 2.15.1, ACM 2.16.0, and later releases")
+				return nil, fmt.Errorf("Red Hat Edge Manager can now be installed directly from the OpenShift operator hub. " +
+					"The tech preview versions included with ACM are no longer supported and cannot be enabled")
 			}
 		}
 	}
@@ -193,9 +192,8 @@ func (r *MultiClusterHub) ValidateUpdate(old runtime.Object) (admission.Warnings
 			}
 			// Block enabling edge-manager-preview component (allow if already enabled)
 			if c.Name == EdgeManagerPreview && c.Enabled && !oldObj.Enabled(EdgeManagerPreview) {
-				return nil, fmt.Errorf("the Edge Manager tech preview component is no longer supported as of ACM 2.13. " +
-					"It is disabled in ACM 2.14, remains available for installation only in ACM 2.15.0, " +
-					"and has been removed from ACM 2.15.1, ACM 2.16.0, and later releases")
+				return nil, fmt.Errorf("Red Hat Edge Manager can now be installed directly from the OpenShift operator hub. " +
+					"The tech preview versions included with ACM are no longer supported and cannot be enabled")
 			}
 		}
 	}

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -69,6 +69,25 @@ var _ = Describe("Multiclusterhub webhook", func() {
 				}
 				Expect(k8sClient.Create(ctx, mch)).NotTo(BeNil(), "Invalid components not allowed in config")
 			})
+			By("because edge-manager-preview is not supported", func() {
+				mch := &MultiClusterHub{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-edge", multiClusterHubName),
+						Namespace: "default",
+					},
+					Spec: MultiClusterHubSpec{
+						Overrides: &Overrides{
+							Components: []ComponentConfig{
+								{
+									Name:    EdgeManagerPreview,
+									Enabled: true,
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, mch)).NotTo(BeNil(), "edge-manager-preview component should be blocked")
+			})
 		})
 
 		It("Should fail to update multiclusterhub", func() {

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -194,40 +194,6 @@ var _ = Describe("Multiclusterhub webhook", func() {
 			})
 		})
 
-		It("Should auto-disable edge-manager-preview on update", func() {
-			By("creating MCH with disabled edge-manager-preview", func() {
-				mch := &MultiClusterHub{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("%s-autodisable", multiClusterHubName),
-						Namespace: "default",
-					},
-					Spec: MultiClusterHubSpec{
-						Overrides: &Overrides{
-							Components: []ComponentConfig{
-								{
-									Name:    EdgeManagerPreview,
-									Enabled: false,
-								},
-							},
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, mch)).To(Succeed())
-
-				// Verify it stays disabled
-				Expect(k8sClient.Get(ctx,
-					types.NamespacedName{Name: mch.Name, Namespace: "default"}, mch)).To(Succeed())
-				for _, c := range mch.Spec.Overrides.Components {
-					if c.Name == EdgeManagerPreview {
-						Expect(c.Enabled).To(BeFalse(), "edge-manager-preview should remain disabled")
-					}
-				}
-
-				// Clean up
-				Expect(k8sClient.Delete(ctx, mch)).To(BeNil())
-			})
-		})
-
 		It("Should delete multiclusterhub", func() {
 			mch := &MultiClusterHub{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterHubName, Namespace: "default"}, mch)).To(Succeed())

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -154,6 +154,80 @@ var _ = Describe("Multiclusterhub webhook", func() {
 			})
 		})
 
+		It("Should block edge-manager-preview on create", func() {
+			By("because edge-manager-preview is not supported", func() {
+				mch := &MultiClusterHub{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-edge-test", multiClusterHubName),
+						Namespace: "default",
+					},
+					Spec: MultiClusterHubSpec{
+						Overrides: &Overrides{
+							Components: []ComponentConfig{
+								{
+									Name:    EdgeManagerPreview,
+									Enabled: true,
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, mch)).NotTo(BeNil(), "edge-manager-preview component should be blocked")
+			})
+		})
+
+		It("Should block enabling edge-manager-preview on update", func() {
+			mch := &MultiClusterHub{}
+			By("rejecting attempts to enable edge-manager-preview", func() {
+				Expect(k8sClient.Get(ctx,
+					types.NamespacedName{Name: multiClusterHubName, Namespace: "default"}, mch)).To(Succeed())
+
+				mch.Spec.Overrides = &Overrides{
+					Components: []ComponentConfig{
+						{
+							Name:    EdgeManagerPreview,
+							Enabled: true,
+						},
+					},
+				}
+				Expect(k8sClient.Update(ctx, mch)).NotTo(BeNil(), "edge-manager-preview cannot be enabled")
+			})
+		})
+
+		It("Should auto-disable edge-manager-preview on update", func() {
+			By("creating MCH with disabled edge-manager-preview", func() {
+				mch := &MultiClusterHub{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-autodisable", multiClusterHubName),
+						Namespace: "default",
+					},
+					Spec: MultiClusterHubSpec{
+						Overrides: &Overrides{
+							Components: []ComponentConfig{
+								{
+									Name:    EdgeManagerPreview,
+									Enabled: false,
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, mch)).To(Succeed())
+
+				// Verify it stays disabled
+				Expect(k8sClient.Get(ctx,
+					types.NamespacedName{Name: mch.Name, Namespace: "default"}, mch)).To(Succeed())
+				for _, c := range mch.Spec.Overrides.Components {
+					if c.Name == EdgeManagerPreview {
+						Expect(c.Enabled).To(BeFalse(), "edge-manager-preview should remain disabled")
+					}
+				}
+
+				// Clean up
+				Expect(k8sClient.Delete(ctx, mch)).To(BeNil())
+			})
+		})
+
 		It("Should delete multiclusterhub", func() {
 			mch := &MultiClusterHub{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: multiClusterHubName, Namespace: "default"}, mch)).To(Succeed())

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -22,6 +22,28 @@ var (
 var _ = Describe("Multiclusterhub webhook", func() {
 
 	Context("Creating a Multiclusterhub", func() {
+		It("Should block edge-manager-preview on create", func() {
+			By("because edge-manager-preview is not supported", func() {
+				mch := &MultiClusterHub{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-edge-manager-block",
+						Namespace: "default",
+					},
+					Spec: MultiClusterHubSpec{
+						Overrides: &Overrides{
+							Components: []ComponentConfig{
+								{
+									Name:    EdgeManagerPreview,
+									Enabled: true,
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, mch)).NotTo(BeNil(), "edge-manager-preview component should be blocked")
+			})
+		})
+
 		It("Should successfully create multiclusterhub", func() {
 			By("by creating a new standalone Multiclusterhub resource", func() {
 				mch := &MultiClusterHub{

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -159,6 +159,18 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Check if any deprecated fields are present within the multiClusterHub spec.
 	r.CheckDeprecatedFieldUsage(multiClusterHub)
 
+	// Auto-disable edge-manager-preview if enabled
+	if multiClusterHub.Enabled(operatorv1.EdgeManagerPreview) {
+		r.Log.Info("Auto-disabling edge-manager-preview component")
+		multiClusterHub.Disable(operatorv1.EdgeManagerPreview)
+		if err := r.Client.Update(ctx, multiClusterHub); err != nil {
+			r.Log.Error(err, "Failed to disable edge-manager-preview")
+			return ctrl.Result{}, err
+		}
+		// Requeue to process the updated spec
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	// Check to see if upgradeable
 	upgrade, err := r.setOperatorUpgradeableStatus(ctx, multiClusterHub)
 	if err != nil {

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2555,7 +2555,7 @@ func Test_AutoDisableEdgeManagerPreview(t *testing.T) {
 	r := &MultiClusterHubReconciler{
 		Client: client,
 		Scheme: scheme,
-		Log:    log.Log.WithName("test"),
+		Log:    ctrl.Log.WithName("test"),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -51,6 +51,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2527,3 +2527,59 @@ func Test_detectContainerChanges(t *testing.T) {
 		})
 	}
 }
+
+func Test_AutoDisableEdgeManagerPreview(t *testing.T) {
+	ctx := context.Background()
+	mch := &operatorv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch",
+			Namespace: "test-ns",
+		},
+		Spec: operatorv1.MultiClusterHubSpec{
+			Overrides: &operatorv1.Overrides{
+				Components: []operatorv1.ComponentConfig{
+					{
+						Name:    operatorv1.EdgeManagerPreview,
+						Enabled: true,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = operatorv1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mch).Build()
+
+	r := &MultiClusterHubReconciler{
+		Client: client,
+		Scheme: scheme,
+		Log:    log.Log.WithName("test"),
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      mch.Name,
+			Namespace: mch.Namespace,
+		},
+	})
+
+	if err != nil {
+		t.Errorf("Reconcile returned error: %v", err)
+	}
+
+	if !result.Requeue {
+		t.Errorf("Expected Requeue=true, got Requeue=false")
+	}
+
+	// Verify edge-manager-preview was disabled
+	updatedMCH := &operatorv1.MultiClusterHub{}
+	if err := client.Get(ctx, types.NamespacedName{Name: mch.Name, Namespace: mch.Namespace}, updatedMCH); err != nil {
+		t.Fatalf("Failed to get updated MCH: %v", err)
+	}
+
+	if updatedMCH.Enabled(operatorv1.EdgeManagerPreview) {
+		t.Errorf("Expected edge-manager-preview to be disabled, but it is still enabled")
+	}
+}


### PR DESCRIPTION
# Description

Blocks edge-manager-preview component in ACM 2.14 via webhook validation and controller auto-disable. The version bundled with ACM is incompatible and no longer supported.

## Related Issue

Related to edge-manager deprecation roadmap across ACM 2.13-2.16.

## Changes Made

- **ValidateCreate**: Reject MCH creation attempts with edge-manager-preview component
- **ValidateUpdate**: Reject attempts to enable edge-manager-preview component (disabled→enabled transition only)
- **Controller**: Auto-disable edge-manager-preview if found enabled on reconcile
- **Tests**: Added 3 webhook test cases covering create/update blocking scenarios
- **Dockerfile**: Updated Go 1.24 → 1.25 to match go.mod v1.25.8 requirement

Error message:
> Red Hat Edge Manager can now be installed directly from the OpenShift operator hub. The tech preview versions included with ACM are no longer supported and cannot be enabled

## Screenshots (if applicable)

N/A - webhook validation logic

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Identical changes to 2.13 PR. Edge-manager-preview remains in default disabled components list.

Controller handles existing installations: reconcile detects enabled=true, sets enabled=false, updates MCH.

## Reviewers

/cc @reviewer1 @reviewer2

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.