### PR TITLE
Auto-migrate deprecated MCH annotations in reconcile loop

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -65,6 +65,16 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	// Migrate deprecated annotations to current equivalents
+	if utils.MigrateDeprecatedAnnotations(multiClusterHub) {
+		r.Log.Info("Migrating deprecated annotations to current equivalents")
+		if err := r.Client.Update(ctx, multiClusterHub); err != nil {
+			r.Log.Error(err, "Failed to update MCH after annotation migration")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	multiClusterHub.Status.HubConditions = filterOutConditionWithSubstring(multiClusterHub.Status.HubConditions,
 		string(operatorv1.ComponentFailure))
 

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -134,6 +134,45 @@ var (
 	AnnotationProbeSuccessThreshold = "installer.open-cluster-management.io/probe-success-threshold"
 )
 
+// DeprecatedAnnotationMap maps deprecated annotation keys to their current replacements.
+var DeprecatedAnnotationMap = map[string]string{
+	DeprecatedAnnotationMCHPause:         AnnotationMCHPause,
+	DeprecatedAnnotationImageOverridesCM: AnnotationImageOverridesCM,
+	DeprecatedAnnotationImageRepo:        AnnotationImageRepo,
+	DeprecatedAnnotationKubeconfig:       AnnotationKubeconfig,
+	DeprecatedAnnotationIgnoreOCPVersion: AnnotationIgnoreOCPVersion,
+}
+
+// MigrateDeprecatedAnnotations replaces deprecated annotation keys with their current equivalents.
+// If a deprecated key exists and the current key does not, the value is copied to the current key.
+// If both exist, the deprecated key is removed and the current key is preserved.
+// Returns true if any annotations were modified.
+func MigrateDeprecatedAnnotations(instance *operatorsv1.MultiClusterHub) bool {
+	annotations := instance.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	modified := false
+	for deprecatedKey, currentKey := range DeprecatedAnnotationMap {
+		deprecatedVal, hasDeprecated := annotations[deprecatedKey]
+		if !hasDeprecated {
+			continue
+		}
+
+		if _, hasCurrent := annotations[currentKey]; !hasCurrent {
+			annotations[currentKey] = deprecatedVal
+		}
+		delete(annotations, deprecatedKey)
+		modified = true
+	}
+
+	if modified {
+		instance.SetAnnotations(annotations)
+	}
+	return modified
+}
+
 /*
 IsPaused checks if the MultiClusterHub instance is labeled as paused.
 It returns true if the instance is paused, otherwise false.

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -303,7 +303,7 @@ func TestMigrateDeprecatedAnnotations(t *testing.T) {
 		{
 			name: "Deprecated annotation migrated to current",
 			annotations: map[string]string{
-				DeprecatedAnnotationMCHPause: "true",
+				DeprecatedAnnotationMCHPause:  "true",
 				DeprecatedAnnotationImageRepo: "quay.io/foo",
 			},
 			wantModified: true,

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -275,6 +275,88 @@ func Test_GetDefaultStorageClassOverride(t *testing.T) {
 	})
 }
 
+func TestMigrateDeprecatedAnnotations(t *testing.T) {
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		wantModified    bool
+		wantAnnotations map[string]string
+	}{
+		{
+			name:            "No annotations",
+			annotations:     nil,
+			wantModified:    false,
+			wantAnnotations: nil,
+		},
+		{
+			name: "Only current annotations",
+			annotations: map[string]string{
+				AnnotationMCHPause:  "true",
+				AnnotationImageRepo: "quay.io/foo",
+			},
+			wantModified: false,
+			wantAnnotations: map[string]string{
+				AnnotationMCHPause:  "true",
+				AnnotationImageRepo: "quay.io/foo",
+			},
+		},
+		{
+			name: "Deprecated annotation migrated to current",
+			annotations: map[string]string{
+				DeprecatedAnnotationMCHPause: "true",
+				DeprecatedAnnotationImageRepo: "quay.io/foo",
+			},
+			wantModified: true,
+			wantAnnotations: map[string]string{
+				AnnotationMCHPause:  "true",
+				AnnotationImageRepo: "quay.io/foo",
+			},
+		},
+		{
+			name: "Both exist - current preserved, deprecated removed",
+			annotations: map[string]string{
+				DeprecatedAnnotationMCHPause: "false",
+				AnnotationMCHPause:           "true",
+			},
+			wantModified: true,
+			wantAnnotations: map[string]string{
+				AnnotationMCHPause: "true",
+			},
+		},
+		{
+			name: "Mixed - some deprecated, some current",
+			annotations: map[string]string{
+				DeprecatedAnnotationKubeconfig: "my-secret",
+				AnnotationImageRepo:            "quay.io/foo",
+			},
+			wantModified: true,
+			wantAnnotations: map[string]string{
+				AnnotationKubeconfig: "my-secret",
+				AnnotationImageRepo:  "quay.io/foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mch := &operatorsv1.MultiClusterHub{}
+			if tt.annotations != nil {
+				mch.SetAnnotations(tt.annotations)
+			}
+
+			got := MigrateDeprecatedAnnotations(mch)
+			if got != tt.wantModified {
+				t.Errorf("MigrateDeprecatedAnnotations() = %v, want %v", got, tt.wantModified)
+			}
+
+			gotAnnotations := mch.GetAnnotations()
+			if !reflect.DeepEqual(gotAnnotations, tt.wantAnnotations) {
+				t.Errorf("annotations = %v, want %v", gotAnnotations, tt.wantAnnotations)
+			}
+		})
+	}
+}
+
 func TestShouldIgnoreOCPVersion(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
# Description

Automatically migrate deprecated MCH annotation keys to their current equivalents during the controller reconcile loop.

## Related Issue

N/A — housekeeping improvement. Deprecated annotations have been warned about but never auto-migrated.

## Changes Made

- Added `DeprecatedAnnotationMap` and `MigrateDeprecatedAnnotations()` to `pkg/utils/annotations.go`
  - Maps 5 deprecated keys to their current equivalents
  - Copies value to current key if only deprecated exists, removes deprecated key
  - If both exist, preserves current value and removes deprecated key
- Called `MigrateDeprecatedAnnotations()` early in `Reconcile()` (before any annotation reads)
  - If migration occurs, updates MCH and requeues
- Added unit tests covering all migration scenarios (deprecated only, both exist, current only, no annotations)

### Deprecated → Current mapping

| Deprecated | Current |
|---|---|
| `mch-pause` | `installer.open-cluster-management.io/pause` |
| `mch-imageOverridesCM` | `installer.open-cluster-management.io/image-overrides-configmap` |
| `mch-imageRepository` | `installer.open-cluster-management.io/image-repository` |
| `mch-kubeconfig` | `installer.open-cluster-management.io/kubeconfig` |
| `ignoreOCPVersion` | `installer.open-cluster-management.io/ignore-ocp-version` |

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

The validating webhook (`checkDeprecatedAnnotations`) continues to warn about deprecated annotations for visibility. The controller migration ensures existing MCH resources get cleaned up on next reconcile without requiring manual user action.