### PR TITLE
Force OADP to always use v0 Subscription until v1-ready bundles ship

### DIFF
--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -22,8 +22,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
@@ -437,35 +435,13 @@ func validateOLMAnnotations(ctx context.Context, mch *MultiClusterHub) error {
 		return fmt.Errorf("validating MCE OLM annotations: %w", err)
 	}
 
-	// OADP doesn't support AllNamespaces install mode required by OLM v1 on OCP <5.0.
-	// Validate OADP annotations against the effective OADP OLM version.
-	oadpOLMVersion := olmVersion
-	if olmVersion == "v1" && !isOCP5OrNewer(os.Getenv("ACM_HUB_OCP_VERSION")) {
-		oadpOLMVersion = "v0"
-	}
-
-	if err := validateOLMAnnotationPair(oadpOLMVersion, annotations,
+	// OADP always uses v0 Subscription until OADP team ships OLM v1-ready bundles.
+	if err := validateOLMAnnotationPair("v0", annotations,
 		annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec); err != nil {
 		return fmt.Errorf("validating OADP OLM annotations: %w", err)
 	}
 
 	return nil
-}
-
-// isOCP5OrNewer returns true if the OCP version is 5.0 or later.
-func isOCP5OrNewer(ocpVersion string) bool {
-	if ocpVersion == "" {
-		return false
-	}
-	major, _, found := strings.Cut(ocpVersion, ".")
-	if !found {
-		return false
-	}
-	majorInt, err := strconv.Atoi(major)
-	if err != nil {
-		return false
-	}
-	return majorInt >= 5
 }
 
 // validateOLMAnnotationPair validates that a v0/v1 annotation pair matches the detected OLM version

--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
@@ -435,13 +437,35 @@ func validateOLMAnnotations(ctx context.Context, mch *MultiClusterHub) error {
 		return fmt.Errorf("validating MCE OLM annotations: %w", err)
 	}
 
-	// Validate OADP annotations
-	if err := validateOLMAnnotationPair(olmVersion, annotations,
+	// OADP doesn't support AllNamespaces install mode required by OLM v1 on OCP <5.0.
+	// Validate OADP annotations against the effective OADP OLM version.
+	oadpOLMVersion := olmVersion
+	if olmVersion == "v1" && !isOCP5OrNewer(os.Getenv("ACM_HUB_OCP_VERSION")) {
+		oadpOLMVersion = "v0"
+	}
+
+	if err := validateOLMAnnotationPair(oadpOLMVersion, annotations,
 		annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec); err != nil {
 		return fmt.Errorf("validating OADP OLM annotations: %w", err)
 	}
 
 	return nil
+}
+
+// isOCP5OrNewer returns true if the OCP version is 5.0 or later.
+func isOCP5OrNewer(ocpVersion string) bool {
+	if ocpVersion == "" {
+		return false
+	}
+	major, _, found := strings.Cut(ocpVersion, ".")
+	if !found {
+		return false
+	}
+	majorInt, err := strconv.Atoi(major)
+	if err != nil {
+		return false
+	}
+	return majorInt >= 5
 }
 
 // validateOLMAnnotationPair validates that a v0/v1 annotation pair matches the detected OLM version

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -407,6 +407,13 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 		values.Global.OLMVersion = olmVersion
 	}
 
+	// OADP doesn't support AllNamespaces install mode required by OLM v1 on OCP <5.0.
+	// Fall back to v0 Subscription for OADP on those clusters.
+	values.Global.OADPOLMVersion = values.Global.OLMVersion
+	if values.Global.OLMVersion == "v1" && !isOCP5OrNewer(os.Getenv("ACM_HUB_OCP_VERSION")) {
+		values.Global.OADPOLMVersion = "v0"
+	}
+
 	values.HubConfig.ClusterSTSEnabled = isSTSEnabled
 
 	values.HubConfig.ReplicaCount = utils.DefaultReplicaCount(mch)
@@ -455,8 +462,8 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 		Enabled: networkPoliciesEnabled,
 	}
 
