### PR TITLE
ACM-37740 Create NetworkPolicy resource for the console

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-networkpolicy.yaml
@@ -1,0 +1,48 @@
+# Copyright Contributors to the Open Cluster Management project
+#
+# NetworkPolicy for console-chart-console-v2 pods in the
+# open-cluster-management namespace.
+#
+# Ingress:
+#   - OpenShift Console (openshift-console namespace) on port 3000
+#     The OCP console reverse-proxies plugin requests to this backend.
+#
+# Egress (allow-all):
+#   The backend proxies requests to the Kubernetes API server (port 443),
+#   search-api (port 4010), observability rbac-query-proxy (port 8443),
+#   Prometheus (port 9091), cluster-proxy-addon (port 9092),
+#   placement-debug (port 9443), and external HTTPS services
+#   (Red Hat SSO, OpenShift Cluster Manager API, Red Hat Insights,
+#   Ansible Automation Platform).
+#   Because targets span many namespaces and include user-configured
+#   external URLs, egress is left unrestricted.
+{{- if .Values.global.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: console-acm-network-policy
+  labels:
+    app: console-chart-v2
+    component: console
+spec:
+  podSelector:
+    matchLabels:
+      app: console-chart-v2
+      component: console
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: console
+          podSelector:
+            matchLabels:
+              app: console
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - {}
+{{- end }}


### PR DESCRIPTION
# Description

Create NetworkPolicy resource to restrict network access for the console pod in the ACM namespace.

## Related Issue

https://redhat.atlassian.net/browse/ACM-37740

## Changes Made

Create NetworkPolicy resource to restrict network access for the console pod in the ACM namespace.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
