### PR TITLE
ACM-38034: treat pre-release MCE builds as compliant

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -104,6 +104,8 @@ func validVersion(have, required string) error {
 
 // validPatchVersion checks that "have" matches the major.minor of "required" and has an equal or higher patch version.
 // This is stricter than validVersion: it rejects versions where the minor version differs from the required version.
+// Pre-release versions of the same patch (e.g. 5.0.0-123) are treated as compliant because operator builds are
+// frequently tagged with numeric build suffixes that semver ranks below the release version.
 func validPatchVersion(have, required string) error {
 	requiredVersion, err := semver.NewVersion(required)
 	if err != nil {
@@ -117,7 +119,15 @@ func validPatchVersion(have, required string) error {
 		return fmt.Errorf("version %s does not match required major.minor %d.%d",
 			have, requiredVersion.Major(), requiredVersion.Minor())
 	}
-	if currentVersion.LessThan(requiredVersion) {
+	// Use ">= x.y.z-0" so that pre-release builds of the same patch (e.g. 5.0.0-123) satisfy the constraint.
+	// By semver spec, 5.0.0-123 < 5.0.0, but operator builds are routinely shipped with numeric pre-release
+	// suffixes and must be treated as equivalent to the release version for compliance purposes.
+	aboveMinPatch, err := semver.NewConstraint(fmt.Sprintf(">= %d.%d.%d-0",
+		requiredVersion.Major(), requiredVersion.Minor(), requiredVersion.Patch()))
+	if err != nil {
+		return err
+	}
+	if !aboveMinPatch.Check(currentVersion) {
 		return fmt.Errorf("version %s did not meet minimum version requirement of %s", have, required)
 	}
 	return nil

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -145,9 +145,14 @@ func Test_ValidMCEVersion(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "dev prerelease is before release",
+			name:       "prerelease tag compliant (build suffix)",
+			mceVersion: fmt.Sprintf("%s-123", RequiredMCEVersion),
+			wantErr:    false,
+		},
+		{
+			name:       "prerelease tag compliant (dev suffix)",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredMCEVersion),
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "exact version",
@@ -207,9 +212,14 @@ func Test_ValidCommunityMCEVersion(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "dev prerelease is before release",
+			name:       "prerelease tag compliant (build suffix)",
+			mceVersion: fmt.Sprintf("%s-123", RequiredCommunityMCEVersion),
+			wantErr:    false,
+		},
+		{
+			name:       "prerelease tag compliant (dev suffix)",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredCommunityMCEVersion),
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "exact version",


### PR DESCRIPTION
## Summary

**Bug**: `validPatchVersion` used `currentVersion.LessThan(requiredVersion)` to check the patch floor. By semver spec, a pre-release version sorts *below* its release (e.g. `5.0.0-123 < 5.0.0`), so MCE builds tagged with a numeric or string suffix (e.g. `5.0.0-123`) were incorrectly flagged as non-compliant.

**Fix**: Replace the `LessThan` check with a `>= x.y.z-0` semver constraint, which is already the pattern used by `validVersion` for OCP. This makes any `5.0.0-*` pre-release satisfy the constraint while still rejecting genuinely lower patch versions (e.g. `4.9.x`).

- `5.0.0-123` ✅ compliant (build-tagged release)
- `5.0.0-dev` ✅ compliant (dev build)
- `5.0.0` ✅ compliant (exact)
- `5.0.5` ✅ compliant (higher patch)
- `5.1.0` ❌ non-compliant (minor mismatch)
- `4.9.99` ❌ non-compliant (below minimum)

## References

- https://redhat.atlassian.net/browse/ACM-38034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version validation now accepts compatible pre-release builds, including numeric and `-dev` suffixes, when the major, minor, and patch versions match.
  * Updated version checks to correctly recognize operator and development builds as compliant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->