### PR TITLE
ACM-37751 - insights-client + insights-metrics networkpolicies

### DIFF
--- a/pkg/templates/charts/toggle/insights/templates/insights-client-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/insights/templates/insights-client-networkpolicy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: insights-client-network-policy
+  labels:
+    app: {{ .Chart.Name }}
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    component: insights-client
+    release: {{ .Chart.Name }}
+    heritage: release-service
+spec:
+  podSelector:
+    matchLabels:
+      name: insights-client
+  policyTypes:
+  - Ingress
+{{- end }}

--- a/pkg/templates/charts/toggle/insights/templates/insights-metrics-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/insights/templates/insights-metrics-networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: insights-metrics-network-policy
+  labels:
+    app: {{ .Chart.Name }}
+    chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+    component: insights-metrics
+    release: {{ .Chart.Name }}
+    heritage: release-service
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      component: "insights-metrics"
+      release: {{ .Chart.Name }}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - port: 8443
+      protocol: TCP
+  policyTypes:
+    - Ingress
+{{- end }}


### PR DESCRIPTION
# Description

Creates NetworkPolicies for insights-client and insights-metrics

## Related Issue

https://redhat.atlassian.net/browse/ACM-37751

## Changes Made

Creates new NetworkPolicy template files for insights-client and insights-metrics

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional network policies for Insights client and metrics components.
  * Policies restrict inbound traffic and can be enabled through the chart’s network policy configuration.
  * Metrics access is limited to approved monitoring traffic on port 8443.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->