### PR TITLE
ACM-24851: Add ConsoleNotification banner for MCE version mismatch

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -948,6 +948,7 @@ rules:
   - search.open-cluster-management.io
   resources:
   - consolelinks
+  - consolenotifications
   - consoleplugins
   - searches
   verbs:

--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -1,0 +1,120 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
+	consolev1 "github.com/openshift/api/console/v1"
+	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	"github.com/stolostron/multiclusterhub-operator/pkg/version"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	mceComplianceBannerName = "acm-mce-version-compliance"
+	bannerBackgroundColor   = "#880808"
+	bannerTextColor         = "#ffffff"
+)
+
+func mceComplianceBannerText(currentVersion, requiredChannel string) string {
+	direction := "does not match"
+	current, errCur := semver.NewVersion(currentVersion)
+	required, errReq := semver.NewVersion(version.RequiredMCEVersion)
+	if errCur == nil && errReq == nil {
+		if current.GreaterThan(required) {
+			direction = "is ahead of"
+		} else {
+			direction = "is behind"
+		}
+	}
+	return fmt.Sprintf(
+		"WARNING: ACM in unexpected configuration: MCE %s %s the expected %s channel.",
+		currentVersion, direction, requiredChannel,
+	)
+}
+
+func (r *MultiClusterHubReconciler) ensureMCEComplianceBanner(ctx context.Context,
+	hub *operatorsv1.MultiClusterHub,
+	compliance *operatorsv1.MCEVersionComplianceStatus) error {
+
+	if compliance == nil || compliance.IsCompliant {
+		return r.removeMCEComplianceBanner(ctx)
+	}
+
+	if compliance.CurrentVersion == "" {
+		return r.removeMCEComplianceBanner(ctx)
+	}
+
+	desired := &consolev1.ConsoleNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mceComplianceBannerName,
+			Labels: map[string]string{
+				"installer.name":      hub.GetName(),
+				"installer.namespace": hub.GetNamespace(),
+			},
+		},
+		Spec: consolev1.ConsoleNotificationSpec{
+			Text:            mceComplianceBannerText(compliance.CurrentVersion, compliance.RequiredChannel),
+			Location:        consolev1.BannerTop,
+			BackgroundColor: bannerBackgroundColor,
+			Color:           bannerTextColor,
+		},
+	}
+
+	existing := &consolev1.ConsoleNotification{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: mceComplianceBannerName}, existing)
+	if errors.IsNotFound(err) {
+		log.Info("Creating MCE compliance ConsoleNotification banner")
+		if err := r.Client.Create(ctx, desired); err != nil {
+			return fmt.Errorf("failed to create ConsoleNotification %s: %w", mceComplianceBannerName, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get ConsoleNotification %s: %w", mceComplianceBannerName, err)
+	}
+
+	if existing.Spec.Text != desired.Spec.Text ||
+		existing.Spec.BackgroundColor != desired.Spec.BackgroundColor ||
+		existing.Spec.Color != desired.Spec.Color ||
+		existing.Spec.Location != desired.Spec.Location {
+		patch := client.MergeFrom(existing.DeepCopy())
+		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		log.Info("Updating MCE compliance ConsoleNotification banner")
+		if err := r.Client.Patch(ctx, existing, patch); err != nil {
+			return fmt.Errorf("failed to patch ConsoleNotification %s: %w", mceComplianceBannerName, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *MultiClusterHubReconciler) removeMCEComplianceBanner(ctx context.Context) error {
+	notification := &consolev1.ConsoleNotification{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: mceComplianceBannerName}, notification)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get ConsoleNotification %s: %w", mceComplianceBannerName, err)
+	}
+
+	log.Info("Removing MCE compliance ConsoleNotification banner")
+	return r.Client.Delete(ctx, notification)
+}
+
+func (r *MultiClusterHubReconciler) cleanupConsoleNotifications(_ logr.Logger, m *operatorsv1.MultiClusterHub) error {
+	return r.Client.DeleteAllOf(context.TODO(), &consolev1.ConsoleNotification{}, client.MatchingLabels{
+		"installer.name":      m.GetName(),
+		"installer.namespace": m.GetNamespace(),
+	})
+}

--- a/controllers/console_notification_test.go
+++ b/controllers/console_notification_test.go
@@ -1,0 +1,254 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestMCEComplianceBannerText_Ahead(t *testing.T) {
+	got := mceComplianceBannerText("5.1.0", "stable-5.0")
+	expected := "WARNING: ACM in unexpected configuration: MCE 5.1.0 is ahead of the expected stable-5.0 channel."
+	if got != expected {
+		t.Errorf("mceComplianceBannerText() = %q, want %q", got, expected)
+	}
+}
+
+func TestMCEComplianceBannerText_Behind(t *testing.T) {
+	got := mceComplianceBannerText("2.17.0", "stable-5.0")
+	expected := "WARNING: ACM in unexpected configuration: MCE 2.17.0 is behind the expected stable-5.0 channel."
+	if got != expected {
+		t.Errorf("mceComplianceBannerText() = %q, want %q", got, expected)
+	}
+}
+
+func TestEnsureMCEComplianceBanner_NonCompliant(t *testing.T) {
+	registerScheme()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multiclusterhub",
+			Namespace: "open-cluster-management",
+		},
+	}
+
+	compliance := &operatorsv1.MCEVersionComplianceStatus{
+		RequiredChannel: "stable-5.0",
+		CurrentVersion:  "5.1.0",
+		IsCompliant:     false,
+		Message:         "MCE version 5.1.0 does not meet channel stable-5.0 requirements",
+	}
+
+	ctx := context.TODO()
+
+	err := recon.ensureMCEComplianceBanner(ctx, hub, compliance)
+	if err != nil {
+		t.Fatalf("ensureMCEComplianceBanner() error = %v", err)
+	}
+
+	notification := &consolev1.ConsoleNotification{}
+	err = recon.Client.Get(ctx, types.NamespacedName{Name: mceComplianceBannerName}, notification)
+	if err != nil {
+		t.Fatalf("failed to get ConsoleNotification: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = recon.Client.Delete(ctx, notification)
+	})
+
+	expectedText := mceComplianceBannerText("5.1.0", "stable-5.0")
+	if notification.Spec.Text != expectedText {
+		t.Errorf("banner text = %q, want %q", notification.Spec.Text, expectedText)
+	}
+	if notification.Spec.Location != consolev1.BannerTop {
+		t.Errorf("banner location = %q, want %q", notification.Spec.Location, consolev1.BannerTop)
+	}
+	if notification.Spec.BackgroundColor != bannerBackgroundColor {
+		t.Errorf("banner backgroundColor = %q, want %q", notification.Spec.BackgroundColor, bannerBackgroundColor)
+	}
+	if notification.Spec.Color != bannerTextColor {
+		t.Errorf("banner color = %q, want %q", notification.Spec.Color, bannerTextColor)
+	}
+	if notification.Labels["installer.name"] != "multiclusterhub" {
+		t.Errorf("label installer.name = %q, want %q", notification.Labels["installer.name"], "multiclusterhub")
+	}
+	if notification.Labels["installer.namespace"] != "open-cluster-management" {
+		t.Errorf("label installer.namespace = %q, want %q", notification.Labels["installer.namespace"], "open-cluster-management")
+	}
+}
+
+func TestEnsureMCEComplianceBanner_Compliant_RemovesBanner(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multiclusterhub",
+			Namespace: "open-cluster-management",
+		},
+	}
+
+	existing := &consolev1.ConsoleNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mceComplianceBannerName,
+			Labels: map[string]string{
+				"installer.name":      "multiclusterhub",
+				"installer.namespace": "open-cluster-management",
+			},
+		},
+		Spec: consolev1.ConsoleNotificationSpec{
+			Text:            "old warning text",
+			Location:        consolev1.BannerTop,
+			BackgroundColor: bannerBackgroundColor,
+			Color:           bannerTextColor,
+		},
+	}
+	if err := recon.Client.Create(ctx, existing); err != nil {
+		t.Fatalf("failed to create existing banner: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = recon.Client.Delete(ctx, &consolev1.ConsoleNotification{
+			ObjectMeta: metav1.ObjectMeta{Name: mceComplianceBannerName},
+		})
+	})
+
+	compliance := &operatorsv1.MCEVersionComplianceStatus{
+		RequiredChannel: "stable-5.0",
+		CurrentVersion:  "5.0.0",
+		IsCompliant:     true,
+		Message:         "MCE version 5.0.0 meets channel stable-5.0 requirements",
+	}
+
+	err := recon.ensureMCEComplianceBanner(ctx, hub, compliance)
+	if err != nil {
+		t.Fatalf("ensureMCEComplianceBanner() error = %v", err)
+	}
+
+	notification := &consolev1.ConsoleNotification{}
+	err = recon.Client.Get(ctx, types.NamespacedName{Name: mceComplianceBannerName}, notification)
+	if err == nil {
+		t.Error("expected ConsoleNotification to be deleted when compliant, but it still exists")
+	}
+}
+
+func TestEnsureMCEComplianceBanner_NilCompliance(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multiclusterhub",
+			Namespace: "open-cluster-management",
+		},
+	}
+
+	err := recon.ensureMCEComplianceBanner(ctx, hub, nil)
+	if err != nil {
+		t.Fatalf("ensureMCEComplianceBanner(nil) error = %v", err)
+	}
+}
+
+func TestEnsureMCEComplianceBanner_NoVersion_NoBanner(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multiclusterhub",
+			Namespace: "open-cluster-management",
+		},
+	}
+
+	compliance := &operatorsv1.MCEVersionComplianceStatus{
+		RequiredChannel: "stable-5.0",
+		CurrentVersion:  "",
+		IsCompliant:     false,
+		Message:         "MCE not yet installed",
+	}
+
+	err := recon.ensureMCEComplianceBanner(ctx, hub, compliance)
+	if err != nil {
+		t.Fatalf("ensureMCEComplianceBanner() error = %v", err)
+	}
+
+	notification := &consolev1.ConsoleNotification{}
+	err = recon.Client.Get(ctx, types.NamespacedName{Name: mceComplianceBannerName}, notification)
+	if err == nil {
+		t.Error("expected no ConsoleNotification when MCE version is empty")
+	}
+}
+
+func TestEnsureMCEComplianceBanner_UpdatesExistingBanner(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multiclusterhub",
+			Namespace: "open-cluster-management",
+		},
+	}
+
+	existing := &consolev1.ConsoleNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mceComplianceBannerName,
+			Labels: map[string]string{
+				"installer.name":      "multiclusterhub",
+				"installer.namespace": "open-cluster-management",
+			},
+		},
+		Spec: consolev1.ConsoleNotificationSpec{
+			Text:            mceComplianceBannerText("5.1.0", "stable-5.0"),
+			Location:        consolev1.BannerTop,
+			BackgroundColor: bannerBackgroundColor,
+			Color:           bannerTextColor,
+		},
+	}
+	if err := recon.Client.Create(ctx, existing); err != nil {
+		t.Fatalf("failed to create existing banner: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = recon.Client.Delete(ctx, &consolev1.ConsoleNotification{
+			ObjectMeta: metav1.ObjectMeta{Name: mceComplianceBannerName},
+		})
+	})
+
+	newCompliance := &operatorsv1.MCEVersionComplianceStatus{
+		RequiredChannel: "stable-5.0",
+		CurrentVersion:  "5.2.0",
+		IsCompliant:     false,
+		Message:         "MCE version 5.2.0 does not meet channel stable-5.0 requirements",
+	}
+
+	err := recon.ensureMCEComplianceBanner(ctx, hub, newCompliance)
+	if err != nil {
+		t.Fatalf("ensureMCEComplianceBanner() error = %v", err)
+	}
+
+	notification := &consolev1.ConsoleNotification{}
+	err = recon.Client.Get(ctx, types.NamespacedName{Name: mceComplianceBannerName}, notification)
+	if err != nil {
+		t.Fatalf("failed to get ConsoleNotification: %v", err)
+	}
+
+	expectedText := mceComplianceBannerText("5.2.0", "stable-5.0")
+	if notification.Spec.Text != expectedText {
+		t.Errorf("updated banner text = %q, want %q", notification.Spec.Text, expectedText)
+	}
+}
+
+func TestRemoveMCEComplianceBanner_NoExistingBanner(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	err := recon.removeMCEComplianceBanner(ctx)
+	if err != nil {
+		t.Fatalf("removeMCEComplianceBanner() error = %v, expected nil for non-existent banner", err)
+	}
+}

