### PR TITLE
ACM-38248: Fix NetworkPolicy namespace ordering

### DIFF
--- a/controllers/components.go
+++ b/controllers/components.go
@@ -128,12 +128,12 @@ func (r *MultiClusterHubReconciler) ensureNamespaceAndPullSecret(m *operatorv1.M
 	var err error
 
 	result, err = r.ensureNamespace(m, ns)
-	if result != (ctrl.Result{}) {
+	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
 	result, err = r.ensurePullSecret(m, ns.Name)
-	if result != (ctrl.Result{}) {
+	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}
 

--- a/controllers/components.go
+++ b/controllers/components.go
@@ -83,6 +83,18 @@ func (r *MultiClusterHubReconciler) fetchChartLocation(component string) string 
 	}
 }
 
+// ensureComponentNamespaces creates namespaces for components that deploy to a separate namespace.
+// Must run before ensureNetworkPolicies so policies can target these namespaces.
+func (r *MultiClusterHubReconciler) ensureComponentNamespaces(m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
+	if m.Enabled(operatorv1.ClusterBackup) {
+		result, err := r.ensureNamespaceAndPullSecret(m, BackupNamespace())
+		if result != (ctrl.Result{}) || err != nil {
+			return result, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
 func (r *MultiClusterHubReconciler) ensureComponentOrNoComponent(ctx context.Context, m *operatorv1.MultiClusterHub,
 	component string, cachespec CacheSpec, ocpConsole, isSTSEnabled bool) (ctrl.Result, error) {
 	var result ctrl.Result
@@ -100,13 +112,6 @@ func (r *MultiClusterHubReconciler) ensureComponentOrNoComponent(ctx context.Con
 		return r.ensureNoComponent(ctx, m, component, cachespec, isSTSEnabled)
 
 	} else {
-		if component == operatorv1.ClusterBackup {
-			result, err = r.ensureNamespaceAndPullSecret(m, BackupNamespace())
-			if result != (ctrl.Result{}) || err != nil {
-				return result, err
-			}
-		}
-
 		if component == operatorv1.Console && !ocpConsole {
 			log.Info("OCP console is not enabled")
 			return r.ensureNoComponent(ctx, m, component, cachespec, isSTSEnabled)

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -1396,6 +1396,12 @@ func Test_ensureComponentNamespaces(t *testing.T) {
 	}
 
 	registerScheme()
+
+	// Pre-create backup namespace as Active so ensureNamespace doesn't return RequeueAfter
+	backupNS := BackupNamespace()
+	backupNS.Status.Phase = corev1.NamespaceActive
+	_ = recon.Client.Create(context.TODO(), backupNS)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := recon.ensureComponentNamespaces(tt.mch)

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -1344,6 +1344,78 @@ func Test_ensureNamespaceAndPullSecret(t *testing.T) {
 	}
 }
 
+func Test_ensureComponentNamespaces(t *testing.T) {
+	tests := []struct {
+		name       string
+		mch        *operatorv1.MultiClusterHub
+		wantResult ctrl.Result
+		wantErr    bool
+	}{
+		{
+			name: "should create backup namespace when cluster-backup enabled",
+			mch: &operatorv1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{Name: "mch", Namespace: "ocm"},
+				Spec: operatorv1.MultiClusterHubSpec{
+					Overrides: &operatorv1.Overrides{
+						Components: []operatorv1.ComponentConfig{
+							{
+								Enabled: true,
+								Name:    operatorv1.ClusterBackup,
+							},
+						},
+					},
+				},
+			},
+			wantResult: ctrl.Result{},
+			wantErr:    false,
+		},
+		{
+			name: "should skip namespace creation when cluster-backup disabled",
+			mch: &operatorv1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{Name: "mch", Namespace: "ocm"},
+				Spec: operatorv1.MultiClusterHubSpec{
+					Overrides: &operatorv1.Overrides{
+						Components: []operatorv1.ComponentConfig{
+							{
+								Enabled: false,
+								Name:    operatorv1.ClusterBackup,
+							},
+						},
+					},
+				},
+			},
+			wantResult: ctrl.Result{},
+			wantErr:    false,
+		},
+		{
+			name:       "should skip namespace creation when no overrides",
+			mch:        &operatorv1.MultiClusterHub{ObjectMeta: metav1.ObjectMeta{Name: "mch", Namespace: "ocm"}},
+			wantResult: ctrl.Result{},
+			wantErr:    false,
+		},
+	}
+
+	registerScheme()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := recon.ensureComponentNamespaces(tt.mch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ensureComponentNamespaces() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if result != tt.wantResult {
+				t.Errorf("ensureComponentNamespaces() result = %v, want %v", result, tt.wantResult)
+			}
+
+			if tt.mch.Enabled(operatorv1.ClusterBackup) {
+				ns := &corev1.Namespace{}
+				if err := recon.Client.Get(context.TODO(), types.NamespacedName{Name: BackupNamespace().Name}, ns); err != nil {
+					t.Errorf("expected backup namespace to be created, got error: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func Test_ensureInternalHubComponent(t *testing.T) {
 	tests := []struct {
 		name string

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -343,6 +343,11 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
+	result, err = r.ensureComponentNamespaces(multiClusterHub)
+	if result != (ctrl.Result{}) || err != nil {
+		return result, err
+	}
+
 	/*
 		Ensure NetworkPolicies for ACM components. This implements a create-once pattern where
 		MCH creates initial NetworkPolicy resources with delegation annotations. Operand teams


### PR DESCRIPTION
# Description

Fixes ACM-38248: Cannot enable cluster-backup. When cluster-backup is enabled, MCH gets stuck in Pending because `ensureNetworkPolicies` tries to create a NetworkPolicy in the `open-cluster-management-backup` namespace before that namespace exists. The namespace was previously created inside the component loop, which runs after NetworkPolicies.

## Related Issue

https://redhat.atlassian.net/browse/ACM-38248

## Changes Made

- **Fix NetworkPolicy namespace ordering** — Extracted `ensureComponentNamespaces()` to create component-specific namespaces (e.g. `open-cluster-management-backup`) before `ensureNetworkPolicies` runs, fixing the `"namespaces not found"` error that blocks cluster-backup enablement.
- **Fix error propagation in `ensureNamespaceAndPullSecret`** — Check `err != nil` (not just non-empty Result) after `ensureNamespace` and `ensurePullSecret` calls, preventing silent error masking.
- **Add unit tests** — Tests for `ensureComponentNamespaces` covering enabled, disabled, and no-overrides cases.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

The `ensureComponentNamespaces` function is designed to be extensible — if future components need separate namespaces, they can be added there. Currently only `cluster-backup` deploys to a separate namespace (`open-cluster-management-backup`).

The disabled-component cleanup path (`ensureNoNamespace`) remains in the component loop — cleanup doesn't need to happen before NetworkPolicies.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.