### PR TITLE
ACM-38913 - Add NetworkPolicy for multicluster-role-assignment controller

### DIFF
--- a/pkg/templates/charts/toggle/fine-grained-rbac/templates/multicluster-role-assignment-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/fine-grained-rbac/templates/multicluster-role-assignment-networkpolicy.yaml
@@ -1,0 +1,37 @@
+# NetworkPolicy for multicluster-role-assignment-controller pods.
+#
+# Ingress:
+#   - Metrics endpoint (port 8443) from Prometheus/monitoring
+#   - Health probes (port 8081) for liveness/readiness checks
+#
+# Egress (allow-all):
+#   The controller talks to the Kubernetes API server to manage
+#   ClusterPermissions, MultiClusterRoleAssignments, and PlacementDecisions.
+#   Because the API server endpoint IP and port are not statically known,
+#   egress is left unrestricted.
+{{- if .Values.global.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: multicluster-role-assignment-controller
+  namespace: '{{ default "open-cluster-management" .Values.global.namespace }}'
+  labels:
+    app.kubernetes.io/name: multicluster-role-assignment
+    app.kubernetes.io/managed-by: multiclusterhub-operator
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: multicluster-role-assignment-controller
+      app.kubernetes.io/name: multicluster-role-assignment
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+    - port: 8081
+      protocol: TCP
+  egress:
+  - {}
+{{- end }}


### PR DESCRIPTION
## Summary
- Adds a NetworkPolicy Helm template for the multicluster-role-assignment (fine-grained-rbac) controller
- Gated behind `global.networkPolicies.enabled`, consistent with existing ACM component NetworkPolicies (console, mtv-integrations, cluster-backup)
- Ingress: allows metrics port (8443) and health probe port (8081)
- Egress: unrestricted (controller requires Kubernetes API server access for managing ClusterPermissions, MultiClusterRoleAssignments, and PlacementDecisions)

## Jira
https://redhat.atlassian.net/browse/ACM-38913

## Test plan
- [ ] Deploy MCH with `networkPolicies.enabled: true` and verify the NetworkPolicy is created in the `open-cluster-management` namespace
- [ ] Verify MRA controller pod continues to function (health probes pass, reconciliation works)
- [ ] Verify NetworkPolicy is not created when `networkPolicies.enabled: false`

/cc @cameronmwall @dislbenn @ngraham20