### PR TITLE
Default NetworkPolicies to enabled when not specified

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -148,10 +148,6 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 		}
 	}
 
-	if utils.MchIsValid(m) && os.Getenv("ACM_HUB_OCP_VERSION") != "" && !updateNecessary {
-		return ctrl.Result{}, nil
-	}
-
 	if !operatorv1.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig) {
 		m.Spec.AvailabilityConfig = operatorv1.HAHigh
 		updateNecessary = true
@@ -160,6 +156,10 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 	if m.Spec.NetworkPolicies == nil {
 		m.Spec.NetworkPolicies = &operatorv1.NetworkPoliciesConfig{Enabled: true}
 		updateNecessary = true
+	}
+
+	if utils.MchIsValid(m) && os.Getenv("ACM_HUB_OCP_VERSION") != "" && !updateNecessary {
+		return ctrl.Result{}, nil
 	}
 
 	// If OCP 4.10+ then set then enable the MCE console. Else ensure it is disabled

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -157,6 +157,11 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 		updateNecessary = true
 	}
 
+	if m.Spec.NetworkPolicies == nil {
+		m.Spec.NetworkPolicies = &operatorv1.NetworkPoliciesConfig{Enabled: true}
+		updateNecessary = true
+	}
+
 	// If OCP 4.10+ then set then enable the MCE console. Else ensure it is disabled
 	clusterVersion := &configv1.ClusterVersion{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion)


### PR DESCRIPTION
# Description

Default the `networkPolicies` field to `{enabled: true}` when not specified on the MultiClusterHub CR, so the field visibly appears on the resource after first reconcile.

## Related Issue

ACM-38188

## Changes Made

- Added nil check for `Spec.NetworkPolicies` in `setDefaults` (`controllers/config.go`)
- When nil, sets `NetworkPolicies` to `&NetworkPoliciesConfig{Enabled: true}` and triggers an update
- Follows the same pattern as `AvailabilityConfig` defaulting

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

The `ensureNetworkPolicies` function already defaults to `true` when the field is nil. This change makes the default explicit on the CR object itself.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-cluster hub configurations now validate availability settings and automatically initialize network policies when no value is provided.
  * Default availability/network-policy settings are applied reliably during reconciliation, so eligible updates won’t be skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->