### PR TITLE
Add networkPolicies field to bundle CRD

### DIFF
--- a/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
+++ b/bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml
@@ -84,6 +84,19 @@ spec:
                 default: local-cluster
                 description: The name of the local-cluster resource
                 type: string
+              networkPolicies:
+                description: NetworkPolicies configures NetworkPolicy deployment for
+                  ACM components
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled controls whether NetworkPolicies are deployed for ACM components
+                      Default: true in ACM 5.0+
+                    type: boolean
+                required:
+                - enabled
+                type: object
               nodeSelector:
                 additionalProperties:
                   type: string


### PR DESCRIPTION
## Summary
- The `networkPolicies` field was added to the source CRD in #4340 but the bundle CRD manifest was not updated to match
- This syncs `bundle/manifests/operator.open-cluster-management.io_multiclusterhubs.yaml` with the source CRD in `config/crd/bases/`

## Test plan
- [ ] Verify bundle CRD matches source CRD
- [ ] Run `make test` to confirm no regressions

/cc @cameronmwall @ngraham20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to enable or disable NetworkPolicy deployment for ACM components.
  * NetworkPolicies are enabled by default for ACM 5.0 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->