### PR TITLE
[WIP] Add dynamic-scoring-framework to multiclusterhub operator.

### DIFF
--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/Chart.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: dynamic-scoring-framework
+description: A Helm chart for Open Cluster Management Dynamic Scoring Framework Addon
+category: "Development"
+keywords:
+  - acm
+  - addon-scoring
+type: application
+version: 5.0.0
+appVersion: 5.0.0
+verified: "RHACM"

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-clusterrole.yaml
@@ -1,0 +1,177 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  verbs:
+  - approve
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - manifestworks
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - watch
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - clustermanagementaddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - clustermanagementaddons/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - clustermanagementaddons
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - addondeploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - addonplacementscores
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - addonplacementscores/status
+  verbs:
+  - update
+  - patch

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+subjects:
+- kind: ServiceAccount
+  name: dynamic-scoring-addon-sa
+  namespace: '{{ .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-config-aarch64-addondeploymentconfig.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-config-aarch64-addondeploymentconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: dynamic-scoring-addon-config-aarch64
+  namespace: '{{ .Values.global.namespace }}'
+spec:
+  agentInstallNamespace: dynamic-scoring
+  customizedVariables:
+  - name: Image
+    value: quay.io/open-cluster-management/dynamic-scoring-addon:latest-aarch64
+  - name: ImagePullSecrets
+    value: '["hub-registry-secret"]'

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-config-addondeploymentconfig.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-config-addondeploymentconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: dynamic-scoring-addon-config
+  namespace: '{{ .Values.global.namespace }}'
+spec:
+  agentInstallNamespace: dynamic-scoring
+  customizedVariables:
+  - name: Image
+    value: quay.io/open-cluster-management/dynamic-scoring-addon:latest
+  - name: ImagePullSecrets
+    value: '["hub-registry-secret"]'

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-controller-deployment.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-controller-deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dynamic-scoring-addon-controller
+  name: dynamic-scoring-addon-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dynamic-scoring-addon-controller
+  template:
+    metadata:
+      labels:
+        app: dynamic-scoring-addon-controller
+        ocm-antiaffinity-selector: dynamic-scoring-addon-controller
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - dynamic-scoring-addon-controller
+              topologyKey: topology.kubernetes.io/zone
+            weight: 70
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - dynamic-scoring-addon-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 35
+      containers:
+      - args:
+        - /dynamic-scoring-addon
+        - controller
+        env:
+{{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+{{- end }}
+        image: '{{ .Values.global.imageOverrides.dynamic_scoring_addon }}'
+        imagePullPolicy: '{{ .Values.global.pullPolicy }}'
+        name: dynamic-scoring-addon-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts: []
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+{{- if .Values.global.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.global.pullSecret }}
+{{- end }}
+{{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      securityContext:
+        runAsNonRoot: true
+{{- if .Values.global.deployOnOCP }}
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
+{{- end }}
+      serviceAccountName: dynamic-scoring-addon-sa
+{{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
+{{- end }}
+      volumes: []

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-sa-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-addon-sa-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynamic-scoring-addon-sa

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-clustermanagementaddon.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-clustermanagementaddon.yaml
@@ -1,0 +1,28 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: dynamic-scoring-framework
+spec:
+  addOnMeta:
+    description: Centralized scoring logic management and distribution agent for Open Cluster Management multi-cluster environments
+    displayName: dynamic-scoring-framework
+  installStrategy:
+    placements:
+    - configs:
+      - group: addon.open-cluster-management.io
+        name: dynamic-scoring-addon-config
+        namespace: open-cluster-management
+        resource: addondeploymentconfigs
+      name: dynamic-scoring-placement
+      namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+    - configs:
+      - group: addon.open-cluster-management.io
+        name: dynamic-scoring-addon-config-aarch64
+        namespace: open-cluster-management
+        resource: addondeploymentconfigs
+      name: dynamic-scoring-placement-aarch64
+      namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+    type: Placements
+  supportedConfigs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-controller-deployment.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-controller-deployment.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+    control-plane: controller-manager
+  name: dynamic-scoring-framework-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dynamic-scoring-framework
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: dynamic-scoring-framework
+        control-plane: controller-manager
+        ocm-antiaffinity-selector: dynamic-scoring-framework-controller
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - dynamic-scoring-framework-controller
+              topologyKey: topology.kubernetes.io/zone
+            weight: 70
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - dynamic-scoring-framework-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 35
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        env:
+{{- if .Values.hubconfig.proxyConfigs }}
+        - name: HTTP_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+        - name: NO_PROXY
+          value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+{{- end }}
+        image: '{{ .Values.global.imageOverrides.dynamic_scoring_controller }}'
+        imagePullPolicy: '{{ .Values.global.pullPolicy }}'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports: []
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts: []
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+{{- if .Values.global.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.global.pullSecret }}
+{{- end }}
+{{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      securityContext:
+        runAsNonRoot: true
+{{- if .Values.global.deployOnOCP }}
+{{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }}
+        seccompProfile:
+          type: RuntimeDefault
+{{- end }}
+{{- end }}
+      serviceAccountName: dynamic-scoring-framework-controller
+      terminationGracePeriodSeconds: 10
+{{- with .Values.hubconfig.tolerations }}
+      tolerations:
+      {{- range . }}
+      - {{ if .Key }} key: {{ .Key }} {{- end }}
+        {{ if .Operator }} operator: {{ .Operator }} {{- end }}
+        {{ if .Value }} value: {{ .Value }} {{- end }}
+        {{ if .Effect }} effect: {{ .Effect }} {{- end }}
+        {{ if .TolerationSeconds }} tolerationSeconds: {{ .TolerationSeconds }} {{- end }}
+        {{- end }}
+{{- end }}
+      volumes: []

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-controller-metrics-service-service.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-controller-metrics-service-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+    control-plane: controller-manager
+  name: dynamic-scoring-framework-controller-metrics-service
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: dynamic-scoring-framework
+    control-plane: controller-manager

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-controller-serviceaccount.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-controller-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynamic-scoring-framework-controller

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscorer-admin-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscorer-admin-role-clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers
+  verbs:
+  - '*'
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers/status
+  verbs:
+  - get

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscorer-editor-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscorer-editor-role-clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers/status
+  verbs:
+  - get

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscorer-viewer-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscorer-viewer-role-clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers/status
+  verbs:
+  - get

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscoringconfig-admin-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscoringconfig-admin-role-clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscoringconfigs
+  verbs:
+  - '*'
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscoringconfigs/status
+  verbs:
+  - get

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscoringconfig-editor-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscoringconfig-editor-role-clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscoringconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscoringconfigs/status
+  verbs:
+  - get

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscoringconfig-viewer-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-dynamicscoringconfig-viewer-role-clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscoringconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscoringconfigs/status
+  verbs:
+  - get

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-leader-election-role-role.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-leader-election-role-role.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-leader-election-rolebinding-rolebinding.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-leader-election-rolebinding-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+subjects:
+- kind: ServiceAccount
+  name: dynamic-scoring-framework-controller
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-manager-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-manager-role-clusterrole.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers
+  - dynamicscoringconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers/finalizers
+  - dynamicscoringconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - dynamic-scoring.open-cluster-management.io
+  resources:
+  - dynamicscorers/status
+  - dynamicscoringconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - manifestworks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-manager-rolebinding-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-manager-rolebinding-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+subjects:
+- kind: ServiceAccount
+  name: dynamic-scoring-framework-controller
+  namespace: '{{ .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-metrics-auth-role-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-metrics-auth-role-clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-metrics-auth-rolebinding-clusterrolebinding.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-metrics-auth-rolebinding-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+subjects:
+- kind: ServiceAccount
+  name: dynamic-scoring-framework-controller
+  namespace: '{{ .Values.global.namespace }}'

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-metrics-reader-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-framework-metrics-reader-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-scoring-framework
+  name: '{{ .Values.org }}:{{ .Chart.Name }}:dynamic-scoring-framework'
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-placement-aarch64-placement.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-placement-aarch64-placement.yaml
@@ -1,0 +1,21 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: dynamic-scoring-placement-aarch64
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+spec:
+  clusterSets:
+  - global
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: cluster-arch
+          operator: In
+          values:
+          - aarch64
+  tolerations:
+  - key: cluster.open-cluster-management.io/unreachable
+    operator: Equal
+  - key: cluster.open-cluster-management.io/unavailable
+    operator: Equal

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-placement-placement.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/dynamic-scoring-placement-placement.yaml
@@ -1,0 +1,21 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: dynamic-scoring-placement
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+spec:
+  clusterSets:
+  - global
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+        - key: cluster-arch
+          operator: NotIn
+          values:
+          - aarch64
+  tolerations:
+  - key: cluster.open-cluster-management.io/unreachable
+    operator: Equal
+  - key: cluster.open-cluster-management.io/unavailable
+    operator: Equal

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/global-managedclustersetbinding.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/templates/global-managedclustersetbinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+spec:
+  clusterSet: global

--- a/pkg/templates/charts/toggle/dynamic-scoring-framework/values.yaml
+++ b/pkg/templates/charts/toggle/dynamic-scoring-framework/values.yaml
@@ -1,0 +1,19 @@
+global:
+  apiUrl: ''
+  baseDomain: ''
+  imageOverrides:
+    dynamic_scoring_addon: ''
+    dynamic_scoring_controller: ''
+  namespace: default
+  olmVersion: v0
+  pullSecret: null
+  templateOverrides: {}
+hubconfig:
+  clusterSTSEnabled: false
+  nodeSelector: null
+  ocpVersion: 4.12.0
+  probeConfig: null
+  proxyConfigs: {}
+  replicaCount: 1
+  tolerations: []
+org: open-cluster-management

--- a/pkg/templates/crds/dynamic-scoring-framework/dynamic-scoring.open-cluster-management.io_dynamicscorers.yaml
+++ b/pkg/templates/crds/dynamic-scoring-framework/dynamic-scoring.open-cluster-management.io_dynamicscorers.yaml
@@ -1,0 +1,320 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: dynamicscorers.dynamic-scoring.open-cluster-management.io
+spec:
+  group: dynamic-scoring.open-cluster-management.io
+  names:
+    kind: DynamicScorer
+    listKind: DynamicScorerList
+    plural: dynamicscorers
+    singular: dynamicscorer
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DynamicScorer is the Schema for the dynamicscorers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DynamicScorerSpec defines the desired state of DynamicScorer.
+            properties:
+              configSyncMode:
+                description: |-
+                  ConfigSyncMode determines how the Dynamic Scoring Agent synchronizes its configuration.
+                  Full mode means the agent fetches the complete configuration from the specified ConfigURL,
+                  while None mode indicates that no configuration synchronization is performed.
+                enum:
+                - Full
+                - None
+                type: string
+              configURL:
+                description: ConfigURL specifies the URL from which the Dynamic Scoring
+                  Agent fetches its configuration.
+                type: string
+              description:
+                description: Description provides a brief explanation of the Dynamic
+                  Scorer's purpose.
+                type: string
+              location:
+                description: |-
+                  Location indicates whether the Dynamic Scorer is hosted within the cluster (`Internal`)
+                  or outside the cluster (`External`).
+                enum:
+                - Internal
+                - External
+                type: string
+              scoreDestination:
+                description: |-
+                  ScoreDestination specifies where the Dynamic Scoring Agent should send the computed scores.
+                  For example, `AddOnPlacementScore` indicates the scores should be sent to the AddOnPlacementScore API.
+                enum:
+                - AddOnPlacementScore
+                - None
+                type: string
+              scoreDimensionFormat:
+                description: |-
+                  ScoreDimensionFormat defines the format of the score dimension used by the Dynamic Scoring Agent.
+                  Score dimensions categorize calculated scores by the AddOnPlacementScore value name.
+                  Some reserved placeholders are available.
+                  Example placeholders: ${cluster}, ${node}, ${device}, ${namespace}, ${app}, ${pod}, ${container}, ${meta}, ${scoreName}
+                  Example format: "resource-usage-${cluster}-${namespace}-${app}"
+                type: string
+              scoring:
+                description: Scoring defines the scoring API configuration for the
+                  Dynamic Scoring Agent to obtain scores.
+                properties:
+                  auth:
+                    description: |-
+                      Auth specifies the authentication configuration used by the Dynamic Scoring Agent to call the scoring API.
+                      This field is optional and ignored when empty.
+                    properties:
+                      tokenSecretRef:
+                        description: TokenSecretRef specifies the reference to the
+                          Kubernetes Secret that contains the authentication token.
+                        properties:
+                          key:
+                            description: The key within the Kubernetes Secret that
+                              contains the authentication token.
+                            type: string
+                          name:
+                            description: The name of the Kubernetes Secret that contains
+                              the authentication token.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    required:
+                    - tokenSecretRef
+                    type: object
+                  host:
+                    description: |-
+                      Host specifies the host used by the Dynamic Scoring Agent to call the scoring API.
+                      For example, if the agent calls the scoring API at https://your-scorer.local/score,
+                      https://your-scorer.local should be specified.
+                    type: string
+                  params:
+                    description: |-
+                      Params specifies the scoring parameters used by the Dynamic Scoring Agent to call the scoring API.
+                      e.g., interval
+                    properties:
+                      interval:
+                        description: |-
+                          The interval in seconds for scoring.
+                          Note: This interval is also used for config synchronization.
+                        type: integer
+                      name:
+                        description: The name of the score.
+                        type: string
+                    required:
+                    - interval
+                    - name
+                    type: object
+                  path:
+                    description: |-
+                      Path specifies the path used by the Dynamic Scoring Agent to call the scoring API.
+                      For example, if the agent calls the scoring API at https://your-scorer.local/score,
+                      /score should be specified.
+                      If not specified, the default value is `/score`.
+                    type: string
+                type: object
+              source:
+                description: Source defines the data source configuration for the
+                  Dynamic Scoring Agent to fetch metrics.
+                properties:
+                  auth:
+                    description: |-
+                      Auth specifies the authentication configuration used by the Dynamic Scoring Agent to retrieve the data source.
+                      This field is optional and ignored when empty or when `Type` is `None`.
+                    properties:
+                      tokenSecretRef:
+                        description: TokenSecretRef specifies the reference to the
+                          Kubernetes Secret that contains the authentication token.
+                        properties:
+                          key:
+                            description: The key within the Kubernetes Secret that
+                              contains the authentication token.
+                            type: string
+                          name:
+                            description: The name of the Kubernetes Secret that contains
+                              the authentication token.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    required:
+                    - tokenSecretRef
+                    type: object
+                  host:
+                    description: |-
+                      Host specifies the host used by the Dynamic Scoring Agent to retrieve data from the source.
+                      For example, if the agent retrieves data from https://your-prometheus.local/api/v1/query_range,
+                      https://your-prometheus.local should be specified.
+                      This field is ignored when `Type` is `None`.
+                    type: string
+                  params:
+                    description: |-
+                      Params specifies the query parameters used by the Dynamic Scoring Agent to query the data source.
+                      This field is ignored when `Type` is `None`.
+                    properties:
+                      query:
+                        description: |-
+                          The Prometheus query string.
+                          To query multiple time series, join queries with semicolons.
+                        type: string
+                      range:
+                        description: The time range in seconds for the query.
+                        type: integer
+                      step:
+                        description: The query resolution step width in seconds.
+                        type: integer
+                    required:
+                    - query
+                    - range
+                    - step
+                    type: object
+                  path:
+                    description: |-
+                      Path specifies the path used by the Dynamic Scoring Agent to retrieve data from the source.
+                      For example, if the agent retrieves data from https://your-prometheus.local/api/v1/query_range,
+                      /api/v1/query_range should be specified.
+                      This field is ignored when `Type` is `None`.
+                    type: string
+                  type:
+                    description: Type specifies the source type (e.g., Prometheus,
+                      None).
+                    enum:
+                    - Prometheus
+                    - None
+                    type: string
+                type: object
+            required:
+            - configSyncMode
+            - configURL
+            - description
+            type: object
+          status:
+            description: DynamicScorerStatus defines the observed state of DynamicScorer.
+            properties:
+              healthStatus:
+                description: ScorerHealthStatus represents the health status of a
+                  scorer.
+                enum:
+                - Active
+                - Inactive
+                - Unknown
+                type: string
+              lastSyncedConfig:
+                description: LastSyncedConfig holds the last configuration successfully
+                  synced by the Dynamic Scoring Agent.
+                properties:
+                  description:
+                    type: string
+                  name:
+                    type: string
+                  scoring:
+                    properties:
+                      host:
+                        description: |-
+                          The hostname or IP address of the scoring endpoint.
+                          e.g. `http://scoring-api.scoring.svc.cluster.local:8080`
+                        type: string
+                      params:
+                        properties:
+                          interval:
+                            description: |-
+                              The interval in seconds for scoring.
+                              Note: This interval is also used for config synchronization.
+                            type: integer
+                          name:
+                            description: The name of the score.
+                            type: string
+                        required:
+                        - interval
+                        - name
+                        type: object
+                      path:
+                        description: |-
+                          The API path of the scoring endpoint.
+                          e.g. `/api/v1/score`
+                        type: string
+                    required:
+                    - params
+                    - path
+                    type: object
+                  source:
+                    description: |-
+                      SourceConfig represents the source configuration.
+                      If the `Type` is `Prometheus`, the `Host` should be the Prometheus server URL.
+                    properties:
+                      host:
+                        description: |-
+                          The hostname or IP address of the source.
+                          e.g. `http://prometheus-server.monitoring.svc.cluster.local:9090`
+                        type: string
+                      params:
+                        properties:
+                          query:
+                            description: |-
+                              The Prometheus query string.
+                              To query multiple time series, join queries with semicolons.
+                            type: string
+                          range:
+                            description: The time range in seconds for the query.
+                            type: integer
+                          step:
+                            description: The query resolution step width in seconds.
+                            type: integer
+                        required:
+                        - query
+                        - range
+                        - step
+                        type: object
+                      path:
+                        description: |-
+                          The API path of the source.
+                          e.g. `/api/v1/query_range` for Prometheus
+                        type: string
+                      type:
+                        description: SourceType represents the type of the source.
+                        type: string
+                    required:
+                    - params
+                    - path
+                    type: object
+                required:
+                - description
+                - name
+                - scoring
+                - source
+                type: object
+            required:
+            - healthStatus
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/templates/crds/dynamic-scoring-framework/dynamic-scoring.open-cluster-management.io_dynamicscoringconfigs.yaml
+++ b/pkg/templates/crds/dynamic-scoring-framework/dynamic-scoring.open-cluster-management.io_dynamicscoringconfigs.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: dynamicscoringconfigs.dynamic-scoring.open-cluster-management.io
+spec:
+  group: dynamic-scoring.open-cluster-management.io
+  names:
+    kind: DynamicScoringConfig
+    listKind: DynamicScoringConfigList
+    plural: dynamicscoringconfigs
+    singular: dynamicscoringconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DynamicScoringConfig is the Schema for the dynamicscoringconfigs
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DynamicScoringConfigSpec defines the desired state of DynamicScoringConfig.
+            properties:
+              masks:
+                description: |-
+                  Masks defines a list of masks used to filter out unnecessary scores for specific clusters.
+                  For example, if a mask specifies a cluster name, only scores related to that cluster will be considered.
+                items:
+                  properties:
+                    clusterName:
+                      type: string
+                    scoreName:
+                      type: string
+                  required:
+                  - clusterName
+                  - scoreName
+                  type: object
+                type: array
+            type: object
+          status:
+            description: DynamicScoringConfigStatus defines the observed state of
+              DynamicScoringConfig.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Added dynamic-scoring-framework to multiclusterhub operator as helm component.

# Description

Dynamic scoring framework is a tech-preview feature targeted for ACM 5.0 and this PR is to add the initial installable helm chart which can be toggled on and off, off by default for ACM 5.0.

## Related Issue

Feature: https://redhat.atlassian.net/browse/ACM-30306
Epic: https://redhat.atlassian.net/browse/ACM-30500
Story: https://redhat.atlassian.net/browse/ACM-37067
Sub-task: https://redhat.atlassian.net/browse/ACM-37079

## Changes Made

Dynamic scoring framework helm chart and the CRDs are added.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
