### PR TITLE
ACM-37777: bump Go to 1.25.11 to resolve stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multiclusterhub-operator
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
## Summary

Bumps the Go version from 1.25.8 to 1.25.11 to resolve 11 Go stdlib CVEs flagged against the multiclusterhub-rhel9 image.

## CVEs Resolved

| CVE | Severity | Component |
|-----|----------|-----------|
| CVE-2026-27145 | High | crypto/x509 — DoS via excessive DNS SAN entries |
| CVE-2026-39836 | High | net — DoS via NUL byte in Dial/LookupPort |
| CVE-2026-39823 | Medium | html/template — XSS via improper URL escaping |
| CVE-2026-33811 | High | net — DoS via long CNAME response |
| CVE-2026-39825 | Medium | net/http/httputil — ReverseProxy forwards hidden query params |
| CVE-2026-42507 | Medium | net/textproto — misleading error messages via injection |
| CVE-2026-33814 | High | HTTP/2 — DoS via malformed SETTINGS_MAX_FRAME_SIZE |
| CVE-2026-39826 | Medium | html/template — XSS via incorrect script tag escaping |
| CVE-2026-42499 | High | net/mail — DoS via pathological email address parsing |
| CVE-2026-39820 | High | net/mail — DoS via crafted email inputs |
| CVE-2026-42504 | High | MIME — DoS via maliciously-crafted MIME header |

Jira: https://redhat.atlassian.net/browse/ACM-37777