### PR TITLE
fix: remove baseBranchPatterns from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,9 +3,6 @@
     "addLabels": [
         "ok-to-test"
     ],
-    "baseBranchPatterns": [
-        "/(^main$)|(^release-2\\.(11|1[2-9]|[2-9][0-9]+)$)/"
-    ],
     "rebaseWhen": "behind-base-branch",
     "recreateWhen": "never",
     "schedule": [


### PR DESCRIPTION
# Description

Remove `baseBranchPatterns` from renovate.json to fix orphaned MintMaker branches.

## Related Issue

MintMaker/Konflux branch duplication — MintMaker already prefixes branch names with the base branch. `baseBranchPatterns` causes the base branch name to appear twice (e.g. `backplane-2.8-backplane-2.8/`), creating orphaned branches that MintMaker cannot prune.

## Changes Made

- Removed `baseBranchPatterns` key from `.github/renovate.json`
- Konflux components already handle branch targeting, making this config redundant

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Existing orphaned `konflux/mintmaker/` branches will need to be manually deleted. This change only prevents new ones from being created.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.