### PR TITLE
Revert "[release-2.17] fix: reject MCE versions with mismatched minor version (#4458)"

### DIFF
--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -1072,7 +1072,10 @@ func TestCalculateMCEVersionCompliance(t *testing.T) {
 			name:      "MCE not found",
 			createMCE: false,
 			expectedStatus: &operatorsv1.MCEVersionComplianceStatus{
-				RequiredChannel: "community-0.10",
+				RequiredChannel: "stable-2.17",
+				CurrentVersion:  "",
+				IsCompliant:     false,
+				Message:         "MCE not yet installed",
 			},
 			expectCompliant: false,
 		},
@@ -1089,12 +1092,15 @@ func TestCalculateMCEVersionCompliance(t *testing.T) {
 				Status: mcev1.MultiClusterEngineStatus{},
 			},
 			expectedStatus: &operatorsv1.MCEVersionComplianceStatus{
-				RequiredChannel: "community-0.10",
+				RequiredChannel: "stable-2.17",
+				CurrentVersion:  "",
+				IsCompliant:     false,
+				Message:         "MCE version not yet available - installation in progress",
 			},
 			expectCompliant: false,
 		},
 		{
-			name:      "MCE with exact required version",
+			name:      "MCE with valid version",
 			createMCE: true,
 			mce: &mcev1.MultiClusterEngine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1104,104 +1110,16 @@ func TestCalculateMCEVersionCompliance(t *testing.T) {
 					},
 				},
 				Status: mcev1.MultiClusterEngineStatus{
-					CurrentVersion: "0.10.0",
+					CurrentVersion: "2.17.0",
 				},
 			},
 			expectedStatus: &operatorsv1.MCEVersionComplianceStatus{
-				RequiredChannel: "community-0.10",
-				CurrentVersion:  "0.10.0",
+				RequiredChannel: "stable-2.17",
+				CurrentVersion:  "2.17.0",
 				IsCompliant:     true,
-				Message:         "MCE version 0.10.0 meets channel community-0.10 requirements",
+				Message:         "MCE version 2.17.0 meets channel stable-2.17 requirements",
 			},
 			expectCompliant: true,
-		},
-		{
-			name:      "MCE with higher patch version is compliant",
-			createMCE: true,
-			mce: &mcev1.MultiClusterEngine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "multiclusterengine",
-					Labels: map[string]string{
-						multiclusterengineutils.MCEManagedByLabel: "true",
-					},
-				},
-				Status: mcev1.MultiClusterEngineStatus{
-					CurrentVersion: "0.10.3",
-				},
-			},
-			expectedStatus: &operatorsv1.MCEVersionComplianceStatus{
-				RequiredChannel: "community-0.10",
-				CurrentVersion:  "0.10.3",
-				IsCompliant:     true,
-				Message:         "MCE version 0.10.3 meets channel community-0.10 requirements",
-			},
-			expectCompliant: true,
-		},
-		{
-			name:      "MCE with higher minor version is not compliant",
-			createMCE: true,
-			mce: &mcev1.MultiClusterEngine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "multiclusterengine",
-					Labels: map[string]string{
-						multiclusterengineutils.MCEManagedByLabel: "true",
-					},
-				},
-				Status: mcev1.MultiClusterEngineStatus{
-					CurrentVersion: "0.11.0",
-				},
-			},
-			expectedStatus: &operatorsv1.MCEVersionComplianceStatus{
-				RequiredChannel: "community-0.10",
-				CurrentVersion:  "0.11.0",
-				IsCompliant:     false,
-				Message:         "MCE version 0.11.0 does not meet channel community-0.10 requirements",
-			},
-			expectCompliant: false,
-		},
-		{
-			name:      "MCE with higher major version is not compliant",
-			createMCE: true,
-			mce: &mcev1.MultiClusterEngine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "multiclusterengine",
-					Labels: map[string]string{
-						multiclusterengineutils.MCEManagedByLabel: "true",
-					},
-				},
-				Status: mcev1.MultiClusterEngineStatus{
-					CurrentVersion: "1.0.0",
-				},
-			},
-			expectedStatus: &operatorsv1.MCEVersionComplianceStatus{
-				RequiredChannel: "community-0.10",
-				CurrentVersion:  "1.0.0",
-				IsCompliant:     false,
-				Message:         "MCE version 1.0.0 does not meet channel community-0.10 requirements",
-			},
-			expectCompliant: false,
-		},
-		{
-			name:      "MCE with lower version is not compliant",
-			createMCE: true,
-			mce: &mcev1.MultiClusterEngine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "multiclusterengine",
-					Labels: map[string]string{
-						multiclusterengineutils.MCEManagedByLabel: "true",
-					},
-				},
-				Status: mcev1.MultiClusterEngineStatus{
-					CurrentVersion: "0.9.0",
-				},
-			},
-			expectedStatus: &operatorsv1.MCEVersionComplianceStatus{
-				RequiredChannel: "community-0.10",
-				CurrentVersion:  "0.9.0",
-				IsCompliant:     false,
-				Message:         "MCE version 0.9.0 does not meet channel community-0.10 requirements",
-			},
-			expectCompliant: false,
 		},
 	}
 
