### PR TITLE
feat: add network policies for open-cluster-management-backup namespace

### DIFF
--- a/controllers/networkpolicy_test.go
+++ b/controllers/networkpolicy_test.go
@@ -300,7 +300,7 @@ func Test_ensureNetworkPolicies_Enabled_GetError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from Get, got nil")
 	}
-	if expected := "failed to get NetworkPolicy mtv-integrations-controller: simulated get error"; err.Error() != expected {
+	if expected := "failed to get NetworkPolicy deny-all: simulated get error"; err.Error() != expected {
 		t.Errorf("error = %q, want %q", err.Error(), expected)
 	}
 }
@@ -419,7 +419,7 @@ func Test_ensureNetworkPolicies_DisabledComponent_GetError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from Get, got nil")
 	}
-	if expected := "failed to get NetworkPolicy mtv-integrations-controller: simulated get error"; err.Error() != expected {
+	if expected := "failed to get NetworkPolicy deny-all: simulated get error"; err.Error() != expected {
 		t.Errorf("error = %q, want %q", err.Error(), expected)
 	}
 }

--- a/pkg/templates/charts/toggle/cluster-backup/templates/networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/networkpolicy.yaml
@@ -1,0 +1,171 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Copyright Contributors to the Open Cluster Management project
+# Network policies for the open-cluster-management-backup namespace.
+# Implements deny-by-default with explicit allow rules for required traffic.
+---
+# Default deny all ingress and egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+# Allow DNS egress for all pods (required for name resolution).
+# Port 5353 is needed because OVN-Kubernetes evaluates NetworkPolicy post-DNAT
+# and CoreDNS pods listen on 5353 while the DNS service exposes port 53.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+---
+# Allow egress to Kubernetes API server for all pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-egress
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+---
+# Allow egress to object storage for Velero and node-agent.
+# No port restriction because customers use varied storage endpoints
+# (AWS S3 on 443, MinIO on 9000, Ceph RGW on 8080, etc.)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-storage-egress
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+spec:
+  podSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: In
+      values:
+      - velero
+      - node-agent
+  policyTypes:
+  - Egress
+  egress:
+  - {}
+---
+# Allow ingress to cluster-backup-operator webhook (port 9443)
+# from the Kubernetes API server for admission webhook calls.
+# API server runs on host-network; use the OpenShift-managed label.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-ingress
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+spec:
+  podSelector:
+    matchLabels:
+      app: cluster-backup-chart
+      component: clusterbackup
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+    ports:
+    - protocol: TCP
+      port: 9443
+---
+# Allow ingress for Velero metrics scraping (port 8085)
+# from monitoring/prometheus namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-velero-metrics-ingress
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: velero
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8085
+    from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+---
+# Allow ingress for OADP controller manager metrics (port 8443)
+# from monitoring/prometheus namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-oadp-metrics-ingress
+  namespace: open-cluster-management-backup
+  labels:
+    app: cluster-backup-chart
+    chart: cluster-backup-chart
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8443
+    from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+{{- end }}


### PR DESCRIPTION
## Summary

Adds deny-by-default network policies for the `open-cluster-management-backup` namespace, restricting traffic to only the communication paths required by backup/restore components.

Relates: [ACM-37736](https://issues.redhat.com/browse/ACM-37736) | [ACM-31154](https://issues.redhat.com/browse/ACM-31154)

---

## Policy Breakdown

| Pod | Ingress Allowed | Egress Allowed |
|-----|----------------|----------------|
| cluster-backup-operator | Webhook (port 9443) from any source (API server) | DNS (53/5353) + API server (443/6443) |
| OADP controller-manager | Metrics (port 8443) from monitoring namespace | DNS (53/5353) + API server (443/6443) |
| velero | Metrics (port 8085) from monitoring namespace | **Unrestricted** (needs S3/MinIO/Ceph/etc.) |
| node-agent | None | **Unrestricted** (needs object storage for backup data) |

---

## Design Decisions

### Unrestricted egress for Velero/node-agent

The `allow-storage-egress` policy allows all egress for Velero and node-agent pods (no port restriction). This was chosen over restricting to port 443 because:

1. **DR is a critical safety system** — if network policies silently break backups on a customer's MinIO-on-9000 setup, the failure only surfaces during a disaster when it's too late
2. **Pod selector is still restrictive** — only `velero` and `node-agent` pods get broad egress, not the backup operator or OADP controller
3. **Customer environments are diverse** — MinIO (9000), Ceph RGW (8080), custom ports behind load balancers are all common, especially in air-gapped environments
4. **The BSL endpoint is customer-configured** — we cannot predict what port they will use

### DNS port 5353

The DNS egress policy includes port 5353 in addition to port 53. This is required because OVN-Kubernetes on OpenShift evaluates NetworkPolicy post-DNAT, and CoreDNS pods listen on port 5353 while the DNS service exposes port 53. Without this, DNS resolution fails silently.

---

## Testing Performed

Tested on an OpenShift 4.21 cluster with ACM 2.17 + OADP 1.5.7:

| # | Test | Result |
|---|------|--------|
| 1 | Backup operator reaches API server (leader election, CRD watches, reconciliation) | **PASS** |
| 2 | Webhook accessible (API server -> port 9443, validates Restore CRs) | **PASS** |
| 3 | DNS resolution for all pods (internal + external hostnames) | **PASS** |
| 4 | Velero reaches S3 endpoint (confirmed via InvalidAccessKeyId error = network works) | **PASS** |
| 5 | Prometheus scrapes Velero metrics from monitoring namespace (port 8085) | **PASS** |
| 6 | BackupSchedule reconciliation (detects BSL unavailable, sets FailedValidation) | **PASS** |
| 7 | Restore reconciliation (detects active schedule conflict) | **PASS** |
| 8 | **Negative**: Velero metrics blocked from non-monitoring namespace | **PASS** (timeout) |
| 9 | **Negative**: Operator metrics (8080) blocked from non-monitoring namespace | **PASS** (timeout) |

### Not testable
- OADP metrics (port 8443): OADP 1.5.x does not expose a metrics endpoint (service has no backing endpoints). Policy is in place for future OADP versions that do.


[ACM-37736]: https://redhat.atlassian.net/browse/ACM-37736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-31154]: https://redhat.atlassian.net/browse/ACM-31154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional support for a cluster-backup NetworkPolicy controlled by `global.networkPolicies.enabled`.
  * Introduced deny-by-default behavior in the cluster-backup namespace, with explicit outbound allow rules for DNS, Kubernetes API access, and required object-storage connectivity.
  * Enabled controlled inbound access for the cluster-backup webhook and restricted metrics scraping for Velero and the controller to approved monitoring sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->