### PR TITLE
ACM-24851: Use PatternFly CSS vars for banner colors

### DIFF
--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -20,8 +20,8 @@ import (
 
 const (
 	mceComplianceBannerName = "acm-mce-version-compliance"
-	bannerBackgroundColor   = "#880808"
-	bannerTextColor         = "#ffffff"
+	bannerBackgroundColor   = "var(--pf-v6-c-banner--m-danger--BackgroundColor, var(--pf-v5-c-banner--m-red--BackgroundColor))"
+	bannerTextColor         = "var(--pf-v6-c-banner--m-danger--Color, var(--pf-v5-global--Color--100))"
 	bannerSupportLinkHref   = "https://access.redhat.com/support"
 	bannerSupportLinkText   = "Contact Red Hat Support"
 )


### PR DESCRIPTION
## Summary

Replace hardcoded hex colors in the MCE compliance `ConsoleNotification` banner with PatternFly CSS custom properties.

## Changes

- `bannerBackgroundColor`: `#880808` → `var(--pf-v6-c-banner--m-danger--BackgroundColor, var(--pf-v5-c-banner--m-red--BackgroundColor))`
- `bannerTextColor`: `#ffffff` → `var(--pf-v6-c-banner--m-danger--Color, var(--pf-v5-global--Color--100))`

## Why

The `ConsoleNotification` CR's `backgroundColor` and `color` fields are injected as inline CSS by the OpenShift Console, so CSS custom properties resolve correctly at render time. Using PatternFly tokens instead of hex values means:

- Colors respond to light/dark mode automatically
- Consistent with the Console's own PatternFly theme
- PF6 tokens are primary; PF5 tokens are fallback for older clusters

## Testing

- Unit tests pass unchanged — they reference the constants, not hardcoded strings
- Custom catalog built and deployed to a test cluster, banner appearance verified

Relates to: ACM-24851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the MCE compliance console notification banner to use theme-aware colors.
  * Improved compatibility with PatternFly v5 and v6 themes while preserving existing banner behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->