@@ -1212,13 +1130,13 @@ func TestCalculateMCEVersionCompliance(t *testing.T) {
 			// Create MCE if specified
 			if tt.createMCE && tt.mce != nil {
 				if err := recon.Client.Create(ctx, tt.mce); err != nil {
-					t.Fatalf("failed to create MCE: %v", err)
+					t.Errorf("failed to create MCE: %v", err)
 				}
-				t.Cleanup(func() {
+				defer func() {
 					if err := recon.Client.Delete(ctx, tt.mce); err != nil {
-						t.Logf("cleanup: failed to delete MCE: %v", err)
+						t.Errorf("failed to delete MCE: %v", err)
 					}
-				})
+				}()
 			}
 
 			// Test the function

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -63,7 +63,7 @@ func ValidMCEVersion(mceVersion string) error {
 	if _, exists := os.LookupEnv("DISABLE_MCE_MIN_VERSION"); exists {
 		return nil
 	}
-	return validPatchVersion(mceVersion, RequiredMCEVersion)
+	return validVersion(mceVersion, RequiredMCEVersion)
 }
 
 // ValidCommunityMCEVersion returns an error if MCE does not satisfy the minimum version requirement
@@ -72,7 +72,7 @@ func ValidCommunityMCEVersion(mceVersion string) error {
 	if _, exists := os.LookupEnv("DISABLE_MCE_MIN_VERSION"); exists {
 		return nil
 	}
-	return validPatchVersion(mceVersion, RequiredCommunityMCEVersion)
+	return validVersion(mceVersion, RequiredCommunityMCEVersion)
 }
 
 // ValidOCPVersion returns an error if ocpVersion does not satisfy the minimum OCP version requirement
@@ -94,27 +94,6 @@ func validVersion(have, required string) error {
 		return err
 	}
 	if !aboveMinVersion.Check(currentVersion) {
-		return fmt.Errorf("version %s did not meet minimum version requirement of %s", have, required)
-	}
-	return nil
-}
-
-// validPatchVersion checks that "have" matches the major.minor of "required" and has an equal or higher patch version.
-// This is stricter than validVersion: it rejects versions where the minor version differs from the required version.
-func validPatchVersion(have, required string) error {
-	requiredVersion, err := semver.NewVersion(required)
-	if err != nil {
-		return err
-	}
-	currentVersion, err := semver.NewVersion(have)
-	if err != nil {
-		return err
-	}
-	if currentVersion.Major() != requiredVersion.Major() || currentVersion.Minor() != requiredVersion.Minor() {
-		return fmt.Errorf("version %s does not match required major.minor %d.%d",
-			have, requiredVersion.Major(), requiredVersion.Minor())
-	}
-	if currentVersion.LessThan(requiredVersion) {
 		return fmt.Errorf("version %s did not meet minimum version requirement of %s", have, required)
 	}
 	return nil

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -114,19 +114,9 @@ func Test_ValidMCEVersion(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "higher patch version",
-			mceVersion: "2.17.5",
+			name:       "above min",
+			mceVersion: "4.99.99",
 			wantErr:    false,
-		},
-		{
-			name:       "higher minor version rejected",
-			mceVersion: "2.18.0",
-			wantErr:    true,
-		},
-		{
-			name:       "higher major version rejected",
-			mceVersion: "3.0.0",
-			wantErr:    true,
 		},
 		{
 			name:       "below min",
@@ -145,9 +135,9 @@ func Test_ValidMCEVersion(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "dev prerelease is before release",
+			name:       "dev version passing",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredMCEVersion),
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "exact version",
@@ -176,19 +166,9 @@ func Test_ValidCommunityMCEVersion(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "higher patch version",
-			mceVersion: "0.10.5",
+			name:       "above min",
+			mceVersion: "4.99.99",
 			wantErr:    false,
-		},
-		{
-			name:       "higher minor version rejected",
-			mceVersion: "0.11.0",
-			wantErr:    true,
-		},
-		{
-			name:       "higher major version rejected",
-			mceVersion: "1.0.0",
-			wantErr:    true,
 		},
 		{
 			name:       "below min",
@@ -207,9 +187,9 @@ func Test_ValidCommunityMCEVersion(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "dev prerelease is before release",
+			name:       "dev version passing",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredCommunityMCEVersion),
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "exact version",


### PR DESCRIPTION
# Description

Reverts PR #4458 (ACM-38175 backport). The `release-2.17` branch is currently locked to security-fixes-only — 2.17.1 is not accepting non-CVE changes at this time.

The original fix on `main` (PR #4450, ACM-38034) remains merged and is shipping in ACM 5.0.

This backport will be re-landed once 2.17.1 opens for general bug fixes.

## Related Issue

- https://redhat.atlassian.net/browse/ACM-38175
- https://redhat.atlassian.net/browse/ACM-38034

## Changes Made

- Reverts commit d9a5183e733a22ad03457160e7c0817a50e5ed29
- Restores the original `validVersion` function (semver `>=` check)
- Removes `validPatchVersion` function and associated tests added in #4458

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have rebased my branch on top of the latest main/master branch.

## Reviewers

/cc @dislbenn @msmigiel-rh"