### PR TITLE
ACM-38144: add support link to MCE compliance banner

### DIFF
--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -22,6 +22,8 @@ const (
 	mceComplianceBannerName = "acm-mce-version-compliance"
 	bannerBackgroundColor   = "#880808"
 	bannerTextColor         = "#ffffff"
+	bannerSupportLinkHref   = "https://access.redhat.com/support"
+	bannerSupportLinkText   = "Contact Red Hat Support"
 )
 
 func mceComplianceBannerText(currentVersion, requiredChannel string) string {
@@ -66,6 +68,10 @@ func (r *MultiClusterHubReconciler) ensureMCEComplianceBanner(ctx context.Contex
 			Location:        consolev1.BannerTop,
 			BackgroundColor: bannerBackgroundColor,
 			Color:           bannerTextColor,
+			Link: &consolev1.Link{
+				Text: bannerSupportLinkText,
+				Href: bannerSupportLinkHref,
+			},
 		},
 	}
 

--- a/controllers/console_notification_test.go
+++ b/controllers/console_notification_test.go
@@ -75,6 +75,15 @@ func TestEnsureMCEComplianceBanner_NonCompliant(t *testing.T) {
 	if notification.Spec.Color != bannerTextColor {
 		t.Errorf("banner color = %q, want %q", notification.Spec.Color, bannerTextColor)
 	}
+	if notification.Spec.Link == nil {
+		t.Fatal("banner link is nil, expected support link")
+	}
+	if notification.Spec.Link.Href != bannerSupportLinkHref {
+		t.Errorf("banner link href = %q, want %q", notification.Spec.Link.Href, bannerSupportLinkHref)
+	}
+	if notification.Spec.Link.Text != bannerSupportLinkText {
+		t.Errorf("banner link text = %q, want %q", notification.Spec.Link.Text, bannerSupportLinkText)
+	}
 	if notification.Labels["installer.name"] != "multiclusterhub" {
 		t.Errorf("label installer.name = %q, want %q", notification.Labels["installer.name"], "multiclusterhub")
 	}


### PR DESCRIPTION
# Description

Adds a clickable \"Contact Red Hat Support\" link to the MCE version mismatch ConsoleNotification banner, directing users to https://access.redhat.com/support for assistance resolving version mismatch configurations.

The banner text itself is unchanged — the link appears as a separate clickable element rendered by the OCP console via the `spec.link` field on ConsoleNotification.

## Related Issue

- https://redhat.atlassian.net/browse/ACM-38144
- Parent: https://redhat.atlassian.net/browse/ACM-24851

## Changes Made

- Added `bannerSupportLinkHref` and `bannerSupportLinkText` constants
- Added `Link` field to the ConsoleNotification spec in `ensureMCEComplianceBanner`
- Added test assertions verifying the link href and text

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have rebased my branch on top of the latest main/master branch.

## Reviewers

/cc @dislbenn @msmigiel-rh"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Contact Red Hat Support” link to the MCE compliance notification banner.
  * The link directs users to the appropriate Red Hat Support resource.

* **Tests**
  * Added coverage verifying the support link’s destination and displayed text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->