### PR TITLE
ACM-38962 Skip catalog lookup when ClusterExtension already exists

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -310,7 +310,8 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 		// Determine target namespace from OLM resource if it exists
 		targetNS := multiclusterengine.OperandNamespace() // default
 
-		if r.OLMVersion == "v1" {
+		switch r.OLMVersion {
+		case "v1":
 			// Check if ClusterExtension exists to get its namespace
 			ce, err := v1.GetManagedMCEClusterExtension(ctx, r.Client)
 			if err != nil {
@@ -319,7 +320,7 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 			if ce != nil {
 				targetNS = ce.Spec.Namespace
 			}
-		} else if r.OLMVersion == "v0" {
+		case "v0":
 			// Check if Subscription exists to get its namespace
 			sub, err := v0.GetManagedMCESubscription(ctx, r.Client)
 			if err != nil {
@@ -579,8 +580,8 @@ func addInstallerLabelSecret(d *corev1.Secret, name string, ns string) bool {
 	return updated
 }
 
-// ensureMCESubscription verifies resources needed for MCE are created
-func (r *MultiClusterHubReconciler) ensureMCESubscription(ctx context.Context, multiClusterHub *operatorv1.MultiClusterHub) (ctrl.Result, error) {
+// ensureMCEInstallation verifies OLM resources needed for MCE are created (Subscription for v0, ClusterExtension for v1)
+func (r *MultiClusterHubReconciler) ensureMCEInstallation(ctx context.Context, multiClusterHub *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 	// If no OLM detected, skip subscription management
 	// MCE is expected to be pre-installed or managed externally
 	if r.OLMVersion == "" {
@@ -695,13 +696,6 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 		return ctrl.Result{}, err
 	}
 
-	// Get ClusterCatalog containing MCE package
-	catalogName, err := v1.GetClusterCatalog(ctx, r.Client, desiredPackage)
-	if err != nil {
-		r.Log.Info("Failed to find a suitable ClusterCatalog", "error", err)
-		return ctrl.Result{}, err
-	}
-
 	// Get annotation overrides for ClusterExtension
 	overrides, err := v1.GetAnnotationOverrides(multiClusterHub)
 	if err != nil {
@@ -716,6 +710,16 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 	operandNs := multiclusterengine.OperandNamespace()
 
 	if mceCE == nil {
+		// Pre-flight: check if a catalog contains the MCE package.
+		// Non-fatal because OLM v1 resolves catalogs automatically via SourceType+PackageName.
+		catalogName, catErr := v1.GetClusterCatalog(ctx, r.Client, desiredPackage)
+		if catErr != nil {
+			r.Log.Info("No ClusterCatalog found containing package, OLM v1 will resolve automatically",
+				"package", desiredPackage, "error", catErr)
+		} else {
+			r.Log.Info("Found ClusterCatalog for package", "catalog", catalogName, "package", desiredPackage)
+		}
+
 		// ClusterExtension doesn't exist - ensure namespace and mark for creation
 		result, err := r.ensureNamespace(multiClusterHub, namespace)
 		if result != (ctrl.Result{}) {
@@ -752,7 +756,7 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 
 	// Create or update ClusterExtension
 	if createCE {
-		r.Log.Info("Creating MCE ClusterExtension", "name", calcCE.Name, "catalog", catalogName)
+		r.Log.Info("Creating MCE ClusterExtension", "name", calcCE.Name)
 		err = r.Client.Create(ctx, calcCE)
 		if err == nil {
 			r.Log.Info("MCE ClusterExtension created successfully", "name", calcCE.Name)
@@ -770,7 +774,7 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 
 func (r *MultiClusterHubReconciler) ensureMultiClusterEngine(ctx context.Context, multiClusterHub *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 	// confirm subscription and reqs exist and are configured correctly
-	result, err := r.ensureMCESubscription(ctx, multiClusterHub)
+	result, err := r.ensureMCEInstallation(ctx, multiClusterHub)
 	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}

--- a/controllers/common_olm_test.go
+++ b/controllers/common_olm_test.go
@@ -547,14 +547,14 @@ func TestEnsureMultiClusterEngine(t *testing.T) {
 		wantResult ctrl.Result
 	}{
 		{
-			name:       "subscription error propagates",
+			name:       "v1 get error causes requeue",
 			olmVersion: "v1",
 			client: &errorClient{
 				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
-				getErr: fmt.Errorf("simulated subscription error"),
+				getErr: fmt.Errorf("simulated get error"),
 			},
-			wantError:  true,
-			wantResult: ctrl.Result{},
+			wantError:  false,
+			wantResult: ctrl.Result{Requeue: true},
 		},
 		{
 			name:       "no OLM - MCE CR NoMatchError propagates as requeue",
@@ -913,7 +913,7 @@ func TestEnsureMCESubscription(t *testing.T) {
 					Namespace: "test-ns",
 				},
 			},
-			wantError:   true, // Will error due to no ClusterCatalog
+			wantError:   false,
 			wantRequeue: false,
 		},
 	}
@@ -940,22 +940,22 @@ func TestEnsureMCESubscription(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			result, err := reconciler.ensureMCESubscription(ctx, tt.mch)
+			result, err := reconciler.ensureMCEInstallation(ctx, tt.mch)
 
 			if tt.wantError {
 				if err == nil {
-					t.Errorf("ensureMCESubscription() expected error but got none")
+					t.Errorf("ensureMCEInstallation() expected error but got none")
 				}
 				return
 			}
 
 			if err != nil {
-				t.Errorf("ensureMCESubscription() unexpected error: %v", err)
+				t.Errorf("ensureMCEInstallation() unexpected error: %v", err)
 				return
 			}
 
 			if tt.wantRequeue && result.Requeue == false {
-				t.Errorf("ensureMCESubscription() expected requeue but got none")
+				t.Errorf("ensureMCEInstallation() expected requeue but got none")
 			}
 		})
 	}
@@ -970,7 +970,7 @@ func TestEnsureMCEClusterExtension(t *testing.T) {
 		wantRequeue bool
 	}{
 		{
-			name: "No ClusterCatalog found - error",
+			name: "No ClusterCatalog found - proceeds with CE creation",
 			objects: []client.Object{
 				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
@@ -984,11 +984,11 @@ func TestEnsureMCEClusterExtension(t *testing.T) {
 					Namespace: "test-ns",
 				},
 			},
-			wantError:   true,
+			wantError:   false,
 			wantRequeue: false,
 		},
 		{
-			name: "No serving ClusterCatalog - error",
+			name: "No serving ClusterCatalog - proceeds with CE creation",
 			objects: []client.Object{
 				&ocv1.ClusterCatalog{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1010,7 +1010,7 @@ func TestEnsureMCEClusterExtension(t *testing.T) {
 					Namespace: "test-ns",
 				},
 			},
-			wantError:   true,
+			wantError:   false,
 			wantRequeue: false,
 		},
 	}


### PR DESCRIPTION
# Description

On OLM v1 clusters, `GetClusterCatalog` was called on every reconcile, querying all serving catalogs via HTTP even when the MCE ClusterExtension already existed. When catalogd returns 404 during catalog unpacking, this caused rapid error-driven requeue loops and added up to 30s × N catalogs of latency per reconcile, roughly doubling automation runtime.

## Related Issue

- [ACM-38962](https://redhat.atlassian.net/browse/ACM-38962) - Timeout errors keep repeating in MCH pod logs after OLM v1 install

## Changes Made

- **Skip catalog lookup when CE exists**: Moved `GetClusterCatalog` inside the `mceCE == nil` block so it only runs during initial ClusterExtension creation. When the CE already exists, the catalog lookup is skipped entirely.
- **Non-fatal catalog lookup**: Made the catalog lookup non-fatal (log info, continue) since OLM v1 resolves catalogs automatically via `SourceType` + `PackageName`. The `catalogName` result was never wired into the CE spec.
- **Rename `ensureMCESubscription` → `ensureMCEInstallation`**: Better reflects that the function handles both OLM v0 (Subscription) and OLM v1 (ClusterExtension) paths.
- **Updated tests**: Adjusted 4 test cases in `common_olm_test.go` to reflect the new non-fatal catalog lookup behavior.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

**Root cause**: `catalogName` from `GetClusterCatalog` was only used in a log message — `NewClusterExtension` and `RenderClusterExtension` never reference a specific catalog name. OLM v1 resolves the catalog automatically via `SourceType: "Catalog"` + `CatalogFilter.PackageName`. The lookup was purely a pre-flight validation that became a blocking operation on every reconcile.

**Edge cases handled**:
- **Upgrade**: CE exists → skip lookup → `RenderClusterExtension` updates channels → OLM v1 resolves catalog
- **CE deleted**: `mceCE == nil` → lookup runs as pre-flight info → CE recreated
- **Catalog changes**: CE spec has no catalog name reference → OLM v1 handles automatically

## Reviewers

/cc @cameronmwall @ngraham20

[ACM-38962]: https://redhat.atlassian.net/browse/ACM-38962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing MultiCluster Engine installation across both OLM versions.
  * Automatically determines the appropriate installation target and configuration based on the detected OLM version.

* **Bug Fixes**
  * Missing catalog information no longer blocks installation when automatic resolution is available.
  * Improved retry behavior when required resources cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->