### PR TITLE
Add HTTP timeout to catalogd API client

### DIFF
--- a/pkg/multiclusterengine/olm/v1/clustercatalog.go
+++ b/pkg/multiclusterengine/olm/v1/clustercatalog.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
@@ -152,7 +153,10 @@ func catalogContainsPackage(ctx context.Context, cl client.Client, catalogName, 
 			MinVersion:         minTLSVersion,
 		},
 	}
-	client := &http.Client{Transport: tr}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   30 * time.Second,
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {


### PR DESCRIPTION
## Description

The HTTP client in `catalogContainsPackage` had no timeout configured. When the catalogd ClusterIP service is unreachable (e.g., due to OVN routing issues or NetworkPolicy misconfiguration), the HTTP call hangs indefinitely, blocking the entire MCH reconciler.

This adds a 30-second timeout to the HTTP client so the request fails gracefully and the reconciler can requeue instead of hanging forever.

## Changes Made

- Added `Timeout: 30 * time.Second` to the `http.Client` in `catalogContainsPackage` (`pkg/multiclusterengine/olm/v1/clustercatalog.go`)

## How was this tested?

- Observed the hang on a live cluster where ClusterIP routing to `catalogd-service.openshift-catalogd.svc` was broken (pod IP worked, ClusterIP timed out)
- `go vet` passes

## Checklist

- [x] Descriptive commit message
- [x] Commits are signed off (DCO)

/cc @cameronmwall @ngraham20

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 30-second timeout when retrieving catalog information, preventing requests from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->