### PR TITLE
Add olmVersion to fine-grained-rbac chart values

### DIFF
--- a/pkg/templates/charts/toggle/fine-grained-rbac/values.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/values.yaml
@@ -5,6 +5,7 @@ global:
     multicluster_role_assignment: quay.io/stolostron/multicluster-role-assignment:latest
   templateOverrides: {}
   namespace: default
+  olmVersion: v0
   pullSecret: null
   pullPolicy: Always
   networkPolicies:


### PR DESCRIPTION
## Summary
- Add `global.olmVersion: v0` to `fine-grained-rbac` `values.yaml` — was the only toggle chart missing this field
- Matches the chart-templates default and all other toggle charts

## Test plan
- [ ] Run `make regenerate-charts` and verify `olmVersion` is preserved
- [ ] Verify no regressions in chart rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)