### PR TITLE
[ACM-38006] Add OADP annotation validation to MCH webhook

### DIFF
--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -51,8 +51,10 @@ const (
 	annotationMCHPause         = "installer.open-cluster-management.io/pause"
 
 	// OLM version-specific annotations
-	annotationMCESubscriptionSpec     = "installer.open-cluster-management.io/mce-subscription-spec"
-	annotationMCEClusterExtensionSpec = "installer.open-cluster-management.io/mce-clusterextension-spec"
+	annotationMCESubscriptionSpec      = "installer.open-cluster-management.io/mce-subscription-spec"
+	annotationMCEClusterExtensionSpec  = "installer.open-cluster-management.io/mce-clusterextension-spec"
+	annotationOADPSubscriptionSpec     = "installer.open-cluster-management.io/oadp-subscription-spec"
+	annotationOADPClusterExtensionSpec = "installer.open-cluster-management.io/oadp-clusterextension-spec"
 
 	// Deprecated annotation keys
 	deprecatedAnnotationIgnoreOCPVersion = "ignoreOCPVersion"
@@ -412,7 +414,7 @@ func contains(list []string, s string) bool {
 	return false
 }
 
-// validateOLMAnnotations validates that MCE annotations match the detected OLM version
+// validateOLMAnnotations validates that MCE and OADP annotations match the detected OLM version
 func validateOLMAnnotations(ctx context.Context, mch *MultiClusterHub) error {
 	annotations := mch.GetAnnotations()
 	if annotations == nil {
@@ -427,30 +429,43 @@ func validateOLMAnnotations(ctx context.Context, mch *MultiClusterHub) error {
 		return nil
 	}
 
-	hasV0Annotation := annotations[annotationMCESubscriptionSpec] != ""
-	hasV1Annotation := annotations[annotationMCEClusterExtensionSpec] != ""
+	// Validate MCE annotations
+	if err := validateOLMAnnotationPair(olmVersion, annotations,
+		annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec); err != nil {
+		return err
+	}
 
-	// No annotations set - valid
-	if !hasV0Annotation && !hasV1Annotation {
+	// Validate OADP annotations
+	if err := validateOLMAnnotationPair(olmVersion, annotations,
+		annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateOLMAnnotationPair validates that a v0/v1 annotation pair matches the detected OLM version
+func validateOLMAnnotationPair(olmVersion string, annotations map[string]string, v0Annotation, v1Annotation string) error {
+	hasV0 := annotations[v0Annotation] != ""
+	hasV1 := annotations[v1Annotation] != ""
+
+	if !hasV0 && !hasV1 {
 		return nil
 	}
 
-	// Reject v0 annotation on v1 cluster
-	if olmVersion == "v1" && hasV0Annotation {
+	if olmVersion == "v1" && hasV0 {
 		return fmt.Errorf("annotation %q is only valid for OLM v0 clusters. This cluster uses OLM v1. Use %q instead",
-			annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
+			v0Annotation, v1Annotation)
 	}
 
-	// Reject v1 annotation on v0 cluster
-	if olmVersion == "v0" && hasV1Annotation {
+	if olmVersion == "v0" && hasV1 {
 		return fmt.Errorf("annotation %q is only valid for OLM v1 clusters. This cluster uses OLM v0. Use %q instead",
-			annotationMCEClusterExtensionSpec, annotationMCESubscriptionSpec)
+			v1Annotation, v0Annotation)
 	}
 
-	// Reject v1 annotation when no OLM detected
-	if olmVersion == "" && hasV1Annotation {
+	if olmVersion == "" && hasV1 {
 		return fmt.Errorf("annotation %q requires OLM v1, but no OLM detected on this cluster",
-			annotationMCEClusterExtensionSpec)
+			v1Annotation)
 	}
 
 	return nil

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -432,13 +432,13 @@ func validateOLMAnnotations(ctx context.Context, mch *MultiClusterHub) error {
 	// Validate MCE annotations
 	if err := validateOLMAnnotationPair(olmVersion, annotations,
 		annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec); err != nil {
-		return err
+		return fmt.Errorf("validating MCE OLM annotations: %w", err)
 	}
 
 	// Validate OADP annotations
 	if err := validateOLMAnnotationPair(olmVersion, annotations,
 		annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec); err != nil {
-		return err
+		return fmt.Errorf("validating OADP OLM annotations: %w", err)
 	}
 
 	return nil

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -419,45 +419,48 @@ var _ = Describe("Multiclusterhub webhook", func() {
 		It("Should return nil when no annotations set", func() {
 			err := validateOLMAnnotationPair("v1", map[string]string{},
 				annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "empty annotations should pass validation for any OLM version")
 		})
 
-		It("Should reject v0 annotation on v1 cluster", func() {
+		It("Should reject MCE v0 annotation on v1 cluster", func() {
 			err := validateOLMAnnotationPair("v1", map[string]string{
 				annotationMCESubscriptionSpec: `{"channel": "stable-2.6"}`,
 			}, annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("only valid for OLM v0"))
+			Expect(err).To(HaveOccurred(), "MCE subscription-spec should be rejected on OLM v1 cluster")
+			Expect(err.Error()).To(ContainSubstring("only valid for OLM v0"),
+				"error should indicate annotation is only valid for OLM v0")
 		})
 
-		It("Should reject v1 annotation on v0 cluster", func() {
+		It("Should reject MCE v1 annotation on v0 cluster", func() {
 			err := validateOLMAnnotationPair("v0", map[string]string{
 				annotationMCEClusterExtensionSpec: `{"channels": ["stable-2.6"]}`,
 			}, annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("only valid for OLM v1"))
+			Expect(err).To(HaveOccurred(), "MCE clusterextension-spec should be rejected on OLM v0 cluster")
+			Expect(err.Error()).To(ContainSubstring("only valid for OLM v1"),
+				"error should indicate annotation is only valid for OLM v1")
 		})
 
-		It("Should reject v1 annotation when no OLM detected", func() {
+		It("Should reject OADP v1 annotation when no OLM detected", func() {
 			err := validateOLMAnnotationPair("", map[string]string{
 				annotationOADPClusterExtensionSpec: `{"channels": ["stable"]}`,
 			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("requires OLM v1"))
+			Expect(err).To(HaveOccurred(), "OADP clusterextension-spec should be rejected when no OLM detected")
+			Expect(err.Error()).To(ContainSubstring("requires OLM v1"),
+				"error should indicate OLM v1 is required")
 		})
 
-		It("Should allow v0 annotation on v0 cluster", func() {
+		It("Should allow OADP v0 annotation on v0 cluster", func() {
 			err := validateOLMAnnotationPair("v0", map[string]string{
 				annotationOADPSubscriptionSpec: `{"channel": "stable-1.4"}`,
 			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "OADP subscription-spec should be allowed on OLM v0 cluster")
 		})
 
-		It("Should allow v1 annotation on v1 cluster", func() {
+		It("Should allow OADP v1 annotation on v1 cluster", func() {
 			err := validateOLMAnnotationPair("v1", map[string]string{
 				annotationOADPClusterExtensionSpec: `{"channels": ["stable"]}`,
 			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "OADP clusterextension-spec should be allowed on OLM v1 cluster")
 		})
 	})
 

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -363,6 +363,42 @@ var _ = Describe("Multiclusterhub webhook", func() {
 			_ = mch
 		})
 
+		It("Should reject OADP v0 annotation when cluster has OLM v1", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-oadp-v0-on-v1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"installer.open-cluster-management.io/oadp-subscription-spec": `{"channel": "stable-1.4"}`,
+					},
+				},
+				Spec: MultiClusterHubSpec{
+					LocalClusterName: "test-cluster",
+				},
+			}
+
+			// Validation behavior depends on live cluster OLM detection
+			_ = mch
+		})
+
+		It("Should reject OADP v1 annotation when cluster has OLM v0", func() {
+			mch := &MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-oadp-v1-on-v0",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"installer.open-cluster-management.io/oadp-clusterextension-spec": `{"channels": ["stable"],"version": "1.6.0"}`,
+					},
+				},
+				Spec: MultiClusterHubSpec{
+					LocalClusterName: "test-cluster",
+				},
+			}
+
+			// Validation behavior depends on live cluster OLM detection
+			_ = mch
+		})
+
 		It("Should allow annotation when it matches cluster OLM version", func() {
 			mch := &MultiClusterHub{
 				ObjectMeta: metav1.ObjectMeta{
@@ -376,6 +412,52 @@ var _ = Describe("Multiclusterhub webhook", func() {
 
 			// No annotations set - should always pass
 			Expect(validateOLMAnnotations(ctx, mch)).To(Succeed())
+		})
+	})
+
+	Context("validateOLMAnnotationPair", func() {
+		It("Should return nil when no annotations set", func() {
+			err := validateOLMAnnotationPair("v1", map[string]string{},
+				annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should reject v0 annotation on v1 cluster", func() {
+			err := validateOLMAnnotationPair("v1", map[string]string{
+				annotationMCESubscriptionSpec: `{"channel": "stable-2.6"}`,
+			}, annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("only valid for OLM v0"))
+		})
+
+		It("Should reject v1 annotation on v0 cluster", func() {
+			err := validateOLMAnnotationPair("v0", map[string]string{
+				annotationMCEClusterExtensionSpec: `{"channels": ["stable-2.6"]}`,
+			}, annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("only valid for OLM v1"))
+		})
+
+		It("Should reject v1 annotation when no OLM detected", func() {
+			err := validateOLMAnnotationPair("", map[string]string{
+				annotationOADPClusterExtensionSpec: `{"channels": ["stable"]}`,
+			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("requires OLM v1"))
+		})
+
+		It("Should allow v0 annotation on v0 cluster", func() {
+			err := validateOLMAnnotationPair("v0", map[string]string{
+				annotationOADPSubscriptionSpec: `{"channel": "stable-1.4"}`,
+			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should allow v1 annotation on v1 cluster", func() {
+			err := validateOLMAnnotationPair("v1", map[string]string{
+				annotationOADPClusterExtensionSpec: `{"channels": ["stable"]}`,
+			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
# Description

Add webhook validation for OADP OLM version-specific annotations, matching the existing validation for MCE annotations.

## Related Issue

- [ACM-38006](https://redhat.atlassian.net/browse/ACM-38006): OLMv1 resources not created for OADP after the oadp-clusterextension-spec annotation is added in MCH

## Changes Made

- Added `annotationOADPSubscriptionSpec` and `annotationOADPClusterExtensionSpec` constants to the webhook
- Extracted shared validation logic into `validateOLMAnnotationPair()` to avoid duplication between MCE and OADP checks
- Extended `validateOLMAnnotations()` to validate both MCE and OADP annotation pairs against detected OLM version:
  - `oadp-clusterextension-spec` on OLMv0 → rejected with error suggesting `oadp-subscription-spec`
  - `oadp-subscription-spec` on OLMv1 → rejected with error suggesting `oadp-clusterextension-spec`
  - `oadp-clusterextension-spec` with no OLM → rejected
- Added unit tests for `validateOLMAnnotationPair()` covering all OLM version combinations
- Added integration-style test stubs for OADP annotation validation matching existing MCE test pattern

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Previously, the webhook only validated MCE annotations (`mce-subscription-spec` / `mce-clusterextension-spec`) against the detected OLM version. OADP annotations were accepted without validation, allowing users to set `oadp-clusterextension-spec` on an OLMv0 cluster where it would be silently ignored — the operator would create an OLMv0 Subscription instead of the expected ClusterExtension.

[ACM-38006]: https://redhat.atlassian.net/browse/ACM-38006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