### PR TITLE
Fix controller-runtime requeue+error warnings and MCE NoMatchError handling

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stolostron/multiclusterhub-operator/pkg/version"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -298,6 +299,10 @@ func (r *MultiClusterHubReconciler) ensureClusterRoleBinding(m *operatorv1.Multi
 func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Context, m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 	mce, err := multiclusterengine.FindAndManageMCE(ctx, r.Client)
 	if err != nil {
+		if apimeta.IsNoMatchError(err) {
+			r.Log.WithName("WARNING").Info("MCE CRD not yet available, requeueing")
+			return ctrl.Result{RequeueAfter: resyncPeriod}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -328,7 +333,7 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 		mce = multiclusterengine.NewMultiClusterEngine(m, targetNS)
 		err = r.Client.Create(ctx, mce)
 		if err != nil {
-			return ctrl.Result{Requeue: true}, fmt.Errorf("error creating new MCE: %w", err)
+			return ctrl.Result{}, fmt.Errorf("error creating new MCE: %w", err)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -342,7 +347,7 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 
 	// secret should be delivered to targetNamespace
 	if mce.Spec.TargetNamespace == "" {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("MCE %s does not have a target namespace to apply pullsecret", mce.Name)
+		return ctrl.Result{}, fmt.Errorf("MCE %s does not have a target namespace to apply pullsecret", mce.Name)
 	}
 	result, err := r.ensurePullSecret(m, mce.Spec.TargetNamespace)
 	if result != (ctrl.Result{}) {
@@ -352,7 +357,7 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 	calcMCE := multiclusterengine.RenderMultiClusterEngine(mce, m)
 	err = r.Client.Update(ctx, calcMCE)
 	if err != nil {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("error updating MCE %s: %w", mce.Name, err)
+		return ctrl.Result{}, fmt.Errorf("error updating MCE %s: %w", mce.Name, err)
 	}
 	return ctrl.Result{}, nil
 }
@@ -674,7 +679,7 @@ func (r *MultiClusterHubReconciler) ensureMCESubscription(ctx context.Context, m
 		err = r.Client.Update(ctx, calcSub)
 	}
 	if err != nil {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("error updating subscription %s: %w", calcSub.Name, err)
+		return ctrl.Result{}, fmt.Errorf("error updating subscription %s: %w", calcSub.Name, err)
 	}
 
 	return ctrl.Result{}, nil
@@ -757,7 +762,7 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 		err = r.Client.Update(ctx, calcCE)
 	}
 	if err != nil {
-		return ctrl.Result{Requeue: true}, fmt.Errorf("error updating ClusterExtension %s: %w", calcCE.Name, err)
+		return ctrl.Result{}, fmt.Errorf("error updating ClusterExtension %s: %w", calcCE.Name, err)
 	}
 
 	return ctrl.Result{}, nil
@@ -766,12 +771,12 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 func (r *MultiClusterHubReconciler) ensureMultiClusterEngine(ctx context.Context, multiClusterHub *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 	// confirm subscription and reqs exist and are configured correctly
 	result, err := r.ensureMCESubscription(ctx, multiClusterHub)
-	if result != (ctrl.Result{}) {
+	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}
 
 	result, err = r.ensureMultiClusterEngineCR(ctx, multiClusterHub)
-	if result != (ctrl.Result{}) {
+	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}
 

--- a/controllers/common_olm_test.go
+++ b/controllers/common_olm_test.go
@@ -540,10 +540,11 @@ func TestEnsureMultiClusterEngineCR_NoMatchError(t *testing.T) {
 
 func TestEnsureMultiClusterEngine(t *testing.T) {
 	tests := []struct {
-		name       string
-		olmVersion string
-		client     client.Client
-		wantError  bool
+		name           string
+		olmVersion     string
+		client         client.Client
+		wantError      bool
+		wantResult     ctrl.Result
 	}{
 		{
 			name:       "subscription error propagates",
@@ -552,7 +553,8 @@ func TestEnsureMultiClusterEngine(t *testing.T) {
 				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
 				getErr: fmt.Errorf("simulated subscription error"),
 			},
-			wantError: true,
+			wantError:  true,
+			wantResult: ctrl.Result{},
 		},
 		{
 			name:       "no OLM - MCE CR NoMatchError propagates as requeue",
@@ -563,7 +565,8 @@ func TestEnsureMultiClusterEngine(t *testing.T) {
 					GroupKind: schema.GroupKind{Group: "multicluster.openshift.io", Kind: "MultiClusterEngine"},
 				},
 			},
-			wantError: false,
+			wantError:  false,
+			wantResult: ctrl.Result{RequeueAfter: resyncPeriod},
 		},
 	}
 
@@ -590,13 +593,13 @@ func TestEnsureMultiClusterEngine(t *testing.T) {
 				if err == nil {
 					t.Errorf("ensureMultiClusterEngine() expected error but got none")
 				}
-				if result != (ctrl.Result{}) {
-					t.Errorf("ensureMultiClusterEngine() expected empty result on error, got %v", result)
-				}
 			} else {
 				if err != nil {
 					t.Errorf("ensureMultiClusterEngine() unexpected error: %v", err)
 				}
+			}
+			if result != tt.wantResult {
+				t.Errorf("ensureMultiClusterEngine() result = %v, want %v", result, tt.wantResult)
 			}
 		})
 	}

--- a/controllers/common_olm_test.go
+++ b/controllers/common_olm_test.go
@@ -540,11 +540,11 @@ func TestEnsureMultiClusterEngineCR_NoMatchError(t *testing.T) {
 
 func TestEnsureMultiClusterEngine(t *testing.T) {
 	tests := []struct {
-		name           string
-		olmVersion     string
-		client         client.Client
-		wantError      bool
-		wantResult     ctrl.Result
+		name       string
+		olmVersion string
+		client     client.Client
+		wantError  bool
+		wantResult ctrl.Result
 	}{
 		{
 			name:       "subscription error propagates",

--- a/controllers/common_olm_test.go
+++ b/controllers/common_olm_test.go
@@ -435,7 +435,7 @@ func TestEnsureMultiClusterEngineCR(t *testing.T) {
 			},
 			olmVersion:  "v0",
 			wantError:   true,
-			wantRequeue: true,
+			wantRequeue: false,
 			wantCreate:  false,
 		},
 	}

--- a/controllers/common_olm_test.go
+++ b/controllers/common_olm_test.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -16,7 +17,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -501,6 +504,104 @@ func TestEnsureMultiClusterEngineCR(t *testing.T) {
 	}
 }
 
+func TestEnsureMultiClusterEngineCR_NoMatchError(t *testing.T) {
+	noMatchErr := &apimeta.NoKindMatchError{
+		GroupKind: schema.GroupKind{Group: "multicluster.openshift.io", Kind: "MultiClusterEngine"},
+	}
+
+	noMatchClient := &listErrorClient{
+		Client:  fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+		listErr: noMatchErr,
+	}
+
+	reconciler := &MultiClusterHubReconciler{
+		Client: noMatchClient,
+		Scheme: scheme.Scheme,
+		Log:    clog.Log.WithName("test"),
+	}
+
+	mch := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch",
+			Namespace: "test-namespace",
+		},
+	}
+
+	ctx := context.Background()
+	result, err := reconciler.ensureMultiClusterEngineCR(ctx, mch)
+
+	if err != nil {
+		t.Errorf("ensureMultiClusterEngineCR() expected nil error for NoMatchError, got: %v", err)
+	}
+	if result.RequeueAfter != resyncPeriod {
+		t.Errorf("ensureMultiClusterEngineCR() expected RequeueAfter=%v, got %v", resyncPeriod, result.RequeueAfter)
+	}
+}
+
+func TestEnsureMultiClusterEngine(t *testing.T) {
+	tests := []struct {
+		name       string
+		olmVersion string
+		client     client.Client
+		wantError  bool
+	}{
+		{
+			name:       "subscription error propagates",
+			olmVersion: "v1",
+			client: &errorClient{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				getErr: fmt.Errorf("simulated subscription error"),
+			},
+			wantError: true,
+		},
+		{
+			name:       "no OLM - MCE CR NoMatchError propagates as requeue",
+			olmVersion: "",
+			client: &listErrorClient{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				listErr: &apimeta.NoKindMatchError{
+					GroupKind: schema.GroupKind{Group: "multicluster.openshift.io", Kind: "MultiClusterEngine"},
+				},
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := &MultiClusterHubReconciler{
+				Client:     tt.client,
+				Scheme:     scheme.Scheme,
+				Log:        clog.Log.WithName("test"),
+				OLMVersion: tt.olmVersion,
+			}
+
+			mch := &operatorsv1.MultiClusterHub{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mch",
+					Namespace: "test-namespace",
+				},
+			}
+
+			ctx := context.Background()
+			result, err := reconciler.ensureMultiClusterEngine(ctx, mch)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("ensureMultiClusterEngine() expected error but got none")
+				}
+				if result != (ctrl.Result{}) {
+					t.Errorf("ensureMultiClusterEngine() expected empty result on error, got %v", result)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ensureMultiClusterEngine() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
 // errorClient wraps a fake client and returns errors for Get operations
 type errorClient struct {
 	client.Client
@@ -512,6 +613,19 @@ func (e *errorClient) Get(ctx context.Context, key types.NamespacedName, obj cli
 		return e.getErr
 	}
 	return e.Client.Get(ctx, key, obj, opts...)
+}
+
+// listErrorClient wraps a fake client and returns errors for List operations
+type listErrorClient struct {
+	client.Client
+	listErr error
+}
+
+func (e *listErrorClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if e.listErr != nil {
+		return e.listErr
+	}
+	return e.Client.List(ctx, list, opts...)
 }
 
 // Helper to find condition in status

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -1104,6 +1104,27 @@ func Test_ensureAuthenticationIssuerNotEmpty(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("should return empty result on error", func(t *testing.T) {
+		errReconciler := &MultiClusterHubReconciler{
+			Client: &errorClient{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				getErr: fmt.Errorf("simulated get error"),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		result, authOk, err := errReconciler.ensureAuthenticationIssuerNotEmpty(context.TODO())
+		if err == nil {
+			t.Errorf("expected error but got none")
+		}
+		if authOk {
+			t.Errorf("expected false but got true")
+		}
+		if result != (ctrl.Result{}) {
+			t.Errorf("expected empty result but got %v", result)
+		}
+	})
 }
 
 func Test_ensureCloudCredentialModeManual(t *testing.T) {
@@ -1148,6 +1169,27 @@ func Test_ensureCloudCredentialModeManual(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("should return empty result on error", func(t *testing.T) {
+		errReconciler := &MultiClusterHubReconciler{
+			Client: &errorClient{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				getErr: fmt.Errorf("simulated get error"),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		result, cloudCredOK, err := errReconciler.ensureCloudCredentialModeManual(context.TODO())
+		if err == nil {
+			t.Errorf("expected error but got none")
+		}
+		if cloudCredOK {
+			t.Errorf("expected false but got true")
+		}
+		if result != (ctrl.Result{}) {
+			t.Errorf("expected empty result but got %v", result)
+		}
+	})
 }
 
 func Test_ensureInfrastructureAWS(t *testing.T) {
@@ -1192,6 +1234,27 @@ func Test_ensureInfrastructureAWS(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("should return empty result on error", func(t *testing.T) {
+		errReconciler := &MultiClusterHubReconciler{
+			Client: &errorClient{
+				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+				getErr: fmt.Errorf("simulated get error"),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		result, infraOk, err := errReconciler.ensureInfrastructureAWS(context.TODO())
+		if err == nil {
+			t.Errorf("expected error but got none")
+		}
+		if infraOk {
+			t.Errorf("expected false but got true")
+		}
+		if result != (ctrl.Result{}) {
+			t.Errorf("expected empty result but got %v", result)
+		}
+	})
 }
 
 func Test_verifyCRDExists(t *testing.T) {

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -324,7 +324,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		present for the other components to deploy successfully.
 	*/
 	result, err = r.ensureMultiClusterEngine(ctx, multiClusterHub)
-	if result != (ctrl.Result{}) {
+	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}
 

--- a/controllers/sts.go
+++ b/controllers/sts.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
-	utils "github.com/stolostron/multiclusterhub-operator/pkg/utils"
 
 	configv1 "github.com/openshift/api/config/v1"
 	ocopv1 "github.com/openshift/api/operator/v1"
@@ -44,7 +43,7 @@ func (r *MultiClusterHubReconciler) ensureAuthenticationIssuerNotEmpty(ctx conte
 	exists, err := r.ensureObjectExistsAndNotDeleted(ctx, auth, "cluster")
 
 	if err != nil || !exists {
-		return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, false, err
+		return ctrl.Result{}, false, err
 	}
 
 	stsEnabled := auth.Spec.ServiceAccountIssuer != "" // Determine STS enabled status
@@ -66,7 +65,7 @@ func (r *MultiClusterHubReconciler) ensureCloudCredentialModeManual(ctx context.
 	exists, err := r.ensureObjectExistsAndNotDeleted(ctx, cloudCred, "cluster")
 
 	if err != nil || !exists {
-		return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, false, err
+		return ctrl.Result{}, false, err
 	}
 
 	stsEnabled := cloudCred.Spec.CredentialsMode == "Manual" // Determine STS enabled status
@@ -88,7 +87,7 @@ func (r *MultiClusterHubReconciler) ensureInfrastructureAWS(ctx context.Context)
 	exists, err := r.ensureObjectExistsAndNotDeleted(ctx, infra, "cluster")
 
 	if err != nil || !exists {
-		return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, false, err
+		return ctrl.Result{}, false, err
 	}
 
 	stsEnabled := infra.Spec.PlatformSpec.Type == "AWS"


### PR DESCRIPTION
# Description

Fix controller-runtime warnings caused by returning both a non-nil error and a Result with Requeue set. Also intercept transient MCE CRD NoMatchError to avoid ERROR-level stack traces during initial install.

## Related Issue

Related to ACM-38248 (log noise during install)

## Changes Made

- **Stop returning both error and requeue result** — controller-runtime ignores the requeue when error is non-nil, triggering a warning. Changed 5 spots in `common.go` and 3 in `sts.go` to return `ctrl.Result{}` with the error instead.
- **Intercept MCE CRD NoMatchError** — When MCE CRD is not yet installed, `FindAndManageMCE` returns a `NoMatchError`. Instead of surfacing this as ERROR with stack trace, intercept it in `ensureMultiClusterEngineCR` and log at INFO level with requeue.
- **Fix caller checks in `ensureMultiClusterEngine`** — The `if result != (ctrl.Result{})` pattern silently swallows errors when result is empty. Added `|| err != nil` to 2 caller sites.
- **Remove unused import** — Removed `utils` import from `sts.go` after eliminating `WarningRefreshInterval` references.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

The `if result != (ctrl.Result{})` caller pattern silently drops errors when a function returns `(ctrl.Result{}, err)`. The two fixed call sites in `ensureMultiClusterEngine` now also check `|| err != nil`.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness handling when MultiCluster Engine custom resources aren’t available yet (treating “no match” as a non-fatal condition and scheduling a resync).
  * Corrected reconcile flow to properly propagate errors even when no immediate requeue result is set.
  * Standardized error/queue behavior for subscription and resource target-namespace validation failures.
  * Updated STS condition checks to return consistent errors without explicit retry delays.

* **Tests**
  * Expanded unit coverage for “no match” scenarios, subscription/list failure handling, and error paths in authentication issuer, cloud credential mode, and AWS infrastructure checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->