### PR TITLE
[release-2.13] ACM-37672: bump Go to 1.25.11 to fix CVE-2026-27145

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multiclusterhub-operator
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Bumps Go from 1.25.8 to 1.25.11 to address CVE-2026-27145 (crypto/x509 DoS via excessive DNS SAN entries).

Related: ACM-37672

Made with [Cursor](https://cursor.com)