-	// Apply OADP ClusterExtension overrides (OLM v1) if annotation present and olmVersion is v1
-	if olmVersion == "v1" {
+	// Apply OADP ClusterExtension overrides (OLM v1) if annotation present and effective OADP OLM version is v1
+	if values.Global.OADPOLMVersion == "v1" {
 		if overrides := parseOADPClusterExtensionAnnotation(mch); overrides != nil {
 			// Override catalog settings for OLM v1
 			if len(overrides.Channels) > 0 {
@@ -521,6 +528,23 @@ func parseOADPAnnotation(m *v1.MultiClusterHub) *subv1alpha1.SubscriptionSpec {
 // getOADPChannel determines the OADP operator channel based on annotation override or OCP version.
 // If override is provided (from annotation), it takes precedence.
 // Otherwise, returns stable channel for OCP 4.19+ or unknown versions, and stable-1.4 for OCP 4.18 and earlier.
+// isOCP5OrNewer returns true if the OCP version is 5.0 or later.
+// Returns false for empty/unknown versions as a safe fallback.
+func isOCP5OrNewer(ocpVersion string) bool {
+	if ocpVersion == "" {
+		return false
+	}
+	major, _, found := strings.Cut(ocpVersion, ".")
+	if !found {
+		return false
+	}
+	majorInt, err := strconv.Atoi(major)
+	if err != nil {
+		return false
+	}
+	return majorInt >= 5
+}
+
 // The ACM_HUB_OCP_VERSION environment variable is used to detect the OpenShift version.
 func getOADPChannel(override string) string {
 	if override != "" {

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -407,12 +407,11 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 		values.Global.OLMVersion = olmVersion
 	}
 
-	// OADP doesn't support AllNamespaces install mode required by OLM v1 on OCP <5.0.
-	// Fall back to v0 Subscription for OADP on those clusters.
-	values.Global.OADPOLMVersion = values.Global.OLMVersion
-	if values.Global.OLMVersion == "v1" && !isOCP5OrNewer(os.Getenv("ACM_HUB_OCP_VERSION")) {
-		values.Global.OADPOLMVersion = "v0"
-	}
+	// OADP doesn't yet publish OLM v1-compatible bundles (AllNamespaces install mode
+	// not declared, and package missing from some OCP 5.0 EC catalog indexes).
+	// Force v0 Subscription for OADP until OADP team ships v1-ready bundles.
+	// TODO: set to values.Global.OLMVersion once OADP bundles are v1-ready
+	values.Global.OADPOLMVersion = "v0"
 
 	values.HubConfig.ClusterSTSEnabled = isSTSEnabled
 
@@ -528,22 +527,6 @@ func parseOADPAnnotation(m *v1.MultiClusterHub) *subv1alpha1.SubscriptionSpec {
 // getOADPChannel determines the OADP operator channel based on annotation override or OCP version.
 // If override is provided (from annotation), it takes precedence.
 // Otherwise, returns stable channel for OCP 4.19+ or unknown versions, and stable-1.4 for OCP 4.18 and earlier.
-// isOCP5OrNewer returns true if the OCP version is 5.0 or later.
-// Returns false for empty/unknown versions as a safe fallback.
-func isOCP5OrNewer(ocpVersion string) bool {
-	if ocpVersion == "" {
-		return false
-	}
-	major, _, found := strings.Cut(ocpVersion, ".")
-	if !found {
-		return false
-	}
-	majorInt, err := strconv.Atoi(major)
-	if err != nil {
-		return false
-	}
-	return majorInt >= 5
-}
 
 // The ACM_HUB_OCP_VERSION environment variable is used to detect the OpenShift version.
 func getOADPChannel(override string) string {

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -503,7 +503,8 @@ func TestRenderChartOLMv1(t *testing.T) {
 	}
 	templateOverrides := map[string]string{}
 
-	// Render cluster-backup chart with OLM v1
+	// Render cluster-backup chart with OLM v1 — OADP should still use v0 Subscription
+	// because OADP bundles don't yet support OLM v1
 	chartPath := utils.ClusterBackupChartLocation
 	templates, errs := RenderChart(chartPath, testMCH, testImages, templateOverrides, false, "v1")
 	if len(errs) > 0 {
@@ -513,10 +514,8 @@ func TestRenderChartOLMv1(t *testing.T) {
 		t.Fatalf("failed to render cluster-backup with OLM v1")
 	}
 
-	// Verify v1 resources present and v0 resources absent
+	// OADP forced to v0: expect Subscription and OperatorGroup, not ClusterExtension
 	foundClusterExtension := false
-	foundServiceAccount := false
-	foundClusterRoleBinding := false
 	foundSubscription := false
 	foundOperatorGroup := false
 
@@ -527,12 +526,6 @@ func TestRenderChartOLMv1(t *testing.T) {
 		if kind == "ClusterExtension" && apiVersion == "olm.operatorframework.io/v1" {
 			foundClusterExtension = true
 		}
-		if kind == "ServiceAccount" && template.GetName() == "oadp-installer" {
-			foundServiceAccount = true
-		}
-		if kind == "ClusterRoleBinding" && template.GetName() == "oadp-installer-admin" {
-			foundClusterRoleBinding = true
-		}
 		if kind == "Subscription" && apiVersion == "operators.coreos.com/v1alpha1" {
 			foundSubscription = true
 		}
@@ -541,23 +534,17 @@ func TestRenderChartOLMv1(t *testing.T) {
 		}
 	}
 
-	// v1 resources should be present
-	if !foundClusterExtension {
-		t.Error("Expected ClusterExtension for OLM v1, not found")
+	// v0 resources should be present (OADP forced to v0)
+	if !foundSubscription {
+		t.Error("Expected Subscription for OADP (forced v0), not found")
 	}
-	if !foundServiceAccount {
-		t.Error("Expected ServiceAccount (oadp-installer) for OLM v1, not found")
-	}
-	if !foundClusterRoleBinding {
-		t.Error("Expected ClusterRoleBinding (oadp-installer-admin) for OLM v1, not found")
+	if !foundOperatorGroup {
+		t.Error("Expected OperatorGroup for OADP (forced v0), not found")
 	}
 
-	// v0 resources should be absent
-	if foundSubscription {
-		t.Error("Found Subscription resource in OLM v1 render, should not be present")
-	}
-	if foundOperatorGroup {
-		t.Error("Found OperatorGroup resource in OLM v1 render, should not be present")
+	// v1 resources should be absent
+	if foundClusterExtension {
+		t.Error("Found ClusterExtension in render, OADP should use v0 Subscription")
 	}
 }
 

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -487,7 +487,7 @@ func TestOADPAnnotation(t *testing.T) {
 
 func TestRenderChartOLMv1(t *testing.T) {
 	os.Setenv("DIRECTORY_OVERRIDE", "../templates")
-	os.Setenv("ACM_HUB_OCP_VERSION", "4.20.0")
+	os.Setenv("ACM_HUB_OCP_VERSION", "5.0.0")
 	defer os.Unsetenv("DIRECTORY_OVERRIDE")
 	defer os.Unsetenv("ACM_HUB_OCP_VERSION")
 

--- a/pkg/rendering/values.go
+++ b/pkg/rendering/values.go
@@ -32,7 +32,8 @@ type Global struct {
 	DeployOnOCP          bool                 `json:"deployOnOCP" structs:"deployOnOCP"`
 	StorageClassName     string               `json:"storageClassName" structs:"storageClassName"`
 	StartingCSV          string               `json:"startingCSV" structs:"startingCSV"`
-	OLMVersion           string               `json:"olmVersion" structs:"olmVersion"` // "v0" or "v1" - detected at runtime by main.go detectOLMVersion
+	OLMVersion           string               `json:"olmVersion" structs:"olmVersion"`         // "v0" or "v1" - detected at runtime by main.go detectOLMVersion
+	OADPOLMVersion       string               `json:"oadpOlmVersion" structs:"oadpOlmVersion"` // effective OLM version for OADP (v0 on OCP <5.0 even if cluster is OLM v1)
 	NetworkPolicies      NetworkPoliciesValue `json:"networkPolicies" structs:"networkPolicies"`
 }
 

--- a/pkg/rendering/values.go
+++ b/pkg/rendering/values.go
@@ -33,7 +33,7 @@ type Global struct {
 	StorageClassName     string               `json:"storageClassName" structs:"storageClassName"`
 	StartingCSV          string               `json:"startingCSV" structs:"startingCSV"`
 	OLMVersion           string               `json:"olmVersion" structs:"olmVersion"`         // "v0" or "v1" - detected at runtime by main.go detectOLMVersion
-	OADPOLMVersion       string               `json:"oadpOlmVersion" structs:"oadpOlmVersion"` // effective OLM version for OADP (v0 on OCP <5.0 even if cluster is OLM v1)
+	OADPOLMVersion       string               `json:"oadpOlmVersion" structs:"oadpOlmVersion"` // forced to v0 until OADP ships OLM v1-ready bundles
 	NetworkPolicies      NetworkPoliciesValue `json:"networkPolicies" structs:"networkPolicies"`
 }
 

--- a/pkg/templates/charts/toggle/cluster-backup/templates/oadp-operators-group.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/oadp-operators-group.yaml
@@ -16,7 +16,7 @@ metadata:
     "helm.sh/hook-weight": "-2"
 data:
   targetNamespaces: open-cluster-management-backup
-  olmVersion: {{ .Values.global.olmVersion }}
+  olmVersion: {{ .Values.global.oadpOlmVersion }}
 
 {{- else if ne .Values.global.oadpOlmVersion "v1" }}
 apiVersion: operators.coreos.com/v1

--- a/pkg/templates/charts/toggle/cluster-backup/templates/oadp-operators-group.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/oadp-operators-group.yaml
@@ -18,7 +18,7 @@ data:
   targetNamespaces: open-cluster-management-backup
   olmVersion: {{ .Values.global.olmVersion }}
 
-{{- else if ne .Values.global.olmVersion "v1" }}
+{{- else if ne .Values.global.oadpOlmVersion "v1" }}
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
@@ -21,7 +21,7 @@ data:
   name: {{ .Values.global.name }}
   source: {{ .Values.global.source }}
   sourceNamespace: {{ .Values.global.sourceNamespace }}
-  olmVersion: {{ .Values.global.olmVersion }}
+  olmVersion: {{ .Values.global.oadpOlmVersion }}
   {{- if .Values.hubconfig.proxyConfigs }}
   env_HTTP_PROXY: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
   env_HTTPS_PROXY: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}

--- a/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml
@@ -28,7 +28,7 @@ data:
   env_NO_PROXY: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
   {{- end }}
 
-{{- else if eq .Values.global.olmVersion "v1" }}
+{{- else if eq .Values.global.oadpOlmVersion "v1" }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/templates/charts/toggle/cluster-backup/values.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/values.yaml
@@ -19,6 +19,7 @@ global:
   sourceNamespace: openshift-marketplace
   startingCSV: ""
   olmVersion: v0
+  oadpOlmVersion: v0
   networkPolicies:
     enabled: true
 hubconfig:


### PR DESCRIPTION
## Summary

OADP operator bundles don't declare `AllNamespaces` install mode (required by OLM v1 on OCP ≤4.22), and the `redhat-oadp-operator` package is missing from some OCP 5.0 EC catalog indexes entirely. This causes ClusterExtension installs to fail on both OCP 4.x and 5.0 EC builds.

**Fix:** Always deploy OADP via v0 Subscription regardless of cluster OLM version until the OADP team ships v1-compatible bundles. When they do, re-enabling v1 is a one-line change (`oadpOlmVersion = olmVersion`).

## Changes

- **`pkg/rendering/renderer.go`**: Hardcode `OADPOLMVersion = "v0"` instead of conditionally computing it from OCP version. Remove `isOCP5OrNewer()` helper — no longer needed.
- **`pkg/rendering/renderer_test.go`**: Update `TestRenderChartOLMv1` to expect Subscription (v0) for OADP even when cluster OLM is v1.
- **`api/v1/multiclusterhub_webhook.go`**: Hardcode OADP annotation validation to `"v0"`. Remove `isOCP5OrNewer()` and unused `strconv`/`strings` imports.
- **`pkg/rendering/values.go`**: Added `OADPOLMVersion` field to `Global` struct.
- **`pkg/templates/charts/toggle/cluster-backup/values.yaml`**: Added `oadpOlmVersion: v0` default.
- **`pkg/templates/charts/toggle/cluster-backup/templates/odap-operator-pre-install-hook.yaml`**: Uses `oadpOlmVersion` instead of `olmVersion` for OADP resource branching.
- **`pkg/templates/charts/toggle/cluster-backup/templates/oadp-operators-group.yaml`**: Uses `oadpOlmVersion` instead of `olmVersion` for OperatorGroup branching.

## Behavior

| Cluster | OADP Deployment | OADP Annotation Allowed |
|---------|----------------|------------------------|
| OLM v1 (any OCP) | Subscription (v0) | `oadp-subscription-spec` |
| OLM v0 (any OCP) | Subscription (v0) | `oadp-subscription-spec` |

This is temporary. Once OADP bundles declare `AllNamespaces` install mode and are published in all catalog indexes, set `oadpOlmVersion = olmVersion` to re-enable v1.

## Test plan

- [x] `make test` passes — all unit tests green
- [x] Verified `TestRenderChartOLMv1` expects Subscription for OADP
- [x] Verified webhook validates OADP annotations as v0
- [ ] Smoketest on OCP 5.0 cluster — OADP deploys via Subscription

/cc @cameronmwall @ngraham20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OADP deployment compatibility on older OpenShift versions.
  * OADP resources now consistently use the appropriate OLM v0 or v1 resource set, independently of other component settings.
  * Corrected rendering of OADP OperatorGroups, Subscriptions, and ClusterExtensions based on the effective OLM version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->