### PR TITLE
chore: update grc-policy-addon cmd

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
@@ -81,9 +81,7 @@ spec:
         {{- end }}
       {{- end }}  
       containers:
-      - args:
-        - controller
-        command:
+      - command:
         - governance-policy-addon-controller
         env:
         - name: POD_NAME


### PR DESCRIPTION
Blocked by:
- https://github.com/stolostron/governance-policy-addon-controller/pull/1302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the controller startup configuration to ensure the deployment launches with the intended entrypoint and arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->