### PR TITLE
Remove redundant MchIsValid wrapper function

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -148,7 +148,7 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 		}
 	}
 
-	if utils.MchIsValid(m) && os.Getenv("ACM_HUB_OCP_VERSION") != "" && !updateNecessary {
+	if operatorv1.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig) && os.Getenv("ACM_HUB_OCP_VERSION") != "" && !updateNecessary {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -118,10 +118,6 @@ func AddInstallerLabel(u *unstructured.Unstructured, name string, ns string) {
 	u.SetLabels(labels)
 }
 
-// MchIsValid Checks if the optional default parameters need to be set
-func MchIsValid(m *operatorsv1.MultiClusterHub) bool {
-	return operatorsv1.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig)
-}
 
 // DefaultReplicaCount returns an integer corresponding to the default number of replicas
 // for HA or non-HA modes

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -213,61 +213,6 @@ var _ = Describe("utility functions", func() {
 	})
 })
 
-func TestMchIsValid(t *testing.T) {
-	validMCH := &mchv1.MultiClusterHub{
-		TypeMeta:   metav1.TypeMeta{Kind: "MultiClusterHub"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "test"},
-		Spec: mchv1.MultiClusterHubSpec{
-			ImagePullSecret:    "test",
-			AvailabilityConfig: mchv1.HAHigh,
-		},
-	}
-
-	type args struct {
-		m *mchv1.MultiClusterHub
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			"Valid MCH with HAHigh",
-			args{validMCH},
-			true,
-		},
-		{
-			"Valid MCH with HABasic",
-			args{&mchv1.MultiClusterHub{
-				Spec: mchv1.MultiClusterHubSpec{
-					AvailabilityConfig: mchv1.HABasic,
-				},
-			}},
-			true,
-		},
-		{
-			"Invalid MCH with empty AvailabilityConfig",
-			args{&mchv1.MultiClusterHub{}},
-			false,
-		},
-		{
-			"Invalid MCH with invalid AvailabilityConfig",
-			args{&mchv1.MultiClusterHub{
-				Spec: mchv1.MultiClusterHubSpec{
-					AvailabilityConfig: mchv1.AvailabilityType("invalid"),
-				},
-			}},
-			false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := MchIsValid(tt.args.m); got != tt.want {
-				t.Errorf("MchIsValid() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestGetImagePullPolicy(t *testing.T) {
 	noPullPolicyMCH := &mchv1.MultiClusterHub{}


### PR DESCRIPTION
# Description

Remove the `MchIsValid` utility function which only delegates to `AvailabilityConfigIsValid` with no added logic. Inline the call directly at the single call site.

## Related Issue

N/A — code cleanup identified during review of #4466.

## Changes Made

- Replaced `utils.MchIsValid(m)` call in `controllers/config.go` with direct `operatorv1.AvailabilityConfigIsValid(m.Spec.AvailabilityConfig)` call
- Removed `MchIsValid` function from `pkg/utils/utils.go`
- Removed `TestMchIsValid` test from `pkg/utils/utils_test.go`

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.