### PR TITLE
ACM-37878: Add NetworkPolicy for klusterlet-addon-controller

### DIFF
--- a/controllers/networkpolicy_test.go
+++ b/controllers/networkpolicy_test.go
@@ -237,6 +237,47 @@ func Test_ensureNetworkPolicies_Enabled_CreatesNP(t *testing.T) {
 	}
 }
 
+func Test_ensureNetworkPolicies_Enabled_CreatesKlusterletAddonControllerNP(t *testing.T) {
+	setChartEnv(t)
+
+	registerScheme()
+	r := newTestReconciler()
+	mch := newTestMCH("mch", "open-cluster-management", boolPtr(true),
+		operatorv1.ComponentConfig{Name: operatorv1.ClusterLifecycle, Enabled: true},
+	)
+
+	result, err := r.ensureNetworkPolicies(context.TODO(), mch, r.CacheSpec, false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("expected empty result, got: %v", result)
+	}
+
+	np := &networkingv1.NetworkPolicy{}
+	if err := r.Client.Get(context.TODO(), client.ObjectKey{
+		Name:      "klusterlet-addon-controller-network-policy",
+		Namespace: "open-cluster-management",
+	}, np); err != nil {
+		t.Fatalf("expected klusterlet-addon-controller-network-policy to be created: %v", err)
+	}
+	if np.Spec.PodSelector.MatchLabels["app"] != "klusterlet-addon-controller-v2" {
+		t.Errorf("unexpected podSelector: %v", np.Spec.PodSelector.MatchLabels)
+	}
+	hasIngress, hasEgress := false, false
+	for _, pt := range np.Spec.PolicyTypes {
+		if pt == networkingv1.PolicyTypeIngress {
+			hasIngress = true
+		}
+		if pt == networkingv1.PolicyTypeEgress {
+			hasEgress = true
+		}
+	}
+	if !hasIngress || !hasEgress {
+		t.Errorf("expected Ingress and Egress policyTypes, got: %v", np.Spec.PolicyTypes)
+	}
+}
+
 func Test_ensureNetworkPolicies_Enabled_SkipsExisting(t *testing.T) {
 	setChartEnv(t)
 

--- a/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/cluster-lifecycle/templates/klusterlet-addon-networkpolicy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Purpose: Default-deny for klusterlet-addon-controller-v2, then allow
+# metrics ingress and DNS/API egress. Hub-only controller (no webhook,
+# Service, Route, or spoke agent). Health probes omitted (kubelet probes
+# are not blocked by NetworkPolicy). Gaps: API egress limited to
+# :443/:6443; DNS is port-only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: klusterlet-addon-controller-network-policy
+  labels:
+    app: klusterlet-addon-controller-v2
+    component: klusterlet-addon-controller
+    app.kubernetes.io/name: klusterlet-addon-controller
+spec:
+  podSelector:
+    matchLabels:
+      app: klusterlet-addon-controller-v2
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # metrics (:8383)
+  - ports:
+    - protocol: TCP
+      port: 8383
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}


### PR DESCRIPTION
## Summary
* Add deny-by-default NetworkPolicy for `klusterlet-addon-controller-v2` in the `cluster-lifecycle` chart (ACM-37878)
* Allow metrics ingress (`:8383`) and DNS (`53`/`5353`) + Kubernetes API (`443`/`6443`) egress
* Gated by existing `MCH.spec.networkPolicies.enabled` / create-once reconcile path (same pattern as ACM-37873)

## Test plan
- [x] Unit test `Test_ensureNetworkPolicies_Enabled_CreatesKlusterletAddonControllerNP` passes
- [ ] Deploy MCH with `networkPolicies.enabled=true` and confirm `klusterlet-addon-controller-network-policy` is created
- [ ] Confirm klusterlet-addon-controller continues reconciling ManagedCluster / KlusterletAddonConfig with the policy applied


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Dynamic Scoring Framework, including configurable deployments, scheduling, monitoring, permissions, and architecture-specific support.
  * Added DynamicScorer and DynamicScoringConfig custom resources for managing scoring behavior and configuration.
  * Added network policy protection for the ClusterLifecycle add-on, including controlled metrics, DNS, and Kubernetes API access.
  * Added global managed cluster set binding support.

* **Tests**
  * Added coverage verifying creation and configuration of the ClusterLifecycle network policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->