### PR TITLE
ACM-37793: Grant ClusterExtension read access for OLMv1 detection

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/console/templates/console-clusterrole.yaml
@@ -31,6 +31,15 @@ rules:
   - watch
 
 - apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
   - operator.open-cluster-management.io
   resources:
   - multiclusterhubs

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -468,6 +468,8 @@ package main
 //+kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthclients,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=*;multiclusterobservabilities;endpointmonitorings,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=observability.open-cluster-management.io,resources=*;multiclusterobservabilities;endpointmonitorings,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=get;list;watch
+//+kubebuilder:rbac:groups=olm.operatorframework.io,resources=clusterextensions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=internalhubcomponents,verbs=get;list;update;patch
 //+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=internalhubcomponents,verbs=get;list;update;patch
 //+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=internalhubcomponents,verbs=get;list;update;watch


### PR DESCRIPTION
## Summary

* Grants `get`/`list`/`watch` on `olm.operatorframework.io/clusterextensions` so the ACM console can watch OLMv1 `ClusterExtension` resources without Forbidden errors.
* Updates console ClusterRole template and regenerates `rbac_gen.go`.
* Required companion for stolostron/console#6590 / ACM-37793 (mirrors stolostron/backplane-operator#3733 for the ACM side).
* `clusterextensions` permission already granted at https://github.com/stolostron/multiclusterhub-operator/blob/d6ee209f277b1105b5f506bba5fa56bce72a8d0a/config/rbac/role.yaml#L1309

## Test plan

* [ ] Confirm generated RBAC markers include `clusterextensions` (`go generate` no unexpected diff)
* [ ] Deploy/update ACM and verify `open-cluster-management:console:clusterrole` includes `clusterextensions`
* [ ] On a hub with OLMv1, confirm console SSE/watch of `ClusterExtension` is no longer Forbidden
* [ ] On a hub without the CRD, confirm existing Subscription-based detection still works

## Reviewers

/cc @cameronmwall @dislbenn @ngraham20

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to cluster extension information, enabling the console to retrieve, list, and monitor available cluster extensions.
  * Updated permissions consistently across deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->