--- a/controllers/lifecycle.go
+++ b/controllers/lifecycle.go
@@ -66,6 +66,7 @@ func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operat
 	cleanupFunctions := []func(reqLogger logr.Logger, m *operatorv1.MultiClusterHub) error{
 		r.cleanupNamespaces, r.cleanupClusterRoles, r.cleanupClusterRoleBindings,
 		r.cleanupMultiClusterEngine, r.orphanOwnedMultiClusterEngine,
+		r.cleanupConsoleNotifications,
 	}
 
 	for _, cleanupFn := range cleanupFunctions {

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -81,7 +81,7 @@ var (
 //+kubebuilder:rbac:groups="olm.operatorframework.io",resources=clusterextensions;clustercatalogs,verbs=create;get;list;patch;update;delete;watch
 //+kubebuilder:rbac:groups="olm.operatorframework.io",resources=clusterextensions/status;clustercatalogs/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups="multicluster.openshift.io",resources=multiclusterengines,verbs=create;get;list;patch;update;delete;watch
-//+kubebuilder:rbac:groups=console.openshift.io;search.open-cluster-management.io,resources=consoleplugins;consolelinks;searches,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=console.openshift.io;search.open-cluster-management.io,resources=consoleplugins;consolelinks;consolenotifications;searches,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=cloudcredentials;consoles,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;authentications;infrastructures,verbs=get;list;watch
 //+kubebuilder:rbac:groups="";"apps",resources=deployments;services;serviceaccounts,verbs=patch;delete;get;deletecollection

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -419,6 +419,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 		Expect(ocmapi.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(networking.AddToScheme(clientScheme)).Should(Succeed())
 		Expect(operatorsapiv2.AddToScheme(clientScheme)).Should(Succeed())
+		Expect(openshift_consolev1.AddToScheme(clientScheme)).Should(Succeed())
 		k8sManager, err := ctrl.NewManager(clientConfig, ctrl.Options{
 			Scheme: clientScheme,
 			Metrics: metricsserver.Options{

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -27,6 +27,7 @@ import (
 	ocmapi "open-cluster-management.io/api/addon/v1alpha1"
 
 	configv1 "github.com/openshift/api/config/v1"
+	openshift_consolev1 "github.com/openshift/api/console/v1"
 	ocopv1 "github.com/openshift/api/operator/v1"
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -1050,6 +1051,7 @@ var _ = Describe("MultiClusterHub controller", func() {
 
 func registerScheme() {
 	configv1.AddToScheme(scheme.Scheme)
+	openshift_consolev1.AddToScheme(scheme.Scheme)
 	ocopv1.AddToScheme(scheme.Scheme)
 	operatorv1.AddToScheme(scheme.Scheme)
 	mcev1.AddToScheme(scheme.Scheme)

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -125,6 +125,11 @@ func (r *MultiClusterHubReconciler) syncHubStatus(ctx context.Context, m *operat
 	allCRs map[string]*unstructured.Unstructured, ocpConsole, isSTSEnabled bool) (reconcile.Result, error) {
 
 	newStatus := r.calculateStatus(ctx, m, allDeps, allCRs, ocpConsole, isSTSEnabled)
+
+	if err := r.ensureMCEComplianceBanner(ctx, m, newStatus.MCEVersionCompliance); err != nil {
+		r.Log.Error(err, "Failed to reconcile MCE compliance ConsoleNotification banner")
+	}
+
 	if reflect.DeepEqual(m.Status, original) {
 		r.Log.Info("Status hasn't changed")
 		return reconcile.Result{}, nil

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	configv1 "github.com/openshift/api/config/v1"
+	openshift_consolev1 "github.com/openshift/api/console/v1"
 	consolev1 "github.com/openshift/api/operator/v1"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -125,6 +126,8 @@ func init() {
 	utilruntime.Must(configv1.AddToScheme(scheme))
 
 	utilruntime.Must(consolev1.AddToScheme(scheme))
+
+	utilruntime.Must(openshift_consolev1.AddToScheme(scheme))
 
 	utilruntime.Must(olmapi.AddToScheme(scheme))
 

--- a/test/unit-tests/crds/consolenotification.yaml
+++ b/test/unit-tests/crds/consolenotification.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
+    capability.openshift.io/name: Console
+    description: Extension for configuring openshift web console notifications.
+    displayName: ConsoleNotification
+  name: consolenotifications.console.openshift.io
+spec:
+  group: console.openshift.io
+  names:
+    kind: ConsoleNotification
+    listKind: ConsoleNotificationList
+    plural: consolenotifications
+    singular: consolenotification
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: ConsoleNotification is the Schema for the consolenotifications API
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleNotificationSpec defines the desired state of ConsoleNotification
+            type: object
+            required:
+            - text
+            properties:
+              backgroundColor:
+                type: string
+              color:
+                type: string
+              link:
+                type: object
+                properties:
+                  href:
+                    type: string
+                  text:
+                    type: string
+              location:
+                type: string
+              text:
+                type: string


### PR DESCRIPTION
## Summary

- Displays a warning banner at the top of the OpenShift console when the installed MCE version does not match the expected channel (e.g. MCE is behind or ahead of the required version)
- Automatically removes the banner when MCE becomes compliant or when MCH is deleted

## Details

When MCE is running at a version that doesn't satisfy ACM's required MCE version, users may not realize their cluster is in an unexpected state. This change creates a `ConsoleNotification` resource (cluster-scoped, part of `console.openshift.io/v1`) to surface a prominent dark red banner at the top of the OCP console.

The banner text is direction-aware:
- **Behind**: `WARNING: ACM in unexpected configuration: MCE 2.17.0 is behind the expected stable-5.0 channel.`
- **Ahead**: `WARNING: ACM in unexpected configuration: MCE 5.1.0 is ahead of the expected stable-5.0 channel.`

### Cleanup
- Banner is removed during normal reconciliation when MCE becomes compliant
- Banner is cleaned up via the MCH finalizer on deletion (using `installer.name`/`installer.namespace` labels)

### Smoke tested
- Installed MCE 2.17 on OCP 5.0, then deployed custom ACM 5.0 catalog — banner appeared correctly
- Deleted MCH — banner was removed

Related: https://redhat.atlassian.net/browse/ACM-24851

🐨 Generated with Crush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenShift Console banner to alert administrators when Multi-Cluster Engine (MCE) version compliance is not met, including “ahead/behind” messaging against the required version.
  * The banner auto-creates, auto-updates when compliance changes, and is removed once compliance is restored.
* **Bug Fixes**
  * Ensured console-notification cleanup runs during hub finalization.
* **Tests**
  * Added coverage for banner creation, text “ahead/behind” messaging, updates, removal, nil/compliant inputs, and missing-current-version scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->