### PR TITLE
Establish hierarchical logger tree and structured logging

### DIFF
--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -108,7 +108,7 @@ var (
 )
 
 var (
-	mchlog = log.Log.WithName("multiclusterhub-resource")
+	mchlog = log.Log.WithName("mch-webhook")
 	Client client.Client
 )
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -163,11 +163,11 @@ func (r *MultiClusterHubReconciler) ensureNamespace(m *operatorv1.MultiClusterHu
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: ns.GetName()}, existingNS); err != nil {
 		if errors.IsNotFound(err) {
 			if err = r.Client.Create(ctx, ns); err != nil {
-				r.Log.Info(fmt.Sprintf("Error creating namespace: %s", err.Error()))
+				r.Log.Info("Error creating namespace", "error", err)
 				return ctrl.Result{Requeue: true}, nil
 			}
 		} else {
-			r.Log.Info(fmt.Sprintf("error locating namespace: %s. Error: %s", ns.GetName(), err.Error()))
+			r.Log.Info("error locating namespace", "namespace", ns.GetName(), "error", err)
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}
@@ -179,7 +179,7 @@ func (r *MultiClusterHubReconciler) ensureNamespace(m *operatorv1.MultiClusterHu
 		return ctrl.Result{}, nil
 	}
 
-	r.Log.Info(fmt.Sprintf("namespace '%s' is not in an active state", ns.GetName()))
+	r.Log.Info("namespace is not in an active state", "namespace", ns.GetName())
 	return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 }
 
@@ -189,7 +189,7 @@ func (r *MultiClusterHubReconciler) ensureOperatorGroup(m *operatorv1.MultiClust
 	operatorGroupList := &olmv1.OperatorGroupList{}
 	err := r.Client.List(ctx, operatorGroupList, client.InNamespace(og.GetNamespace()))
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("error listing operatorgroups in ns: %s. Error: %s", og.GetNamespace(), err.Error()))
+		r.Log.Info("error listing operatorgroups in ns", "namespace", og.GetNamespace(), "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -200,12 +200,12 @@ func (r *MultiClusterHubReconciler) ensureOperatorGroup(m *operatorv1.MultiClust
 		return ctrl.Result{}, nil
 	}
 
-	r.Log.Info(fmt.Sprintf("Ensuring operator group exists in ns: %s", og.GetNamespace()))
+	r.Log.Info("Ensuring operator group exists in ns", "namespace", og.GetNamespace())
 
 	force := true
 	err = r.Client.Patch(ctx, og, client.Apply, &client.PatchOptions{Force: &force, FieldManager: "multiclusterhub-operator"})
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("Error: %s", err.Error()))
+		r.Log.Info("Error patching operator group", "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, "Created new resource")
@@ -216,7 +216,7 @@ func (r *MultiClusterHubReconciler) ensureOperatorGroup(m *operatorv1.MultiClust
 		Name: og.GetName(),
 	}, existingOperatorGroup)
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("error locating operatorgroup: %s/%s. Error: %s", og.GetNamespace(), og.GetName(), err.Error()))
+		r.Log.Info("error locating operatorgroup", "namespace", og.GetNamespace(), "name", og.GetName(), "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -240,17 +240,17 @@ func (r *MultiClusterHubReconciler) ensureServiceAccount(m *operatorv1.MultiClus
 
 	if !errors.IsNotFound(err) {
 		// Unexpected error
-		r.Log.Info(fmt.Sprintf("error getting ServiceAccount in ns: %s. Error: %s", sa.GetNamespace(), err.Error()))
+		r.Log.Info("error getting ServiceAccount in ns", "namespace", sa.GetNamespace(), "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// ServiceAccount doesn't exist, create it
-	r.Log.Info(fmt.Sprintf("Ensuring ServiceAccount exists in ns: %s", sa.GetNamespace()))
+	r.Log.Info("Ensuring ServiceAccount exists in ns", "namespace", sa.GetNamespace())
 
 	force := true
 	err = r.Client.Patch(ctx, sa, client.Apply, &client.PatchOptions{Force: &force, FieldManager: "multiclusterhub-operator"})
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("Error creating ServiceAccount: %s", err.Error()))
+		r.Log.Info("Error creating ServiceAccount", "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -276,17 +276,17 @@ func (r *MultiClusterHubReconciler) ensureClusterRoleBinding(m *operatorv1.Multi
 
 	if !errors.IsNotFound(err) {
 		// Unexpected error
-		r.Log.Info(fmt.Sprintf("error getting ClusterRoleBinding %s. Error: %s", crb.GetName(), err.Error()))
+		r.Log.Info("error getting ClusterRoleBinding", "name", crb.GetName(), "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// ClusterRoleBinding doesn't exist, create it
-	r.Log.Info(fmt.Sprintf("Ensuring ClusterRoleBinding exists: %s", crb.GetName()))
+	r.Log.Info("Ensuring ClusterRoleBinding exists", "name", crb.GetName())
 
 	force := true
 	err = r.Client.Patch(ctx, crb, client.Apply, &client.PatchOptions{Force: &force, FieldManager: "multiclusterhub-operator"})
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("Error creating ClusterRoleBinding: %s", err.Error()))
+		r.Log.Info("Error creating ClusterRoleBinding", "error", err)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -297,10 +297,10 @@ func (r *MultiClusterHubReconciler) ensureClusterRoleBinding(m *operatorv1.Multi
 }
 
 func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Context, m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
-	mce, err := multiclusterengine.FindAndManageMCE(ctx, r.Client)
+	mce, err := multiclusterengine.FindAndManageMCE(r.Log.WithName("mce"), ctx, r.Client)
 	if err != nil {
 		if apimeta.IsNoMatchError(err) {
-			r.Log.WithName("WARNING").Info("MCE CRD not yet available, requeueing")
+			r.Log.Info("MCE CRD not yet available, requeueing")
 			return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 		}
 		return ctrl.Result{}, err
@@ -377,7 +377,7 @@ func (r *MultiClusterHubReconciler) ensurePullSecret(m *operatorv1.MultiClusterH
 		for i, secret := range secretList.Items {
 			r.Log.Info("Deleting imagePullSecret", "Name", secret.Name, "Namespace", secret.Namespace)
 			if err := r.Client.Delete(context.TODO(), &secretList.Items[i]); err != nil {
-				r.Log.Error(err, fmt.Sprintf("Error deleting imagepullsecret: %s", secret.GetName()))
+				r.Log.Error(err, "Error deleting imagepullsecret", "name", secret.GetName())
 				return ctrl.Result{}, err
 			}
 		}
@@ -409,7 +409,7 @@ func (r *MultiClusterHubReconciler) ensurePullSecret(m *operatorv1.MultiClusterH
 	force := true
 	if err := r.Client.Patch(context.TODO(), mceSecret, client.Apply,
 		&client.PatchOptions{Force: &force, FieldManager: "multiclusterhub-operator"}); err != nil {
-		r.Log.Info(fmt.Sprintf("Error applying pullSecret to mce namespace: %s", err.Error()))
+		r.Log.Info("Error applying pullSecret to mce namespace", "error", err)
 		return ctrl.Result{}, err
 	}
 
@@ -596,7 +596,7 @@ func (r *MultiClusterHubReconciler) ensureMCEInstallation(ctx context.Context, m
 
 	// OLM v0 path (existing Subscription-based logic)
 	desiredPackage := multiclusterengine.DesiredPackage()
-	mceSub, err := v0.FindAndManageMCESubscription(ctx, r.Client, desiredPackage)
+	mceSub, err := v0.FindAndManageMCESubscription(r.Log.WithName("mce").WithName("olm"), ctx, r.Client, desiredPackage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -635,7 +635,7 @@ func (r *MultiClusterHubReconciler) ensureMCEInstallation(ctx context.Context, m
 	// Search for catalogsource if not defined in overrides
 	if overrides == nil || overrides.CatalogSource == "" {
 		desiredChannel := multiclusterengine.DesiredChannel()
-		ctlSrc, err = v0.GetCatalogSource(r.Client, desiredChannel, desiredPackage)
+		ctlSrc, err = v0.GetCatalogSource(r.Log.WithName("mce").WithName("olm"), r.Client, desiredChannel, desiredPackage)
 		if err != nil {
 			r.Log.Info("Failed to find a suitable catalogsource.", "error", err)
 			return ctrl.Result{}, err
@@ -691,7 +691,7 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 	desiredPackage := multiclusterengine.DesiredPackage()
 
 	// Find or manage existing ClusterExtension
-	mceCE, err := v1.FindAndManageMCEClusterExtension(ctx, r.Client, desiredPackage)
+	mceCE, err := v1.FindAndManageMCEClusterExtension(r.Log.WithName("mce").WithName("olm"), ctx, r.Client, desiredPackage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -712,7 +712,7 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 	if mceCE == nil {
 		// Pre-flight: check if a catalog contains the MCE package.
 		// Non-fatal because OLM v1 resolves catalogs automatically via SourceType+PackageName.
-		catalogName, catErr := v1.GetClusterCatalog(ctx, r.Client, desiredPackage)
+		catalogName, catErr := v1.GetClusterCatalog(r.Log.WithName("mce").WithName("olm"), ctx, r.Client, desiredPackage)
 		if catErr != nil {
 			r.Log.Info("No ClusterCatalog found containing package, OLM v1 will resolve automatically",
 				"package", desiredPackage, "error", catErr)
@@ -803,7 +803,7 @@ func (r *MultiClusterHubReconciler) waitForMCEReady(ctx context.Context) (ctrl.R
 	}
 
 	if existingMCE.Status.CurrentVersion == "" {
-		r.Log.Info(fmt.Sprintf("Multiclusterengine: %s is not yet available", existingMCE.GetName()))
+		r.Log.Info("Multiclusterengine is not yet available", "name", existingMCE.GetName())
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
 
@@ -1016,7 +1016,7 @@ func (r *MultiClusterHubReconciler) ensureSearchCR(m *operatorv1.MultiClusterHub
 	force := true
 	err := r.Client.Patch(ctx, searchCR, client.Apply, &client.PatchOptions{Force: &force, FieldManager: "multiclusterhub-operator"})
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("error applying Search CR. Error: %s", err.Error()))
+		r.Log.Info("error applying Search CR", "error", err)
 		return ctrl.Result{}, err
 	}
 
@@ -1030,7 +1030,7 @@ func (r *MultiClusterHubReconciler) ensureNoClusterManagementAddOn(m *operatorv1
 
 	addonName, err := operatorv1.GetClusterManagementAddonName(component)
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("Detected unregistered ClusterManagementAddon component: %s", err.Error()))
+		r.Log.Info("Detected unregistered ClusterManagementAddon component", "error", err)
 		return ctrl.Result{}, err
 	}
 
@@ -1086,7 +1086,7 @@ func (r *MultiClusterHubReconciler) ensureNoSearchCR(m *operatorv1.MultiClusterH
 	searchList := &searchv2v1alpha1.SearchList{}
 	err := r.Client.List(ctx, searchList, client.InNamespace(m.GetNamespace()))
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("error locating Search CR. Error: %s", err.Error()))
+		r.Log.Info("Error locating Search CR", "error", err)
 		return ctrl.Result{}, err
 	}
 
@@ -1100,7 +1100,7 @@ func (r *MultiClusterHubReconciler) ensureNoSearchCR(m *operatorv1.MultiClusterH
 	}
 	err = r.Client.List(ctx, searchList, client.InNamespace(m.GetNamespace()))
 	if err != nil {
-		r.Log.Info(fmt.Sprintf("error locating Search CR. Error: %s", err.Error()))
+		r.Log.Info("error locating Search CR", "error", err)
 		return ctrl.Result{}, err
 	}
 	if len(searchList.Items) != 0 {

--- a/controllers/components.go
+++ b/controllers/components.go
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func (r *MultiClusterHubReconciler) fetchChartLocation(component string) string {
@@ -78,7 +77,7 @@ func (r *MultiClusterHubReconciler) fetchChartLocation(component string) string 
 		return utils.VolsyncChartLocation
 
 	default:
-		log.Info(fmt.Sprintf("Unregistered component detected: %v", component))
+		r.Log.Info("Unregistered component detected", "component", component)
 		return fmt.Sprintf("/chart/toggle/%v", component)
 	}
 }
@@ -113,7 +112,7 @@ func (r *MultiClusterHubReconciler) ensureComponentOrNoComponent(ctx context.Con
 
 	} else {
 		if component == operatorv1.Console && !ocpConsole {
-			log.Info("OCP console is not enabled")
+			r.Log.Info("OCP console is not enabled")
 			return r.ensureNoComponent(ctx, m, component, cachespec, isSTSEnabled)
 		}
 
@@ -158,12 +157,12 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 	}
 
 	// Renders all templates from charts
-	templates, errs := renderer.RenderChart(chartLocation, m, cachespec.ImageOverrides, cachespec.TemplateOverrides,
+	templates, errs := renderer.RenderChart(r.Log.WithName("renderer"), chartLocation, m, cachespec.ImageOverrides, cachespec.TemplateOverrides,
 		isSTSEnabled, r.OLMVersion)
 
 	if len(errs) > 0 {
 		for _, err := range errs {
-			log.Info(err.Error())
+			r.Log.Info(err.Error())
 		}
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
@@ -175,7 +174,7 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 				if deploymentConfig, found := r.getDeploymentConfig(componentConfig.ConfigOverrides.Deployments,
 					template.GetName()); found {
 
-					log.V(2).Info("Applying deployment overrides for template", "Name", template.GetName())
+					r.Log.V(2).Info("Applying deployment overrides for template", "Name", template.GetName())
 					for _, container := range deploymentConfig.Containers {
 						if err := r.applyEnvConfig(template, container.Name, container.Env); err != nil {
 							return ctrl.Result{}, err
@@ -183,12 +182,12 @@ func (r *MultiClusterHubReconciler) ensureComponent(ctx context.Context, m *oper
 					}
 
 				} else {
-					log.V(2).Info("No deployment config found for deployment", "Name", template.GetName())
+					r.Log.V(2).Info("No deployment config found for deployment", "Name", template.GetName())
 				}
 			}
 		}
 	} else {
-		log.V(2).Info("No component config found", "Component", component)
+		r.Log.V(2).Info("No component config found", "Component", component)
 	}
 
 	// Applies all templates
@@ -288,12 +287,12 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 	}
 
 	// Renders all templates from charts
-	templates, errs := renderer.RenderChart(chartLocation, m, imageOverrides, cachespec.TemplateOverrides,
+	templates, errs := renderer.RenderChart(r.Log.WithName("renderer"), chartLocation, m, imageOverrides, cachespec.TemplateOverrides,
 		isSTSEnabled, r.OLMVersion)
 
 	if len(errs) > 0 {
 		for _, err := range errs {
-			log.Info(err.Error())
+			r.Log.Info(err.Error())
 		}
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
@@ -308,7 +307,7 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 		result, err := r.deleteTemplate(ctx, m, template)
 		if result != (ctrl.Result{}) || err != nil {
 			if err != nil {
-				logf.Log.Error(err, fmt.Sprintf("Failed to delete template: %s", template.GetName()))
+				r.Log.Error(err, "Failed to delete template", "name", template.GetName())
 			}
 			return result, err
 		}
@@ -354,7 +353,7 @@ func (r *MultiClusterHubReconciler) applyEnvConfig(template *unstructured.Unstru
 
 	containers, found, err := unstructured.NestedSlice(template.Object, "spec", "template", "spec", "containers")
 	if err != nil || !found {
-		log.Error(err, "Failed to get containers from template", "Kind", template.GetKind(), "Name", template.GetName())
+		r.Log.Error(err, "Failed to get containers from template", "Kind", template.GetKind(), "Name", template.GetName())
 		return err
 	}
 
@@ -373,7 +372,7 @@ func (r *MultiClusterHubReconciler) applyEnvConfig(template *unstructured.Unstru
 			}
 
 			if err := unstructured.SetNestedSlice(containerMap, existingEnv, "env"); err != nil {
-				log.Error(err, "Failed to set environment variable", "Container", containerName)
+				r.Log.Error(err, "Failed to set environment variable", "Container", containerName)
 				return err
 
 			} else {
@@ -384,7 +383,7 @@ func (r *MultiClusterHubReconciler) applyEnvConfig(template *unstructured.Unstru
 	}
 
 	if err = unstructured.SetNestedSlice(template.Object, containers, "spec", "template", "spec", "containers"); err != nil {
-		log.Error(err, "Failed to set containers in template", "Template", template.GetName())
+		r.Log.Error(err, "Failed to set containers in template", "Template", template.GetName())
 		return err
 	}
 

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -20,21 +20,18 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	utils "github.com/stolostron/multiclusterhub-operator/pkg/utils"
 
+	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var configLog = logf.Log.WithName("config")
 
 // previewToGAComponents maps preview component names to their GA equivalents.
 // When a preview component is enabled, it is automatically replaced with the GA version.
@@ -53,7 +50,7 @@ var defaultAnnotations = map[string]string{
 
 // setDefaultAnnotations applies default values for any missing annotations
 // Returns true if any annotations were added
-func setDefaultAnnotations(m *operatorv1.MultiClusterHub) bool {
+func setDefaultAnnotations(log logr.Logger, m *operatorv1.MultiClusterHub) bool {
 	updated := false
 	annotations := m.GetAnnotations()
 	if annotations == nil {
@@ -64,7 +61,7 @@ func setDefaultAnnotations(m *operatorv1.MultiClusterHub) bool {
 		if _, exists := annotations[key]; !exists {
 			annotations[key] = defaultValue
 			updated = true
-			configLog.Info("Setting default annotation", "annotation", key, "value", defaultValue)
+			log.Info("Setting default annotation", "annotation", key, "value", defaultValue)
 		}
 	}
 
@@ -118,7 +115,7 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 	}
 
 	// Set default annotations if not specified
-	if setDefaultAnnotations(m) {
+	if setDefaultAnnotations(log, m) {
 		updateNecessary = true
 	}
 
@@ -142,7 +139,7 @@ func (r *MultiClusterHubReconciler) setDefaults(m *operatorv1.MultiClusterHub, o
 	for _, c := range m.Spec.Overrides.Components {
 		if !operatorv1.ValidComponent(c, operatorv1.MCHComponents) {
 			if m.Prune(c.Name) {
-				log.Info(fmt.Sprintf("Removing invalid component: %v from existing MultiClusterHub", c.Name))
+				log.Info("Removing invalid component from existing MultiClusterHub", "component", c.Name)
 				updateNecessary = true
 			}
 		}

--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -78,7 +78,7 @@ func (r *MultiClusterHubReconciler) ensureMCEComplianceBanner(ctx context.Contex
 	existing := &consolev1.ConsoleNotification{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: mceComplianceBannerName}, existing)
 	if errors.IsNotFound(err) {
-		log.Info("Creating MCE compliance ConsoleNotification banner")
+		r.Log.Info("Creating MCE compliance ConsoleNotification banner")
 		if err := r.Client.Create(ctx, desired); err != nil {
 			return fmt.Errorf("failed to create ConsoleNotification %s: %w", mceComplianceBannerName, err)
 		}
@@ -95,7 +95,7 @@ func (r *MultiClusterHubReconciler) ensureMCEComplianceBanner(ctx context.Contex
 		patch := client.MergeFrom(existing.DeepCopy())
 		existing.Spec = desired.Spec
 		existing.Labels = desired.Labels
-		log.Info("Updating MCE compliance ConsoleNotification banner")
+		r.Log.Info("Updating MCE compliance ConsoleNotification banner")
 		if err := r.Client.Patch(ctx, existing, patch); err != nil {
 			return fmt.Errorf("failed to patch ConsoleNotification %s: %w", mceComplianceBannerName, err)
 		}
@@ -114,7 +114,7 @@ func (r *MultiClusterHubReconciler) removeMCEComplianceBanner(ctx context.Contex
 		return fmt.Errorf("failed to get ConsoleNotification %s: %w", mceComplianceBannerName, err)
 	}
 
-	log.Info("Removing MCE compliance ConsoleNotification banner")
+	r.Log.Info("Removing MCE compliance ConsoleNotification banner")
 	return r.Client.Delete(ctx, notification)
 }
 

--- a/controllers/finalizers.go
+++ b/controllers/finalizers.go
@@ -256,17 +256,17 @@ func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logge
 			}, helmRelease)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					reqLogger.Info(fmt.Sprintf("Unable to locate helmrelease: %s", helmReleaseName))
+					reqLogger.Info("Unable to locate helmrelease", "name", helmReleaseName)
 					continue
 				}
-				reqLogger.Error(err, fmt.Sprintf("Error getting helmrelease: %s", helmReleaseName))
+				reqLogger.Error(err, "Error getting helmrelease", "name", helmReleaseName)
 				return err
 			}
 
 			utils.AddInstallerLabel(helmRelease, m.GetName(), m.GetNamespace())
 			err = r.Client.Update(context.TODO(), helmRelease)
 			if err != nil {
-				reqLogger.Error(err, fmt.Sprintf("Error updating helmrelease: %s", helmReleaseName))
+				reqLogger.Error(err, "Error updating helmrelease", "name", helmReleaseName)
 				return err
 			}
 		}
@@ -277,7 +277,7 @@ func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logge
 		for i, appsub := range appSubList.Items {
 			err = r.Client.Delete(context.TODO(), &appSubList.Items[i])
 			if err != nil {
-				reqLogger.Error(err, fmt.Sprintf("Error terminating sub: %s", appsub.GetName()))
+				reqLogger.Error(err, "Error terminating sub", "name", appsub.GetName())
 				return err
 			}
 		}

--- a/controllers/finalizers_test.go
+++ b/controllers/finalizers_test.go
@@ -4,11 +4,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengineutils"
 	resources "github.com/stolostron/multiclusterhub-operator/test/unit-tests"
 )
+
+var testLog = logr.Discard()
+
+func newTestLog(t *testing.T) logr.Logger {
+	return testr.New(t)
+}
 
 func TestBackupNamespace(t *testing.T) {
 	tests := []struct {
@@ -102,11 +110,11 @@ func Test_cleanupMultiClusterEngine(t *testing.T) {
 			}
 
 			// If MCE exists the first time it will return an error.
-			if err := recon.cleanupMultiClusterEngine(log, &tt.mch); err == nil {
+			if err := recon.cleanupMultiClusterEngine(newTestLog(t), &tt.mch); err == nil {
 				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
 			}
 
-			if err := recon.cleanupMultiClusterEngine(log, &tt.mch); err != nil {
+			if err := recon.cleanupMultiClusterEngine(newTestLog(t), &tt.mch); err != nil {
 				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
 			}
 		})
@@ -138,13 +146,13 @@ func Test_cleanupMultiClusterEngine_OLMv1(t *testing.T) {
 	recon.OLMVersion = "v1"
 
 	// First call should return error (MCE still exists)
-	err := recon.cleanupMultiClusterEngine(log, &mch)
+	err := recon.cleanupMultiClusterEngine(newTestLog(t), &mch)
 	if err == nil {
 		t.Error("expected error on first cleanup call, got nil")
 	}
 
 	// Second call should succeed (MCE deleted)
-	err = recon.cleanupMultiClusterEngine(log, &mch)
+	err = recon.cleanupMultiClusterEngine(newTestLog(t), &mch)
 	if err != nil {
 		t.Errorf("expected no error on second cleanup call, got: %v", err)
 	}
@@ -178,13 +186,13 @@ func Test_cleanupMultiClusterEngine_OLMv0(t *testing.T) {
 	recon.OLMVersion = "v0"
 
 	// First call should return error (MCE still exists)
-	err := recon.cleanupMultiClusterEngine(log, &mch)
+	err := recon.cleanupMultiClusterEngine(newTestLog(t), &mch)
 	if err == nil {
 		t.Error("expected error on first cleanup call, got nil")
 	}
 
 	// Second call should succeed (MCE deleted)
-	err = recon.cleanupMultiClusterEngine(log, &mch)
+	err = recon.cleanupMultiClusterEngine(newTestLog(t), &mch)
 	if err != nil {
 		t.Errorf("expected no error on second cleanup call, got: %v", err)
 	}

--- a/controllers/infrastructure.go
+++ b/controllers/infrastructure.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Context, m *operatorv1.MultiClusterHub) (
@@ -45,7 +44,7 @@ func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Co
 
 	err := r.Client.Get(ctx, types.NamespacedName{Name: m.GetNamespace()}, existingNs)
 	if err != nil || errors.IsNotFound(err) {
-		log.Error(err, fmt.Sprintf("Failed to find namespace for MultiClusterHub: %s", m.GetNamespace()))
+		r.Log.Error(err, "Failed to find namespace for MultiClusterHub", "namespace", m.GetNamespace())
 		return ctrl.Result{}, err
 	}
 
@@ -54,14 +53,12 @@ func (r *MultiClusterHubReconciler) ensureOpenShiftNamespaceLabel(ctx context.Co
 	}
 
 	if _, ok := existingNs.Labels[utils.OpenShiftClusterMonitoringLabel]; !ok {
-		r.Log.Info(fmt.Sprintf("Adding label: %s to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
-			m.GetNamespace()))
+		r.Log.Info("Adding label to namespace", "label", utils.OpenShiftClusterMonitoringLabel, "namespace", m.GetNamespace())
 		existingNs.Labels[utils.OpenShiftClusterMonitoringLabel] = "true"
 
 		err = r.Client.Update(ctx, existingNs)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("Failed to update namespace for MultiClusterHub: %s with the label: %s",
-				m.GetNamespace(), utils.OpenShiftClusterMonitoringLabel))
+			r.Log.Error(err, "Failed to update namespace for MultiClusterHub with label", "namespace", m.GetNamespace(), "label", utils.OpenShiftClusterMonitoringLabel)
 			return ctrl.Result{}, err
 		}
 	}
@@ -84,7 +81,7 @@ func (r *MultiClusterHubReconciler) createTrustBundleConfigmap(ctx context.Conte
 		Name:      trustBundleName,
 		Namespace: trustBundleNamespace,
 	}
-	log.Info(fmt.Sprintf("using trust bundle configmap %s/%s", trustBundleNamespace, trustBundleName))
+	r.Log.Info("using trust bundle configmap", "namespace", trustBundleNamespace, "name", trustBundleName)
 
 	// Check if configmap exists
 	cm := &corev1.ConfigMap{}
@@ -92,7 +89,7 @@ func (r *MultiClusterHubReconciler) createTrustBundleConfigmap(ctx context.Conte
 	if err != nil && !errors.IsNotFound(err) {
 		// Unknown error. Requeue
 		msg := fmt.Sprintf("error while getting trust bundle configmap %s/%s", trustBundleNamespace, trustBundleName)
-		log.Error(err, msg)
+		r.Log.Error(err, msg)
 		return ctrl.Result{}, err
 	} else if err == nil {
 		// configmap exists
@@ -119,7 +116,7 @@ func (r *MultiClusterHubReconciler) createTrustBundleConfigmap(ctx context.Conte
 	err = r.Client.Create(ctx, cm)
 	if err != nil {
 		// Error creating configmap
-		log.Info(fmt.Sprintf("error creating trust bundle configmap %s: %s", trustBundleName, err))
+		r.Log.Info("error creating trust bundle configmap", "name", trustBundleName, "error", err)
 		return ctrl.Result{}, err
 	}
 	// Configmap created successfully
@@ -155,7 +152,7 @@ func (r *MultiClusterHubReconciler) createMetricsService(ctx context.Context, m 
 	if err := r.Client.Get(ctx, namespacedName, &corev1.Service{}); err != nil {
 		if !errors.IsNotFound(err) {
 			// Unknown error. Requeue
-			log.Error(err, fmt.Sprintf("error while getting multiclusterhub metrics service: %s/%s", sNamespace, sName))
+			r.Log.Error(err, "error while getting multiclusterhub metrics service", "namespace", sNamespace, "name", sName)
 			return ctrl.Result{}, err
 		}
 
@@ -191,11 +188,11 @@ func (r *MultiClusterHubReconciler) createMetricsService(ctx context.Context, m 
 
 		if err = r.Client.Create(ctx, s); err != nil {
 			// Error creating metrics service
-			log.Error(err, fmt.Sprintf("error creating multiclusterhub metrics service: %s", sName))
+			r.Log.Error(err, "error creating multiclusterhub metrics service", "name", sName)
 			return ctrl.Result{}, err
 		}
 
-		log.Info(fmt.Sprintf("Created multiclusterhub metrics service: %s", sName))
+		r.Log.Info("Created multiclusterhub metrics service", "name", sName)
 	}
 
 	return ctrl.Result{}, nil
@@ -230,7 +227,7 @@ func (r *MultiClusterHubReconciler) createMetricsServiceMonitor(ctx context.Cont
 	if err := r.Client.Get(ctx, namespacedName, &promv1.ServiceMonitor{}); err != nil {
 		if !errors.IsNotFound(err) {
 			// Unknown error. Requeue
-			log.Error(err, fmt.Sprintf("error while getting multiclusterhub metrics service: %s/%s", smNamespace, smName))
+			r.Log.Error(err, "error while getting multiclusterhub metrics servicemonitor", "namespace", smNamespace, "name", smName)
 			return ctrl.Result{}, err
 		}
 
@@ -273,11 +270,11 @@ func (r *MultiClusterHubReconciler) createMetricsServiceMonitor(ctx context.Cont
 
 		if err = r.Client.Create(ctx, sm); err != nil {
 			// Error creating metrics servicemonitor
-			log.Error(err, fmt.Sprintf("error creating metrics servicemonitor: %s", smName))
+			r.Log.Error(err, "error creating metrics servicemonitor", "name", smName)
 			return ctrl.Result{}, err
 		}
 
-		logf.Log.Info(fmt.Sprintf("Created multiclusterhub metrics servicemonitor: %s", smName))
+		r.Log.Info("Created multiclusterhub metrics servicemonitor", "name", smName)
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/internal_hub_components.go
+++ b/controllers/internal_hub_components.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func (r *MultiClusterHubReconciler) ensureInternalHubComponent(ctx context.Context, m *operatorv1.MultiClusterHub,
@@ -77,13 +76,13 @@ func (r *MultiClusterHubReconciler) ensureNoInternalHubComponent(ctx context.Con
 
 	// Check if it has a deletion timestamp (indicating it's in the process of being deleted)
 	if ihc.GetDeletionTimestamp() != nil {
-		log.Info("InternalHubComponent deletion in progress", "Name", ihc.GetName(), "Namespace", ihc.GetNamespace(),
+		r.Log.Info("InternalHubComponent deletion in progress", "Name", ihc.GetName(), "Namespace", ihc.GetNamespace(),
 			"DeletionTimestamp", ihc.GetDeletionTimestamp())
 
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
 
-	log.Info("Deleting InternalHubComponent", "Name", ihc.GetName(), "Namespace", ihc.GetNamespace())
+	r.Log.Info("Deleting InternalHubComponent", "Name", ihc.GetName(), "Namespace", ihc.GetNamespace())
 	if err := r.Client.Delete(ctx, ihc); err != nil {
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to delete InternalHubComponent CR: %s/%s: %v",
@@ -95,7 +94,7 @@ func (r *MultiClusterHubReconciler) ensureNoInternalHubComponent(ctx context.Con
 	if err := r.Client.Get(ctx,
 		types.NamespacedName{Name: ihc.GetName(), Namespace: ihc.GetNamespace()}, ihc); err != nil {
 		if errors.IsNotFound(err) {
-			logf.Log.Info("InternalHubComponent successfully deleted", "Name", ihc.GetName(), "Namespace", ihc.GetNamespace())
+			r.Log.Info("InternalHubComponent successfully deleted", "Name", ihc.GetName(), "Namespace", ihc.GetNamespace())
 			return ctrl.Result{}, nil
 		}
 

--- a/controllers/lifecycle.go
+++ b/controllers/lifecycle.go
@@ -97,11 +97,13 @@ func (r *MultiClusterHubReconciler) installCRDs(reqLogger logr.Logger, m *operat
 
 	for _, crd := range crds {
 		utils.AddInstallerLabel(crd, m.GetName(), m.GetNamespace())
-		err, ok := deploying.Deploy(r.Client, crd)
+		err, ok := deploying.Deploy(r.Log.WithName("deployer"), r.Client, crd)
+
 		if err != nil {
 			reqLogger.Error(err, "failed to deploy", "Kind", crd.GetKind(), "Name", crd.GetName())
 			return DeployFailedReason, err
 		}
+
 		if ok {
 			message := fmt.Sprintf("created new resource: %s %s", crd.GetKind(), crd.GetName())
 			condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, message)
@@ -162,16 +164,15 @@ func (r *MultiClusterHubReconciler) deployResources(reqLogger logr.Logger, m *op
 		if res.GetNamespace() == m.Namespace {
 			err := controllerutil.SetControllerReference(m, res, r.Scheme)
 			if err != nil {
-				r.Log.Error(
-					err,
-					fmt.Sprintf(
-						"Failed to set controller reference on %s %s/%s",
-						res.GetKind(), m.Namespace, res.GetName(),
-					),
+				r.Log.Error(err, "Failed to set controller reference",
+					"Kind", res.GetKind(),
+					"namespace", m.Namespace,
+					"name", res.GetName(),
 				)
 			}
 		}
-		err, ok := deploying.Deploy(r.Client, res)
+		err, ok := deploying.Deploy(r.Log.WithName("deployer"), r.Client, res)
+
 		if err != nil {
 			reqLogger.Error(err, "failed to deploy resource", "Kind", res.GetKind(), "Name", res.GetName())
 			return DeployFailedReason, err

--- a/controllers/managedcluster.go
+++ b/controllers/managedcluster.go
@@ -5,7 +5,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 
 	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	utils "github.com/stolostron/multiclusterhub-operator/pkg/utils"
@@ -65,14 +64,14 @@ func getKlusterletAddonConfig(m *operatorsv1.MultiClusterHub) *unstructured.Unst
 func (r *MultiClusterHubReconciler) ensureKlusterletAddonConfig(m *operatorsv1.MultiClusterHub) (ctrl.Result, error) {
 	ctx := context.Background()
 
-	r.Log.Info(fmt.Sprintf("Checking for ManagedCluster %v namespace", m.Spec.LocalClusterName))
+	r.Log.Info("Checking for ManagedCluster namespace", "namespace", m.Spec.LocalClusterName)
 	ns := &corev1.Namespace{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: m.Spec.LocalClusterName}, ns)
 	if err != nil && errors.IsNotFound(err) {
-		r.Log.Info(fmt.Sprintf("Waiting for %v namespace to be created", m.Spec.LocalClusterName))
+		r.Log.Info("Waiting for namespace to be created", "namespace", m.Spec.LocalClusterName)
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	} else if err != nil {
-		r.Log.Error(err, fmt.Sprintf("Failed to check for %v namespace", m.Spec.LocalClusterName))
+		r.Log.Error(err, "Failed to check for namespace", "namespace", m.Spec.LocalClusterName)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/multiclusterhub_controller.go
+++ b/controllers/multiclusterhub_controller.go
@@ -38,7 +38,6 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // MultiClusterHubReconciler reconciles a MultiClusterHub object
@@ -64,10 +63,7 @@ const (
 	defaultTrustBundleName = "trusted-ca-bundle"
 )
 
-var (
-	log              = ctrllog.Log.WithName("reconcile")
-	STSEnabledStatus = false
-)
+var STSEnabledStatus = false
 
 //+kubebuilder:rbac:groups="";"admissionregistration.k8s.io";"apiextensions.k8s.io";"apiregistration.k8s.io";"apps";"apps.open-cluster-management.io";"authorization.k8s.io";"hive.openshift.io";"mcm.ibm.com";"proxy.open-cluster-management.io";"rbac.authorization.k8s.io";"security.openshift.io";"clusterview.open-cluster-management.io";"discovery.open-cluster-management.io";"wgpolicyk8s.io",resources=apiservices;channels;clusterjoinrequests;clusterrolebindings;clusterstatuses/log;configmaps;customresourcedefinitions;deployments;discoveryconfigs;hiveconfigs;mutatingwebhookconfigurations;validatingwebhookconfigurations;namespaces;pods;policyreports;replicasets;rolebindings;secrets;serviceaccounts;services;subjectaccessreviews;subscriptions;helmreleases;managedclusters;managedclustersets,verbs=get
 //+kubebuilder:rbac:groups="";"admissionregistration.k8s.io";"apiextensions.k8s.io";"apiregistration.k8s.io";"apps";"apps.open-cluster-management.io";"authorization.k8s.io";"hive.openshift.io";"monitoring.coreos.com";"rbac.authorization.k8s.io";"mcm.ibm.com";"security.openshift.io",resources=apiservices;channels;clusterjoinrequests;clusterrolebindings;clusterroles;configmaps;customresourcedefinitions;deployments;hiveconfigs;mutatingwebhookconfigurations;validatingwebhookconfigurations;namespaces;rolebindings;secrets;serviceaccounts;services;servicemonitors;subjectaccessreviews;subscriptions;validatingwebhookconfigurations,verbs=create;update

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -90,7 +90,7 @@ func getTestImageOverrides() map[string]string {
 func ApplyPrereqs(k8sClient client.Client) {
 	ctx := context.Background()
 	if err := os.Setenv(helpers.DefaultStorageClassName, "gp3-csi"); err != nil {
-		log.Error(err, "failed to set default storage class")
+		testLog.Error(err, "failed to set default storage class")
 	}
 
 	By("Creating Ingress")

--- a/controllers/networkpolicy.go
+++ b/controllers/networkpolicy.go
@@ -70,8 +70,7 @@ func (r *MultiClusterHubReconciler) ensureNetworkPolicies(ctx context.Context, m
 		if !componentEnabled {
 			// Component disabled - delete its NetworkPolicy if MCH-created
 			chartLocation := r.fetchChartLocation(component)
-			templates, errs := renderer.RenderChart(chartLocation, mch, cacheSpec.ImageOverrides, cacheSpec.TemplateOverrides,
-				isSTSEnabled, r.OLMVersion)
+			templates, errs := renderer.RenderChart(r.Log.WithName("renderer"), chartLocation, mch, cacheSpec.ImageOverrides, cacheSpec.TemplateOverrides, isSTSEnabled, r.OLMVersion)
 
 			if len(errs) > 0 {
 				// Skip deletion if chart rendering fails - component may have been removed
@@ -105,8 +104,7 @@ func (r *MultiClusterHubReconciler) ensureNetworkPolicies(ctx context.Context, m
 
 		// Render NetworkPolicy from Helm template
 		chartLocation := r.fetchChartLocation(component)
-		templates, errs := renderer.RenderChart(chartLocation, mch, cacheSpec.ImageOverrides, cacheSpec.TemplateOverrides,
-			isSTSEnabled, r.OLMVersion)
+		templates, errs := renderer.RenderChart(r.Log.WithName("renderer"), chartLocation, mch, cacheSpec.ImageOverrides, cacheSpec.TemplateOverrides, isSTSEnabled, r.OLMVersion)
 
 		if len(errs) > 0 {
 			// Rendering errors indicate real chart failures - log and requeue

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -46,7 +45,6 @@ import (
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (retQueue ctrl.Result, retError error) {
-	r.Log = log
 	r.Log.Info("Reconciling MultiClusterHub")
 
 	// Fetch the MultiClusterHub instance
@@ -129,12 +127,10 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}()
 
-	// Attempt to retrieve image overrides from environmental variables.
-	imageOverrides := overrides.GetOverridesFromEnv(overrides.OperandImagePrefix)
+	imageOverrides := overrides.GetOverridesFromEnv(r.Log.WithName("overrides"), overrides.OperandImagePrefix)
 
-	// If no overrides found using OperandImagePrefix, attempt to retrieve using OSBSImagePrefix.
 	if len(imageOverrides) == 0 {
-		imageOverrides = overrides.GetOverridesFromEnv(overrides.OSBSImagePrefix)
+		imageOverrides = overrides.GetOverridesFromEnv(r.Log.WithName("overrides"), overrides.OSBSImagePrefix)
 	}
 
 	// Check if no image overrides were found using either prefix.
@@ -145,17 +141,17 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Apply image repository override from annotation if present.
 	if imageRepo := utils.GetImageRepository(multiClusterHub); imageRepo != "" {
-		r.Log.Info(fmt.Sprintf("Overriding Image Repository from annotation: %s", imageRepo))
+		r.Log.Info("Overriding image repository from annotation", "imageRepo", imageRepo)
 		imageOverrides = utils.OverrideImageRepository(imageOverrides, imageRepo)
 	}
 
-	// Check for developer overrides in configmap.
 	if ioConfigmapName := utils.GetImageOverridesConfigmapName(multiClusterHub); ioConfigmapName != "" {
-		imageOverrides, err = overrides.GetOverridesFromConfigmap(r.Client, imageOverrides,
+		imageOverrides, err = overrides.GetOverridesFromConfigmap(
+			r.Log.WithName("overrides"), r.Client, imageOverrides,
 			multiClusterHub.GetNamespace(), ioConfigmapName, false)
 		if err != nil {
-			r.Log.Error(err, fmt.Sprintf("Failed to find image override configmap: %s/%s",
-				multiClusterHub.GetNamespace(), ioConfigmapName))
+			r.Log.Error(err, "Failed to find image override configmap",
+				"namespace", multiClusterHub.GetNamespace(), "configmap", ioConfigmapName)
 
 			return ctrl.Result{}, err
 		}
@@ -167,16 +163,15 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	r.CacheSpec.ImageRepository = utils.GetImageRepository(multiClusterHub)
 	r.CacheSpec.ImageOverridesCM = utils.GetImageOverridesConfigmapName(multiClusterHub)
 
-	// Attempt to retrieve template overrides from environmental variables.
-	templateOverrides := overrides.GetOverridesFromEnv(overrides.TemplateOverridePrefix)
+	templateOverrides := overrides.GetOverridesFromEnv(r.Log.WithName("overrides"), overrides.TemplateOverridePrefix)
 
-	// Check for developer overrides in configmap
 	if toConfigmapName := utils.GetTemplateOverridesConfigmapName(multiClusterHub); toConfigmapName != "" {
-		templateOverrides, err = overrides.GetOverridesFromConfigmap(r.Client, templateOverrides,
+		templateOverrides, err = overrides.GetOverridesFromConfigmap(
+			r.Log.WithName("overrides"), r.Client, templateOverrides,
 			multiClusterHub.GetNamespace(), toConfigmapName, true)
 		if err != nil {
-			r.Log.Error(err, fmt.Sprintf("Failed to find template override configmap: %s/%s",
-				multiClusterHub.GetNamespace(), toConfigmapName))
+			r.Log.Error(err, "Failed to find template override configmap",
+				"namespace", multiClusterHub.GetNamespace(), "configmap", toConfigmapName)
 
 			return ctrl.Result{}, err
 		}
@@ -216,7 +211,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			// that we can retry during the next reconciliation.
 			if err := r.finalizeHub(r.Log, multiClusterHub, ocpConsole, stsEnabled); err != nil {
 				// Logging err and returning nil to ensure 45 second wait
-				r.Log.Info(fmt.Sprintf("Finalizing: %s", err.Error()))
+				r.Log.Info("Finalizing", "error", err)
 				return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 			}
 
@@ -297,11 +292,10 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if utils.ProxyEnvVarsAreSet() {
-		r.Log.Info(
-			fmt.Sprintf("Proxy configuration environment variables are set. HTTP_PROXY: %s, HTTPS_PROXY: %s, NO_PROXY: %s",
-				os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"),
-			),
-		)
+		r.Log.Info("Proxy configuration environment variables are set",
+			"HTTP_PROXY", os.Getenv("HTTP_PROXY"),
+			"HTTPS_PROXY", os.Getenv("HTTPS_PROXY"),
+			"NO_PROXY", os.Getenv("NO_PROXY"))
 	}
 
 	result, err = r.ensurePullSecretCreated(multiClusterHub, multiClusterHub.GetNamespace())
@@ -430,6 +424,6 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
 
-	logf.Log.Info("Reconcile completed. Requeuing after " + utils.ShortRefreshInterval.String())
+	r.Log.Info("Reconcile completed. Requeuing after " + utils.ShortRefreshInterval.String())
 	return ctrl.Result{RequeueAfter: utils.ShortRefreshInterval}, nil
 }

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
@@ -116,7 +117,7 @@ func (r *MultiClusterHubReconciler) ComponentsAreRunning(m *operatorsv1.MultiClu
 	componentStatuses := getComponentStatuses(m, deployList, crList, ocpConsole, isSTSEnabled, r.OLMVersion)
 
 	delete(componentStatuses, m.Spec.LocalClusterName)
-	return allComponentsSuccessful(componentStatuses)
+	return allComponentsSuccessful(r.Log, componentStatuses)
 }
 
 // syncHubStatus checks if the status is up-to-date and sync it if necessary
@@ -145,7 +146,7 @@ func (r *MultiClusterHubReconciler) syncHubStatus(ctx context.Context, m *operat
 			return reconcile.Result{RequeueAfter: resyncPeriod}, nil
 		}
 
-		r.Log.Error(err, fmt.Sprintf("Failed to update %s/%s status ", m.Namespace, m.Name))
+		r.Log.Error(err, "Failed to update status", "namespace", m.Namespace, "name", m.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -175,7 +176,7 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 	}
 
 	// Set current version
-	successful := allComponentsSuccessful(components)
+	successful := allComponentsSuccessful(r.Log, components)
 	if successful && isMinorVersionWithinRange(mceVersionCompliance.CurrentVersion, version.Version, 5) {
 		status.CurrentVersion = version.Version
 	}
@@ -196,7 +197,7 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 			// Set AllOldComponentsRemovedReason so hubPruning() returns false on next reconcile
 			complete := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, AllOldComponentsRemovedReason, "All old resources pruned")
 			SetHubCondition(&status, *complete)
-			log.Info("Component pruning complete - all resources successfully removed")
+			r.Log.Info("Component pruning complete - all resources successfully removed")
 		} else {
 			// only add unavailable status if complete status already present
 			if HubConditionPresent(status, operatorsv1.Complete) {
@@ -227,7 +228,7 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 	} else if hasComponentFailure {
 		status.Phase = operatorsv1.HubError
 	} else {
-		status.Phase = aggregatePhase(status)
+		status.Phase = aggregatePhase(r.Log, status)
 	}
 
 	return status
@@ -570,7 +571,7 @@ func mapCSV(csv *unstructured.Unstructured) operatorsv1.StatusCondition {
 }
 
 // allComponentsSuccessful returns true if all components are successful, otherwise false
-func allComponentsSuccessful(components map[string]operatorsv1.StatusCondition) bool {
+func allComponentsSuccessful(log logr.Logger, components map[string]operatorsv1.StatusCondition) bool {
 	if len(components) == 0 {
 		return false
 	}
@@ -607,7 +608,7 @@ func allComponentsSuccessful(components map[string]operatorsv1.StatusCondition) 
 
 // aggregatePhase calculates overall HubPhaseType based on hub status. This does NOT account for
 // a hub in the process of deletion.
-func aggregatePhase(status operatorsv1.MultiClusterHubStatus) operatorsv1.HubPhaseType {
+func aggregatePhase(log logr.Logger, status operatorsv1.MultiClusterHubStatus) operatorsv1.HubPhaseType {
 	if utils.IsUnitTest() {
 		return operatorsv1.HubRunning
 	}
@@ -637,7 +638,7 @@ func aggregatePhase(status operatorsv1.MultiClusterHubStatus) operatorsv1.HubPha
 		return phase
 	}
 
-	if successful := allComponentsSuccessful(status.Components); successful {
+	if successful := allComponentsSuccessful(log, status.Components); successful {
 		if hubPruning(status) {
 			// hub is in pruning phase
 			return operatorsv1.HubPending

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -59,7 +59,7 @@ func Test_allComponentsSuccessful(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := allComponentsSuccessful(tt.args.components); !reflect.DeepEqual(got, tt.want) {
+			if got := allComponentsSuccessful(newTestLog(t), tt.args.components); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("allComponentsSuccessful() = %v, want %v", got, tt.want)
 			}
 		})
@@ -511,7 +511,7 @@ func TestCalculateStatus_RemovesStaleProgressingCondition(t *testing.T) {
 		}
 
 		// Verify phase would be Running (not stuck in Pending)
-		phase := aggregatePhase(newStatus)
+		phase := aggregatePhase(newTestLog(t), newStatus)
 		if phase != operatorsv1.HubRunning {
 			t.Errorf("Expected phase to be HubRunning after fix, got %v", phase)
 		}
@@ -627,7 +627,7 @@ func Test_aggregatePhase(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := aggregatePhase(tt.status); !reflect.DeepEqual(got, tt.want) {
+			if got := aggregatePhase(newTestLog(t), tt.status); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("aggregatePhase() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/storage.go
+++ b/controllers/storage.go
@@ -30,7 +30,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func (r *MultiClusterHubReconciler) GetDefaultStorageClassName(storageClasses storagev1.StorageClassList) string {
@@ -43,7 +42,7 @@ func (r *MultiClusterHubReconciler) GetDefaultStorageClassName(storageClasses st
 	}
 
 	if len(storageClasses.Items) > 1 {
-		log.Info("Warning: Multiple non-default storage classes found. A default storage class needs to be declared.")
+		r.Log.Info("Warning: Multiple non-default storage classes found. A default storage class needs to be declared.")
 	}
 	return ""
 }
@@ -62,13 +61,13 @@ func (r *MultiClusterHubReconciler) SetDefaultStorageClassName(ctx context.Conte
 		overrideStorageClass != envStorageClass {
 
 		if err := os.Setenv(helpers.DefaultStorageClassName, overrideStorageClass); err != nil {
-			log.Error(err, "unable to set the default StorageClass environment variable from annotation",
+			r.Log.Error(err, "unable to set the default StorageClass environment variable from annotation",
 				helpers.DefaultStorageClassName, overrideStorageClass)
 
 			return ctrl.Result{}, err
 		}
 
-		log.Info("Applied default StorageClass annotation override",
+		r.Log.Info("Applied default StorageClass annotation override",
 			"StorageClassName", overrideStorageClass)
 		return ctrl.Result{}, nil
 	}
@@ -92,7 +91,7 @@ func (r *MultiClusterHubReconciler) SetDefaultStorageClassName(ctx context.Conte
 			return ctrl.Result{}, err
 		}
 
-		logf.Log.Info("Default StorageClassName set from cluster resources",
+		r.Log.Info("Default StorageClassName set from cluster resources",
 			"Name", defaultStorageClass)
 	}
 	return ctrl.Result{}, nil

--- a/controllers/sts.go
+++ b/controllers/sts.go
@@ -20,7 +20,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -129,13 +128,12 @@ func (r *MultiClusterHubReconciler) ensureObjectExistsAndNotDeleted(ctx context.
 ) (bool, error) {
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: name}, obj); err != nil {
 		if errors.IsNotFound(err) {
-			r.Log.Info(
-				fmt.Sprintf("%s was not found. Ignoring since object must be deleted",
-					reflect.TypeOf(obj).Elem().Name()), "Name", name)
+			r.Log.Info("Object was not found. Ignoring since object must be deleted",
+				"type", reflect.TypeOf(obj).Elem().Name(), "name", name)
 			return false, nil
 		}
 
-		r.Log.Error(err, fmt.Sprintf("failed to get %s", reflect.TypeOf(obj).Elem().Name()), "Name", name)
+		r.Log.Error(err, "failed to get object", "type", reflect.TypeOf(obj).Elem().Name(), "name", name)
 		return false, err
 	}
 

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -49,7 +49,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 	if template.GetKind() == "APIService" {
 		result, err := r.ensureUnstructuredResource(m, template)
 		if err != nil {
-			log.Info(err.Error())
+			r.Log.Info(err.Error())
 			return result, err
 		}
 	} else {
@@ -60,12 +60,12 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 				crd := &apixv1.CustomResourceDefinition{}
 
 				if err := r.Client.Get(ctx, types.NamespacedName{Name: gvk.Name}, crd); errors.IsNotFound(err) {
-					log.Info("CustomResourceDefinition does not exist. Skipping resource creation",
+					r.Log.Info("CustomResourceDefinition does not exist. Skipping resource creation",
 						"Group", gvk.Group, "Version", gvk.Version, "Kind", gvk.Kind, "Name", template.GetName())
 					return ctrl.Result{RequeueAfter: utils.WarningRefreshInterval}, nil
 
 				} else if err != nil {
-					log.Error(err, "failed to get CustomResourceDefinition", "Resource", gvk)
+					r.Log.Error(err, "failed to get CustomResourceDefinition", "Resource", gvk)
 					return ctrl.Result{}, err
 				}
 			}
@@ -79,7 +79,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 				if err := r.Client.Create(ctx, template, &client.CreateOptions{}); err != nil {
 					return r.logAndSetCondition(err, "failed to create resource", template, m)
 				}
-				log.Info("Creating resource", "Kind", template.GetKind(), "Name", template.GetName())
+				r.Log.Info("Creating resource", "Kind", template.GetKind(), "Name", template.GetName())
 			} else {
 				return r.logAndSetCondition(err, "failed to get resource", existing, m)
 			}
@@ -95,7 +95,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 
 			desiredVersion := os.Getenv("OPERATOR_VERSION")
 			if desiredVersion == "" {
-				log.Info("Warning: OPERATOR_VERSION environment variable is not set")
+				r.Log.Info("Warning: OPERATOR_VERSION environment variable is not set")
 			}
 
 			if !r.ensureResourceVersionAlignment(existing, desiredVersion) {
@@ -115,12 +115,12 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 			if existing.GetKind() == "PersistentVolumeClaim" {
 				storageClassName, found, err := unstructured.NestedString(existing.Object, "spec", "storageClassName")
 				if err != nil {
-					log.Error(err, "failed to retrieve storageClassName from PVC", "Name", existing.GetName())
+					r.Log.Error(err, "failed to retrieve storageClassName from PVC", "Name", existing.GetName())
 					return ctrl.Result{}, err
 				}
 
 				if found && storageClassName != os.Getenv(helpers.DefaultStorageClassName) {
-					log.Info(
+					r.Log.Info(
 						"To update the PVC with a new StorageClass, delete the existing PVC to allow it to be recreated.",
 						"Name", existing.GetName(), "CurrentStorageClass", storageClassName,
 						"NewStorageClass", os.Getenv(helpers.DefaultStorageClassName))
@@ -131,7 +131,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 					"volumeClaimTemplates")
 
 				if err != nil {
-					log.Error(err, "failed to retrieve volumeClaimTemplates from StatefulSet", "Name",
+					r.Log.Error(err, "failed to retrieve volumeClaimTemplates from StatefulSet", "Name",
 						existing.GetName())
 					return ctrl.Result{}, err
 				}
@@ -144,13 +144,13 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 							volumeClaimTemplate.(map[string]interface{}), "spec", "storageClassName")
 
 						if err != nil {
-							log.Error(err, "failed to retrieve storageClassName from volumeClaimTemplate", "Index", i,
+							r.Log.Error(err, "failed to retrieve storageClassName from volumeClaimTemplate", "Index", i,
 								"Name", existing.GetName())
 							return ctrl.Result{}, err
 						}
 
 						if found && storageClassName != os.Getenv(helpers.DefaultStorageClassName) {
-							log.Info(
+							r.Log.Info(
 								"To update the STS with a new StorageClass, delete the existing STS to allow it to be recreated.",
 								"Name", existing.GetName(), "CurrentStorageClass", storageClassName,
 								"NewStorageClass", os.Getenv(helpers.DefaultStorageClassName))
@@ -166,10 +166,10 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 				if existing.GetKind() == "Deployment" {
 					containersChanged, err := r.detectContainerChanges(existing, template)
 					if err != nil {
-						log.Error(err, "Failed to detect container changes", "Name", template.GetName())
+						r.Log.Error(err, "Failed to detect container changes", "Name", template.GetName())
 
 					} else if containersChanged {
-						log.Info("Container set changed (added/removed) - using Update instead of Patch",
+						r.Log.Info("Container set changed (added/removed) - using Update instead of Patch",
 							"Kind", template.GetKind(), "Name", template.GetName())
 						useUpdate = true
 					}
@@ -207,7 +207,7 @@ func (r *MultiClusterHubReconciler) deleteTemplate(ctx context.Context, m *opera
 
 	// set status progressing condition
 	if err != nil {
-		log.Error(err, "Odd error delete template")
+		r.Log.Error(err, "Odd error delete template")
 		return ctrl.Result{}, err
 	}
 
@@ -223,7 +223,7 @@ func (r *MultiClusterHubReconciler) deleteTemplate(ctx context.Context, m *opera
 
 	err = r.Client.Delete(ctx, template)
 	if err != nil {
-		log.Error(err, "Failed to delete template")
+		r.Log.Error(err, "Failed to delete template")
 		return ctrl.Result{}, err
 	}
 
@@ -343,13 +343,13 @@ func (r *MultiClusterHubReconciler) ensureResourceVersionAlignment(template *uns
 	annotations := template.GetAnnotations()
 	currentVersion, ok := annotations[utils.AnnotationReleaseVersion]
 	if !ok {
-		log.Info(fmt.Sprintf("Annotation '%v' not found on resource", utils.AnnotationReleaseVersion),
+		r.Log.Info("Annotation not found on resource", "annotation", utils.AnnotationReleaseVersion,
 			"Kind", template.GetKind(), "Name", template.GetName())
 		return false
 	}
 
 	if currentVersion != desiredVersion {
-		log.Info("Resource version mismatch detected; attempting to update resource",
+		r.Log.Info("Resource version mismatch detected; attempting to update resource",
 			"Kind", template.GetKind(), "Name", template.GetName(),
 			"CurrentVersion", currentVersion, "DesiredVersion", desiredVersion)
 
@@ -362,7 +362,7 @@ func (r *MultiClusterHubReconciler) ensureResourceVersionAlignment(template *uns
 func (r *MultiClusterHubReconciler) logAndSetCondition(err error, message string,
 	template *unstructured.Unstructured, m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 
-	log.Error(err, message, "Kind", template.GetKind(), "Name", template.GetName())
+	r.Log.Error(err, message, "Kind", template.GetKind(), "Name", template.GetName())
 	wrappedError := pkgerrors.Wrapf(err, "%s Kind: %s Name: %s", message, template.GetKind(), template.GetName())
 
 	condType := fmt.Sprintf("%v: %v (Kind:%v)", operatorv1.ComponentFailure, template.GetName(),
@@ -400,7 +400,7 @@ func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *un
 
 	// Different number of containers = containers added or removed
 	if len(existingContainers) != len(desiredContainers) {
-		log.Info("Container count changed",
+		r.Log.Info("Container count changed",
 			"Name", existing.GetName(),
 			"Existing", len(existingContainers),
 			"Desired", len(desiredContainers))
@@ -427,7 +427,7 @@ func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *un
 		}
 		if name, ok := container["name"].(string); ok {
 			if !existingNames[name] {
-				log.Info("New container detected in desired spec",
+				r.Log.Info("New container detected in desired spec",
 					"Deployment", existing.GetName(),
 					"Container", name)
 				return true, nil
@@ -455,7 +455,7 @@ func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *un
 		}
 		if name, ok := container["name"].(string); ok {
 			if !desiredNames[name] {
-				log.Info("Container removed in desired spec",
+				r.Log.Info("Container removed in desired spec",
 					"Deployment", existing.GetName(),
 					"Container", name)
 				return true, nil

--- a/main.go
+++ b/main.go
@@ -77,7 +77,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -176,7 +175,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	ctrl.Log.WithName("MultiClusterHub Operator version").Info(fmt.Sprintf("%#v", version.Get()))
+	setupLog.Info("Operator version", "details", version.Get())
 
 	ns, err := getOperatorNamespace()
 	if err != nil {
@@ -341,7 +340,7 @@ func main() {
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		UncachedClient:  uncachedClient,
-		Log:             ctrl.Log.WithName("Controller").WithName("Multiclusterhub"),
+		Log:             ctrl.Log.WithName("mch-controller"),
 		UpgradeableCond: upgradeableCondition,
 		OLMVersion:      olmVersion,
 	}
@@ -411,8 +410,8 @@ func addMultiClusterEngineWatch(ctx context.Context, mgr ctrl.Manager, uncachedC
 							namespace = labels["multiclusterhub.namespace"]
 						}
 						if name == "" || namespace == "" {
-							l := log.Log.WithName("mce")
-							l.Info(fmt.Sprintf("MCE updated but missing installer.name or installer.namespace labels. Current labels: %v", labels))
+							l := setupLog.WithName("mce")
+							l.Info("MCE updated but missing installer labels", "labels", labels)
 							return
 						}
 						q.Add(

--- a/pkg/deploying/deployer.go
+++ b/pkg/deploying/deployer.go
@@ -11,21 +11,20 @@ import (
 	"crypto/sha1" // #nosec G505 (not using sha for private encryption)
 	"encoding/hex"
 
+	"github.com/go-logr/logr"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
-var log = logf.Log.WithName("deployer")
 var hashAnnotation = utils.AnnotationConfiguration
 
 // Deploy attempts to create or update the obj resource depending on whether it exists.
 // Returns true if deploy does try to create a new resource
-func Deploy(c runtimeclient.Client, obj *unstructured.Unstructured) (error, bool) {
+func Deploy(log logr.Logger, c runtimeclient.Client, obj *unstructured.Unstructured) (error, bool) {
 	found := &unstructured.Unstructured{}
 	found.SetGroupVersionKind(obj.GroupVersionKind())
 	err := c.Get(context.TODO(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, found)
@@ -33,7 +32,7 @@ func Deploy(c runtimeclient.Client, obj *unstructured.Unstructured) (error, bool
 		if errors.IsNotFound(err) {
 			log.Info("Creating resource", "Kind", obj.GetKind(), "Name", obj.GetName())
 			if kind := found.GetKind(); kind == "ServiceAccount" || kind == "CustomResourceDefinition" {
-				annotate(obj)
+				annotate(log, obj)
 			}
 			return c.Create(context.TODO(), obj), true
 		}
@@ -49,10 +48,10 @@ func Deploy(c runtimeclient.Client, obj *unstructured.Unstructured) (error, bool
 	}
 	// Update if hash doesn't match
 	if kind := found.GetKind(); kind == "ServiceAccount" || kind == "CustomResourceDefinition" {
-		if shasMatch(found, obj) {
+		if shasMatch(log, found, obj) {
 			return nil, false
 		}
-		annotate(obj)
+		annotate(log, obj)
 	}
 
 	// If resources exists, update it with current config
@@ -74,9 +73,8 @@ func hash(u *unstructured.Unstructured) (string, error) {
 	return hex.EncodeToString(bs), nil
 }
 
-// annotated modifies a deployment and sets an annotation with the hash of the deployment spec
-func annotate(u *unstructured.Unstructured) {
-	var log = logf.Log.WithValues("Namespace", u.GetNamespace(), "Name", u.GetName())
+func annotate(log logr.Logger, u *unstructured.Unstructured) {
+	log = log.WithValues("Namespace", u.GetNamespace(), "Name", u.GetName())
 
 	hx, err := hash(u)
 	if err != nil {
@@ -91,7 +89,7 @@ func annotate(u *unstructured.Unstructured) {
 	}
 }
 
-func shasMatch(found, want *unstructured.Unstructured) bool {
+func shasMatch(log logr.Logger, found, want *unstructured.Unstructured) bool {
 	hx, err := hash(want)
 	if err != nil {
 		log.Error(err, "Couldn't marshal object spec.", "Name", found.GetName())

--- a/pkg/deploying/deployer_test.go
+++ b/pkg/deploying/deployer_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,13 +19,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var testLog = logr.Discard()
+
 func TestNewDeployment(t *testing.T) {
 	fakeclient := fake.NewFakeClient()
 	dep, err := toUnstructuredObj(newDeployment("dep", "ns", 1))
 	if err != nil {
 		t.Fatalf("failed to generate deployment %v", err)
 	}
-	err, _ = Deploy(fakeclient, dep)
+	err, _ = Deploy(testLog, fakeclient, dep)
 	if err != nil {
 		t.Fatalf("failed to deploy deployment %v", err)
 	}
@@ -49,7 +52,7 @@ func newSA() *unstructured.Unstructured {
 func TestRepeatedDeploy(t *testing.T) {
 	fakeclient := fake.NewFakeClient()
 
-	err, new := Deploy(fakeclient, newSA())
+	err, new := Deploy(testLog, fakeclient, newSA())
 	if err != nil {
 		t.Fatalf("failed to deploy service account: %v", err)
 	}
@@ -57,7 +60,7 @@ func TestRepeatedDeploy(t *testing.T) {
 		t.Fatalf("Deploy() didn't create service account")
 	}
 
-	err, new = Deploy(fakeclient, newSA())
+	err, new = Deploy(testLog, fakeclient, newSA())
 	if err != nil {
 		t.Fatalf("failed to deploy service account: %v", err)
 	}
@@ -83,7 +86,7 @@ func TestRepeatedDeploy(t *testing.T) {
 	// Change resource and deploy again
 	annotatedSA := newSA()
 	annotatedSA.SetAnnotations(map[string]string{"foo": "bar"})
-	err, new = Deploy(fakeclient, annotatedSA)
+	err, new = Deploy(testLog, fakeclient, annotatedSA)
 	if err != nil {
 		t.Fatalf("failed to deploy service account: %v", err)
 	}
@@ -166,7 +169,7 @@ func Test_shasMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shasMatch(tt.found, tt.want); got != tt.expected {
+			if got := shasMatch(testLog, tt.found, tt.want); got != tt.expected {
 				t.Errorf("shasMatch() = %v, want %v", got, tt.expected)
 			}
 		})
@@ -178,7 +181,7 @@ func Test_annotate(t *testing.T) {
 	pod.SetAnnotations(map[string]string{"foo": "bar"})
 
 	t.Run("Keep existing annotations", func(t *testing.T) {
-		annotate(pod)
+		annotate(testLog, pod)
 		if got := pod.GetAnnotations()["foo"]; got != "bar" {
 			t.Errorf("Expected annotation to equal %s; got %s", "bar", got)
 		}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -9,12 +9,6 @@
 //   - Manifest templating
 package manifest
 
-import (
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-)
-
-var log = logf.Log.WithName("manifest")
-
 const ManifestsPathEnvVar = "MANIFESTS_PATH"
 
 // ManifestImage contains details for a specific image version

--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	olmapi "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -19,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -212,8 +212,7 @@ func OperandNamespace() string {
 }
 
 // find MCE. label it for future. return nil if no mce found.
-func FindAndManageMCE(ctx context.Context, k8sClient client.Client) (*mcev1.MultiClusterEngine, error) {
-	// first find subscription via managed-by label
+func FindAndManageMCE(log logr.Logger, ctx context.Context, k8sClient client.Client) (*mcev1.MultiClusterEngine, error) {
 	mce, err := multiclusterengineutils.GetManagedMCE(ctx, k8sClient)
 	if err != nil {
 		return nil, err
@@ -222,8 +221,7 @@ func FindAndManageMCE(ctx context.Context, k8sClient client.Client) (*mcev1.Mult
 		return mce, nil
 	}
 
-	// if label doesn't work find it via list
-	log.Log.WithName("reconcile").Info("Failed to find subscription via label")
+	log.Info("Failed to find MCE via label, listing all")
 	wholeList := &mcev1.MultiClusterEngineList{}
 	err = k8sClient.List(ctx, wholeList)
 	if err != nil {
@@ -243,10 +241,10 @@ func FindAndManageMCE(ctx context.Context, k8sClient client.Client) (*mcev1.Mult
 	}
 	labels[multiclusterengineutils.MCEManagedByLabel] = "true"
 	wholeList.Items[0].SetLabels(labels)
-	log.Log.WithName("reconcile").Info("Adding label to MCE")
+	log.Info("Adding label to MCE")
 
 	if err := k8sClient.Update(ctx, &wholeList.Items[0]); err != nil {
-		log.Log.WithName("reconcile").Error(err, "Failed to add managedBy label to preexisting MCE")
+		log.Error(err, "Failed to add managedBy label to preexisting MCE")
 		return &wholeList.Items[0], err
 	}
 	return &wholeList.Items[0], nil

--- a/pkg/multiclusterengine/multiclusterengine_test.go
+++ b/pkg/multiclusterengine/multiclusterengine_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/onsi/gomega"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -15,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var testLog = logr.Discard()
 
 func TestDesiredPackage(t *testing.T) {
 	os.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
@@ -85,7 +88,7 @@ func TestFindAndManageMCE(t *testing.T) {
 		WithLists(&mcev1.MultiClusterEngineList{Items: []mcev1.MultiClusterEngine{*managedmce1}}).
 		Build()
 
-	got, err := FindAndManageMCE(context.Background(), cl)
+	got, err := FindAndManageMCE(testLog, context.Background(), cl)
 	if err != nil {
 		t.Errorf("FindAndManageMCE() should have found mce by label. Got %v", err)
 	}
@@ -99,7 +102,7 @@ func TestFindAndManageMCE(t *testing.T) {
 		WithLists(&mcev1.MultiClusterEngineList{Items: []mcev1.MultiClusterEngine{*managedmce1, *managedmce2}}).
 		Build()
 
-	_, err = FindAndManageMCE(context.Background(), cl)
+	_, err = FindAndManageMCE(testLog, context.Background(), cl)
 	if err == nil {
 		t.Errorf("FindAndManageMCE() should have errored due to multiple mces")
 	}
@@ -110,7 +113,7 @@ func TestFindAndManageMCE(t *testing.T) {
 		WithLists(&mcev1.MultiClusterEngineList{Items: []mcev1.MultiClusterEngine{*unmanagedmce1}}).
 		Build()
 
-	got, err = FindAndManageMCE(context.Background(), cl)
+	got, err = FindAndManageMCE(testLog, context.Background(), cl)
 	if err != nil {
 		t.Errorf("FindAndManageMCE() should have found mce and labeled it. Got error %v", err)
 	}

--- a/pkg/multiclusterengine/olm/v0/catalog.go
+++ b/pkg/multiclusterengine/olm/v0/catalog.go
@@ -12,12 +12,12 @@ import (
 	"math"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	olmapi "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -29,26 +29,24 @@ const (
 
 // GetCatalogSource returns the name and namespace of an MCE catalogSource with the required channel.
 // Returns error if two or more catalogsources satisfy criteria.
-func GetCatalogSource(k8sClient client.Client, desiredChannel, desiredPackage string) (types.NamespacedName, error) {
+func GetCatalogSource(log logr.Logger, k8sClient client.Client, desiredChannel, desiredPackage string) (types.NamespacedName, error) {
 	nn := types.NamespacedName{}
 
-	pkgs, err := GetMCEPackageManifests(k8sClient, desiredPackage)
+	pkgs, err := GetMCEPackageManifests(log, k8sClient, desiredPackage)
 	if err != nil {
 		return nn, err
 	}
 
-	// Return an error if there are no package manifests found with the desired MCE package name.
 	if len(pkgs) == 0 {
 		return nn, fmt.Errorf("no %s packageManifests found", desiredPackage)
 	}
 
-	filtered := filterPackageManifests(pkgs, desiredChannel)
-	// Return an error if there are no package manifests found with the desired MCE channel name.
+	filtered := filterPackageManifests(log, pkgs, desiredChannel)
 	if len(filtered) == 0 {
 		return nn, fmt.Errorf("no %s packageManifests found with desired channel %s", desiredPackage, desiredChannel)
 	}
 
-	catalogSource, err := findHighestPriorityCatalogSource(k8sClient, filtered)
+	catalogSource, err := findHighestPriorityCatalogSource(log, k8sClient, filtered)
 	if err != nil {
 		return nn, err
 	}
@@ -67,11 +65,10 @@ func extractCatalogSource(pm olmapi.PackageManifest) types.NamespacedName {
 }
 
 // findHighestPriorityCatalogSource finds the catalog source with the highest priority among the given list.
-func findHighestPriorityCatalogSource(k8sClient client.Client, pkgs []olmapi.PackageManifest) (*subv1alpha1.CatalogSource, error) {
+func findHighestPriorityCatalogSource(log logr.Logger, k8sClient client.Client, pkgs []olmapi.PackageManifest) (*subv1alpha1.CatalogSource, error) {
 	var (
 		highestPriorityCatalogSources []*subv1alpha1.CatalogSource
 		maxPriority                   = math.MinInt64
-		log                           = log.Log.WithName("reconcile")
 	)
 
 	for _, pm := range pkgs {
@@ -79,18 +76,15 @@ func findHighestPriorityCatalogSource(k8sClient client.Client, pkgs []olmapi.Pac
 		nn := extractCatalogSource(pm)
 
 		if err := k8sClient.Get(context.TODO(), nn, cs); err != nil {
-			// Log the error and continue to the next iteration
-			log.Error(err, fmt.Sprintf("failed to retrieve catalog source %s/%s", nn.Namespace, nn.Name))
+			log.Error(err, "Failed to retrieve catalog source", "namespace", nn.Namespace, "name", nn.Name)
 			continue
 		}
 
 		if cs.Spec.Priority > maxPriority {
-			// Found a new highest priority, reset the slice and update the maxPriority
 			maxPriority = cs.Spec.Priority
 			highestPriorityCatalogSources = []*subv1alpha1.CatalogSource{cs}
 
 		} else if cs.Spec.Priority == maxPriority {
-			// Found another catalog source with the same highest priority, append it to the slice
 			highestPriorityCatalogSources = append(highestPriorityCatalogSources, cs)
 		}
 	}
@@ -101,12 +95,11 @@ func findHighestPriorityCatalogSource(k8sClient client.Client, pkgs []olmapi.Pac
 
 	case 1:
 		catalogSource := highestPriorityCatalogSources[0]
-		log.V(2).Info(fmt.Sprintf("Using catalog source %v/%v with the highest priority: %v",
-			catalogSource.Namespace, catalogSource.Name, catalogSource.Spec.Priority))
+		log.V(2).Info("Using catalog source with highest priority",
+			"namespace", catalogSource.Namespace, "name", catalogSource.Name, "priority", catalogSource.Spec.Priority)
 		return catalogSource, nil
 
 	default:
-		// Multiple catalog sources found with the same highest priority
 		var catalogNames []string
 		for _, cs := range highestPriorityCatalogSources {
 			catalogNames = append(catalogNames, fmt.Sprintf("%s/%s", cs.Namespace, cs.Name))
@@ -122,7 +115,7 @@ func findHighestPriorityCatalogSource(k8sClient client.Client, pkgs []olmapi.Pac
 // at the latest available version. Returns an empty list if no packagemanifests include the
 // channel. If more than one packagemanifest have the same latest version available it will
 // return them all.
-func filterPackageManifests(pkgManifests []olmapi.PackageManifest, desiredChannel string) []olmapi.PackageManifest {
+func filterPackageManifests(log logr.Logger, pkgManifests []olmapi.PackageManifest, desiredChannel string) []olmapi.PackageManifest {
 	filtered := []olmapi.PackageManifest{}
 	latestVersion := &semver.Version{}
 	for _, p := range pkgManifests {
@@ -131,7 +124,7 @@ func filterPackageManifests(pkgManifests []olmapi.PackageManifest, desiredChanne
 				versionString := c.CurrentCSVDesc.Version.String()
 				v, err := semver.NewVersion(versionString)
 				if err != nil {
-					log.Log.WithName("reconcile").Info("failed to parse version from packagemanifest", "catalogsource", p.Status.CatalogSource)
+					log.Info("Failed to parse version from packagemanifest", "catalogsource", p.Status.CatalogSource)
 					continue
 				}
 				if len(filtered) == 0 {
@@ -152,9 +145,8 @@ func filterPackageManifests(pkgManifests []olmapi.PackageManifest, desiredChanne
 }
 
 // GetMCEPackageManifests returns packagemanifests with the name multicluster-engine
-func GetMCEPackageManifests(k8sClient client.Client, packageName string) ([]olmapi.PackageManifest, error) {
+func GetMCEPackageManifests(log logr.Logger, k8sClient client.Client, packageName string) ([]olmapi.PackageManifest, error) {
 	ctx := context.Background()
-	log := log.Log.WithName("reconcile")
 	packageManifests := &olmapi.PackageManifestList{}
 	var err error
 	if utils.IsUnitTest() {

--- a/pkg/multiclusterengine/olm/v0/catalog_test.go
+++ b/pkg/multiclusterengine/olm/v0/catalog_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
 	olmversion "github.com/operator-framework/api/pkg/lib/version"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	olmapi "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
@@ -18,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var testLog = logr.Discard()
 
 func Test_filterPackageManifests(t *testing.T) {
 	type args struct {
@@ -293,7 +296,7 @@ func Test_filterPackageManifests(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := filterPackageManifests(tt.args.pkgManifests, tt.args.channel); !reflect.DeepEqual(got, tt.want) {
+			if got := filterPackageManifests(testLog, tt.args.pkgManifests, tt.args.channel); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("filterPackageManifests() = %v, want %v", got, tt.want)
 			}
 		})
@@ -396,7 +399,7 @@ func Test_GetCatalogSource(t *testing.T) {
 				t.Errorf("failed to create manifest: %v", err)
 			}
 
-			got, err := GetCatalogSource(mockClient, tt.channel, tt.packageName)
+			got, err := GetCatalogSource(testLog, mockClient, tt.channel, tt.packageName)
 			if err != nil {
 				t.Errorf("GetCatalogSource(mockClient) error = %v", err)
 			}
@@ -546,9 +549,9 @@ func Test_findHighestPriorityCatalogSource(t *testing.T) {
 				}
 			}
 
-			_, err := findHighestPriorityCatalogSource(mockClient, tt.pkgs)
+			_, err := findHighestPriorityCatalogSource(testLog, mockClient, tt.pkgs)
 			if got := err != nil; got != tt.want {
-				t.Errorf("findHighestPriorityCatalogSource(mockClient, tt.pkgs) = got: %v, want: %v", got, tt.want)
+				t.Errorf("findHighestPriorityCatalogSource(testLog, mockClient, tt.pkgs) = got: %v, want: %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/multiclusterengine/olm/v0/subscription.go
+++ b/pkg/multiclusterengine/olm/v0/subscription.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
@@ -16,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -167,8 +167,7 @@ func GetManagedMCESubscription(ctx context.Context, k8sClient client.Client) (*s
 }
 
 // FindAndManageMCESubscription finds MCE subscription. label it for future. return nil if no sub found.
-func FindAndManageMCESubscription(ctx context.Context, k8sClient client.Client, desiredPackage string) (*subv1alpha1.Subscription, error) {
-	// first find subscription via managed-by label
+func FindAndManageMCESubscription(log logr.Logger, ctx context.Context, k8sClient client.Client, desiredPackage string) (*subv1alpha1.Subscription, error) {
 	sub, err := GetManagedMCESubscription(ctx, k8sClient)
 	if err != nil {
 		return nil, err
@@ -177,9 +176,7 @@ func FindAndManageMCESubscription(ctx context.Context, k8sClient client.Client, 
 		return sub, nil
 	}
 
-	// if label doesn't work find it via .spec.name (it's package)
-	// we can't assume it's name or namespace
-	log.Log.WithName("reconcile").Info("Failed to find subscription via label")
+	log.Info("Failed to find subscription via label, listing all")
 	wholeList := &subv1alpha1.SubscriptionList{}
 	err = k8sClient.List(ctx, wholeList)
 	if err != nil {
@@ -190,16 +187,15 @@ func FindAndManageMCESubscription(ctx context.Context, k8sClient client.Client, 
 			continue
 		}
 		if wholeList.Items[i].Spec.Package == desiredPackage {
-			// adding label so it can be found in the future
 			labels := wholeList.Items[i].GetLabels()
 			if labels == nil {
 				labels = map[string]string{}
 			}
 			labels[multiclusterengineutils.MCEManagedByLabel] = "true"
 			wholeList.Items[i].SetLabels(labels)
-			log.Log.WithName("reconcile").Info("Adding label to subscription")
+			log.Info("Adding label to subscription")
 			if err := k8sClient.Update(ctx, &wholeList.Items[i]); err != nil {
-				log.Log.WithName("reconcile").Error(err, "Failed to add managedBy label to preexisting MCE with MCH spec")
+				log.Error(err, "Failed to add managedBy label to preexisting MCE subscription")
 				return &wholeList.Items[i], err
 			}
 			return &wholeList.Items[i], nil

--- a/pkg/multiclusterengine/olm/v0/subscription_test.go
+++ b/pkg/multiclusterengine/olm/v0/subscription_test.go
@@ -208,7 +208,7 @@ func TestFindAndManageMCESubscription(t *testing.T) {
 		WithLists(&subv1alpha1.SubscriptionList{Items: []subv1alpha1.Subscription{*managedSub1}}).
 		Build()
 
-	got, err := FindAndManageMCESubscription(context.Background(), cl, multiclusterengine.MCECommunityPackageName)
+	got, err := FindAndManageMCESubscription(testLog, context.Background(), cl, multiclusterengine.MCECommunityPackageName)
 	if err != nil {
 		t.Errorf("FindAndManageMCESubscription() should have found subscription by label. Got %v", err)
 	}
@@ -222,7 +222,7 @@ func TestFindAndManageMCESubscription(t *testing.T) {
 		WithLists(&subv1alpha1.SubscriptionList{Items: []subv1alpha1.Subscription{*managedSub1, *managedSub2}}).
 		Build()
 
-	_, err = FindAndManageMCESubscription(context.Background(), cl, multiclusterengine.MCECommunityPackageName)
+	_, err = FindAndManageMCESubscription(testLog, context.Background(), cl, multiclusterengine.MCECommunityPackageName)
 	if err == nil {
 		t.Errorf("FindAndManageMCESubscription() should have errored due to multiple subscriptions")
 	}
@@ -233,7 +233,7 @@ func TestFindAndManageMCESubscription(t *testing.T) {
 		WithLists(&subv1alpha1.SubscriptionList{Items: []subv1alpha1.Subscription{*unmanagedSub1}}).
 		Build()
 
-	got, err = FindAndManageMCESubscription(context.Background(), cl, multiclusterengine.MCECommunityPackageName)
+	got, err = FindAndManageMCESubscription(testLog, context.Background(), cl, multiclusterengine.MCECommunityPackageName)
 	if err != nil {
 		t.Errorf("FindAndManageMCESubscription() should have found subscription and labeled it. Got error %v", err)
 	}

--- a/pkg/multiclusterengine/olm/v1/clustercatalog.go
+++ b/pkg/multiclusterengine/olm/v1/clustercatalog.go
@@ -15,11 +15,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -38,8 +38,7 @@ var catalogQueryFunc = func(ctx context.Context, cl client.Client, catalogName, 
 // Unlike v0 CatalogSource (namespaced), ClusterCatalog is cluster-scoped so returns only name.
 // Selects catalog based on priority (highest priority wins).
 // Returns error if multiple catalogs with same highest priority exist.
-func GetClusterCatalog(ctx context.Context, k8sClient client.Client, desiredPackage string) (string, error) {
-	log := log.Log.WithName("reconcile")
+func GetClusterCatalog(log logr.Logger, ctx context.Context, k8sClient client.Client, desiredPackage string) (string, error) {
 
 	// List all ClusterCatalogs
 	ccList := &ocv1.ClusterCatalogList{}
@@ -124,8 +123,7 @@ func GetClusterCatalog(ctx context.Context, k8sClient client.Client, desiredPack
 	}
 
 	catalog := highestPriorityCatalogs[0]
-	log.Info(fmt.Sprintf("Using ClusterCatalog %s (priority: %d) for package %s",
-		catalog.Name, catalog.Spec.Priority, desiredPackage))
+	log.Info("Using ClusterCatalog for package", "catalog", catalog.Name, "priority", catalog.Spec.Priority, "package", desiredPackage)
 	return catalog.Name, nil
 }
 

--- a/pkg/multiclusterengine/olm/v1/clustercatalog_test.go
+++ b/pkg/multiclusterengine/olm/v1/clustercatalog_test.go
@@ -7,12 +7,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var testLog = logr.Discard()
 
 func Test_GetClusterCatalog(t *testing.T) {
 	// Save original catalogQueryFunc and restore after tests
@@ -332,7 +335,7 @@ func Test_GetClusterCatalog(t *testing.T) {
 				Build()
 
 			// Run test
-			gotName, err := GetClusterCatalog(context.TODO(), client, tt.desiredPackage)
+			gotName, err := GetClusterCatalog(testLog, context.TODO(), client, tt.desiredPackage)
 
 			// Verify error expectations
 			if (err != nil) != tt.wantErr {

--- a/pkg/multiclusterengine/olm/v1/clusterextension.go
+++ b/pkg/multiclusterengine/olm/v1/clusterextension.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/go-logr/logr"
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine"
@@ -18,7 +19,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -124,11 +124,8 @@ func GetManagedMCEClusterExtension(ctx context.Context, k8sClient client.Client)
 }
 
 // FindAndManageMCEClusterExtension finds MCE ClusterExtension, labels it for future. Returns nil if not found.
-func FindAndManageMCEClusterExtension(ctx context.Context, k8sClient client.Client,
+func FindAndManageMCEClusterExtension(log logr.Logger, ctx context.Context, k8sClient client.Client,
 	desiredPackage string) (*ocv1.ClusterExtension, error) {
-	log := log.Log.WithName("reconcile")
-
-	// First try via managed label
 	ce, err := GetManagedMCEClusterExtension(ctx, k8sClient)
 	if err != nil {
 		return nil, err

--- a/pkg/overrides/overrides.go
+++ b/pkg/overrides/overrides.go
@@ -17,15 +17,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/stolostron/multiclusterhub-operator/pkg/manifest"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var logf = log.Log.WithName("overrides")
 
 const (
 	// OSBSImagePrefix ...
@@ -106,7 +104,7 @@ GetOverridesFromConfigmap reads and formats image or template overrides from a C
 ConfigMap, parses the data, and returns overrides. If the ConfigMap is not found or has unexpected data, it returns
 an error.
 */
-func GetOverridesFromConfigmap(k8sClient client.Client, overrides map[string]string, namespace, configmapName string,
+func GetOverridesFromConfigmap(log logr.Logger, k8sClient client.Client, overrides map[string]string, namespace, configmapName string,
 	isTemplate bool) (map[string]string, error) {
 
 	objectType := "image"
@@ -114,7 +112,7 @@ func GetOverridesFromConfigmap(k8sClient client.Client, overrides map[string]str
 		objectType = "template"
 	}
 
-	logf.Info(fmt.Sprintf("Overriding %s from configmap: %s/%s", objectType, namespace, configmapName))
+	log.Info("Overriding from configmap", "type", objectType, "namespace", namespace, "configmap", configmapName)
 
 	configmap := &corev1.ConfigMap{}
 	err := k8sClient.Get(context.TODO(), types.NamespacedName{
@@ -160,10 +158,9 @@ func GetOverridesFromConfigmap(k8sClient client.Client, overrides map[string]str
 /*
 GetOverridesFromEnv reads and formats full image or template reference from environment variables.
 */
-func GetOverridesFromEnv(prefix string) map[string]string {
+func GetOverridesFromEnv(log logr.Logger, prefix string) map[string]string {
 	overrides := make(map[string]string)
 
-	// Iterate through environment variables
 	for _, e := range os.Environ() {
 		key, value := parseEnvVarByPrefix(e, prefix)
 		if key != "" && value != "" {
@@ -172,7 +169,7 @@ func GetOverridesFromEnv(prefix string) map[string]string {
 	}
 
 	if len(overrides) > 0 {
-		logf.Info(fmt.Sprintf("Found overrides from environment variables set by %s prefix", prefix))
+		log.Info("Found overrides from environment variables", "prefix", prefix)
 	}
 
 	return overrides

--- a/pkg/overrides/overrides_test.go
+++ b/pkg/overrides/overrides_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stolostron/multiclusterhub-operator/pkg/manifest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,46 +18,48 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var testLog = logr.Discard()
+
 func Test_GetOverridesFromEnv(t *testing.T) {
 	os.Setenv("OPERAND_IMAGE_APPLICATION_UI", "quay.io/stolostron/application-ui:test-image")
 	os.Setenv("OPERAND_IMAGE_CERT_POLICY_CONTROLLER", "quay.io/stolostron/cert-policy-controller:test-image")
 
-	if len(GetOverridesFromEnv(OperandImagePrefix)) != 2 {
+	if len(GetOverridesFromEnv(testLog, OperandImagePrefix)) != 2 {
 		t.Fatal("Expected image overrides")
 	}
 
 	os.Unsetenv("OPERAND_IMAGE_APPLICATION_UI")
 	os.Unsetenv("OPERAND_IMAGE_CERT_POLICY_CONTROLLER")
 
-	if len(GetOverridesFromEnv(OperandImagePrefix)) != 0 {
+	if len(GetOverridesFromEnv(testLog, OperandImagePrefix)) != 0 {
 		t.Fatal("Expected no image overrides")
 	}
 
 	os.Setenv("RELATED_IMAGE_APPLICATION_UI", "quay.io/stolostron/application-ui:test-image")
 	os.Setenv("RELATED_IMAGE_CERT_POLICY_CONTROLLER", "quay.io/stolostron/cert-policy-controller:test-image")
 
-	if len(GetOverridesFromEnv(OSBSImagePrefix)) != 2 {
+	if len(GetOverridesFromEnv(testLog, OSBSImagePrefix)) != 2 {
 		t.Fatal("Expected related image overrides")
 	}
 
 	os.Unsetenv("RELATED_IMAGE_APPLICATION_UI")
 	os.Unsetenv("RELATED_IMAGE_CERT_POLICY_CONTROLLER")
 
-	if len(GetOverridesFromEnv(OSBSImagePrefix)) != 0 {
+	if len(GetOverridesFromEnv(testLog, OSBSImagePrefix)) != 0 {
 		t.Fatal("Expected no related image overrides")
 	}
 
 	os.Setenv("TEMPLATE_OVERRIDE_FOO_LIMIT_CPU", "3m")
 	os.Setenv("TEMPLATE_OVERRIDE_FOO_LIMIT_MEMORY", "40Mi")
 
-	if len(GetOverridesFromEnv(TemplateOverridePrefix)) != 2 {
+	if len(GetOverridesFromEnv(testLog, TemplateOverridePrefix)) != 2 {
 		t.Fatal("Expected template overrides")
 	}
 
 	os.Unsetenv("TEMPLATE_OVERRIDE_FOO_LIMIT_CPU")
 	os.Unsetenv("TEMPLATE_OVERRIDE_FOO_LIMIT_MEMORY")
 
-	if len(GetOverridesFromEnv(TemplateOverridePrefix)) != 0 {
+	if len(GetOverridesFromEnv(testLog, TemplateOverridePrefix)) != 0 {
 		t.Fatal("Expected no template overrides")
 	}
 }
@@ -243,7 +246,7 @@ func Test_GetOverridesFromConfigmap(t *testing.T) {
 		}
 
 		overrides := map[string]string{}
-		overrides, err = GetOverridesFromConfigmap(fakeclient, overrides, "namespace", "configmapName", true)
+		overrides, err = GetOverridesFromConfigmap(testLog, fakeclient, overrides, "namespace", "configmapName", true)
 		if err != nil {
 			t.Errorf("Failed to get overrides from configmap: %v", err)
 		}
@@ -281,7 +284,7 @@ func Test_GetOverridesFromConfigmap(t *testing.T) {
 		}
 
 		overrides := map[string]string{}
-		overrides, err = GetOverridesFromConfigmap(fakeclient, overrides, "namespace", "configmapName", false)
+		overrides, err = GetOverridesFromConfigmap(testLog, fakeclient, overrides, "namespace", "configmapName", false)
 		if err != nil {
 			t.Errorf("Failed to get overrides from configmap: %v", err)
 		}

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-var log = logf.Log.WithName("predicate")
+var log = logf.Log.WithName("mch-controller").WithName("predicate")
 
 // GenerationChangedPredicate will skip update events that have no change in the object's metadata.generation field.
 // The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.

--- a/pkg/rendering/renderer.go
+++ b/pkg/rendering/renderer.go
@@ -27,6 +27,7 @@ import (
 	loader "helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 
+	"github.com/go-logr/logr"
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/helpers"
@@ -35,7 +36,6 @@ import (
 	"helm.sh/helm/v3/pkg/engine"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -65,8 +65,6 @@ const (
 	defaultOADPCatalogSourceNamespace = "openshift-marketplace"
 )
 
-var log = logf.Log.WithName("reconcile")
-
 func convertTolerations(tols []corev1.Toleration) []Toleration {
 	var tolerations []Toleration
 	for _, t := range tols {
@@ -82,7 +80,7 @@ func convertTolerations(tols []corev1.Toleration) []Toleration {
 }
 
 // parseProbeConfigFromAnnotations reads probe config from MCH annotations
-func parseProbeConfigFromAnnotations(mch *v1.MultiClusterHub) *ProbeConfig {
+func parseProbeConfigFromAnnotations(log logr.Logger, mch *v1.MultiClusterHub) *ProbeConfig {
 	if mch.Annotations == nil {
 		return nil
 	}
@@ -93,9 +91,9 @@ func parseProbeConfigFromAnnotations(mch *v1.MultiClusterHub) *ProbeConfig {
 	if val, ok := mch.Annotations[utils.AnnotationProbeTimeoutSeconds]; ok {
 		timeout, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
-			log.Info(fmt.Sprintf("Invalid probe-timeout-seconds annotation value %q: %v", val, err))
+			log.Info("Invalid probe-timeout-seconds annotation value", "value", val, "error", err)
 		} else if timeout <= 0 {
-			log.Info(fmt.Sprintf("Invalid probe-timeout-seconds annotation value %q: must be positive", val))
+			log.Info("Invalid probe-timeout-seconds annotation value: must be positive", "value", val)
 		} else {
 			timeout32 := int32(timeout)
 			config.TimeoutSeconds = &timeout32
@@ -106,9 +104,9 @@ func parseProbeConfigFromAnnotations(mch *v1.MultiClusterHub) *ProbeConfig {
 	if val, ok := mch.Annotations[utils.AnnotationProbeFailureThreshold]; ok {
 		threshold, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
-			log.Info(fmt.Sprintf("Invalid probe-failure-threshold annotation value %q: %v", val, err))
+			log.Info("Invalid probe-failure-threshold annotation value", "value", val, "error", err)
 		} else if threshold <= 0 {
-			log.Info(fmt.Sprintf("Invalid probe-failure-threshold annotation value %q: must be positive", val))
+			log.Info("Invalid probe-failure-threshold annotation value: must be positive", "value", val)
 		} else {
 			threshold32 := int32(threshold)
 			config.FailureThreshold = &threshold32
@@ -119,9 +117,9 @@ func parseProbeConfigFromAnnotations(mch *v1.MultiClusterHub) *ProbeConfig {
 	if val, ok := mch.Annotations[utils.AnnotationProbeSuccessThreshold]; ok {
 		threshold, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
-			log.Info(fmt.Sprintf("Invalid probe-success-threshold annotation value %q: %v", val, err))
+			log.Info("Invalid probe-success-threshold annotation value", "value", val, "error", err)
 		} else if threshold <= 0 {
-			log.Info(fmt.Sprintf("Invalid probe-success-threshold annotation value %q: must be positive", val))
+			log.Info("Invalid probe-success-threshold annotation value: must be positive", "value", val)
 		} else {
 			threshold32 := int32(threshold)
 			config.SuccessThreshold = &threshold32
@@ -252,7 +250,7 @@ func RenderCRDs(crdDir string, mch *v1.MultiClusterHub) ([]*unstructured.Unstruc
 // RenderCharts renders all Helm charts in the specified directory.
 // olmVersion: OLM version detected at runtime ("v0", "v1", or "" for no OLM).
 // Passed to chart templates as .Values.global.olmVersion for conditional rendering.
-func RenderCharts(chartDir string, mch *v1.MultiClusterHub, images map[string]string, tpl map[string]string,
+func RenderCharts(log logr.Logger, chartDir string, mch *v1.MultiClusterHub, images map[string]string, tpl map[string]string,
 	isSTSEnabled bool, olmVersion string) ([]*unstructured.Unstructured, []error) {
 
 	var templates []*unstructured.Unstructured
@@ -272,10 +270,10 @@ func RenderCharts(chartDir string, mch *v1.MultiClusterHub, images map[string]st
 
 	for _, chart := range charts {
 		chartPath := filepath.Join(chartDir, chart.Name())
-		chartTemplates, errs := renderTemplates(chartPath, mch, images, tpl, isSTSEnabled, olmVersion)
+		chartTemplates, errs := renderTemplates(log, chartPath, mch, images, tpl, isSTSEnabled, olmVersion)
 		if len(errs) > 0 {
 			for _, err := range errs {
-				log.Info(err.Error())
+				log.Info("Chart rendering error", "error", err)
 			}
 			return nil, errs
 		}
@@ -287,7 +285,7 @@ func RenderCharts(chartDir string, mch *v1.MultiClusterHub, images map[string]st
 // RenderChart renders a single Helm chart from the specified path.
 // olmVersion: OLM version detected at runtime ("v0", "v1", or "" for no OLM).
 // Passed to chart templates as .Values.global.olmVersion for conditional rendering.
-func RenderChart(chartPath string, mch *v1.MultiClusterHub, images map[string]string, templates map[string]string,
+func RenderChart(log logr.Logger, chartPath string, mch *v1.MultiClusterHub, images map[string]string, templates map[string]string,
 	isSTSEnabled bool, olmVersion string) ([]*unstructured.Unstructured, []error) {
 
 	if val, ok := os.LookupEnv("DIRECTORY_OVERRIDE"); ok {
@@ -298,10 +296,10 @@ func RenderChart(chartPath string, mch *v1.MultiClusterHub, images map[string]st
 
 	}
 
-	chartTemplates, errs := renderTemplates(chartPath, mch, images, templates, isSTSEnabled, olmVersion)
+	chartTemplates, errs := renderTemplates(log, chartPath, mch, images, templates, isSTSEnabled, olmVersion)
 	if len(errs) > 0 {
 		for _, err := range errs {
-			log.Info(err.Error())
+			log.Info("Chart rendering error", "error", err)
 		}
 		return nil, errs
 	}
@@ -310,7 +308,7 @@ func RenderChart(chartPath string, mch *v1.MultiClusterHub, images map[string]st
 
 }
 
-func renderTemplates(chartPath string, mch *v1.MultiClusterHub, images map[string]string, tpl map[string]string,
+func renderTemplates(log logr.Logger, chartPath string, mch *v1.MultiClusterHub, images map[string]string, tpl map[string]string,
 	isSTSEnabled bool, olmVersion string) ([]*unstructured.Unstructured, []error) {
 
 	var templates []*unstructured.Unstructured
@@ -318,12 +316,12 @@ func renderTemplates(chartPath string, mch *v1.MultiClusterHub, images map[strin
 
 	chart, err := loader.Load(chartPath)
 	if err != nil {
-		log.Info("error loading chart")
+		log.Info("Error loading chart", "path", chartPath)
 		return nil, append(errs, err)
 	}
 
 	valuesYaml := &Values{}
-	injectValuesOverrides(valuesYaml, mch, images, tpl, isSTSEnabled, olmVersion)
+	injectValuesOverrides(log, valuesYaml, mch, images, tpl, isSTSEnabled, olmVersion)
 	helmEngine := engine.Engine{
 		Strict:   true,
 		LintMode: false,
@@ -331,13 +329,13 @@ func renderTemplates(chartPath string, mch *v1.MultiClusterHub, images map[strin
 
 	vals, err := valuesYaml.ToValues()
 	if err != nil {
-		log.Info(fmt.Sprintf("error rendering chart: %s", chart.Name()))
+		log.Info("Error rendering chart", "chart", chart.Name())
 		return nil, append(errs, err)
 	}
 
 	rawTemplates, err := helmEngine.Render(chart, chartutil.Values{"Values": vals.AsMap()})
 	if err != nil {
-		log.Info(fmt.Sprintf("error rendering chart: %s", chart.Name()))
+		log.Info("Error rendering chart", "chart", chart.Name())
 		return nil, append(errs, err)
 	}
 
@@ -381,7 +379,7 @@ func renderTemplates(chartPath string, mch *v1.MultiClusterHub, images map[strin
 	return templates, errs
 }
 
-func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[string]string,
+func injectValuesOverrides(log logr.Logger, values *Values, mch *v1.MultiClusterHub, images map[string]string,
 	templates map[string]string, isSTSEnabled bool, olmVersion string) {
 
 	values.Global.ImageOverrides = images
@@ -421,7 +419,7 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 
 	values.HubConfig.Tolerations = convertTolerations(utils.GetTolerations(mch))
 
-	values.HubConfig.ProbeConfig = parseProbeConfigFromAnnotations(mch)
+	values.HubConfig.ProbeConfig = parseProbeConfigFromAnnotations(log, mch)
 
 	values.HubConfig.OCPVersion = os.Getenv("ACM_HUB_OCP_VERSION")
 
@@ -447,7 +445,7 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 		values.HubConfig.ProxyConfigs = proxyVar
 	}
 
-	values.Global.Name, values.Global.Channel, values.Global.InstallPlanApproval, values.Global.Source, values.Global.SourceNamespace, values.Global.StartingCSV = GetOADPConfig(mch)
+	values.Global.Name, values.Global.Channel, values.Global.InstallPlanApproval, values.Global.Source, values.Global.SourceNamespace, values.Global.StartingCSV = GetOADPConfig(log, mch)
 
 	values.Global.MinOADPChannel = defaultOADPChannel
 	values.Global.MinOADPStableChannel = defaultOADPStableChannel
@@ -463,7 +461,7 @@ func injectValuesOverrides(values *Values, mch *v1.MultiClusterHub, images map[s
 
 	// Apply OADP ClusterExtension overrides (OLM v1) if annotation present and effective OADP OLM version is v1
 	if values.Global.OADPOLMVersion == "v1" {
-		if overrides := parseOADPClusterExtensionAnnotation(mch); overrides != nil {
+		if overrides := parseOADPClusterExtensionAnnotation(log, mch); overrides != nil {
 			// Override catalog settings for OLM v1
 			if len(overrides.Channels) > 0 {
 				// Use first channel from override
@@ -494,7 +492,7 @@ type OADPClusterExtensionOverrides struct {
 // parseOADPClusterExtensionAnnotation unmarshals the OADP ClusterExtension annotation from a MultiClusterHub.
 // Returns nil if no annotation is present or if unmarshaling fails.
 // The annotation key is installer.open-cluster-management.io/oadp-clusterextension-spec (OLM v1).
-func parseOADPClusterExtensionAnnotation(m *v1.MultiClusterHub) *OADPClusterExtensionOverrides {
+func parseOADPClusterExtensionAnnotation(log logr.Logger, m *v1.MultiClusterHub) *OADPClusterExtensionOverrides {
 	oadpAnnotationOverrides := utils.GetOADPClusterExtensionAnnotationOverrides(m)
 	if oadpAnnotationOverrides == "" {
 		return nil
@@ -502,7 +500,7 @@ func parseOADPClusterExtensionAnnotation(m *v1.MultiClusterHub) *OADPClusterExte
 	overrides := &OADPClusterExtensionOverrides{}
 	err := json.Unmarshal([]byte(oadpAnnotationOverrides), overrides)
 	if err != nil {
-		log.Info(fmt.Sprintf("Failed to unmarshal OADP ClusterExtension annotation: %s. Error: %v", oadpAnnotationOverrides, err))
+		log.Info("Failed to unmarshal OADP ClusterExtension annotation", "annotation", oadpAnnotationOverrides, "error", err)
 		return nil
 	}
 	return overrides
@@ -511,7 +509,7 @@ func parseOADPClusterExtensionAnnotation(m *v1.MultiClusterHub) *OADPClusterExte
 // parseOADPAnnotation unmarshals the OADP subscription annotation from a MultiClusterHub.
 // Returns an empty SubscriptionSpec if no annotation is present or if unmarshaling fails.
 // The annotation key is installer.open-cluster-management.io/oadp-subscription-spec (OLM v0).
-func parseOADPAnnotation(m *v1.MultiClusterHub) *subv1alpha1.SubscriptionSpec {
+func parseOADPAnnotation(log logr.Logger, m *v1.MultiClusterHub) *subv1alpha1.SubscriptionSpec {
 	sub := &subv1alpha1.SubscriptionSpec{}
 	oadpSpec := utils.GetOADPAnnotationOverrides(m)
 	if oadpSpec == "" {
@@ -519,7 +517,7 @@ func parseOADPAnnotation(m *v1.MultiClusterHub) *subv1alpha1.SubscriptionSpec {
 	}
 
 	if err := json.Unmarshal([]byte(oadpSpec), sub); err != nil {
-		log.Info(fmt.Sprintf("Failed to unmarshal OADP annotation: %s.", oadpSpec))
+		log.Info("Failed to unmarshal OADP annotation", "annotation", oadpSpec, "error", err)
 	}
 	return sub
 }
@@ -553,8 +551,8 @@ func valueOrDefault(value, defaultValue string) string {
 	return defaultValue
 }
 
-func GetOADPConfig(m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval, string, string, string) {
-	sub := parseOADPAnnotation(m)
+func GetOADPConfig(log logr.Logger, m *v1.MultiClusterHub) (string, string, subv1alpha1.Approval, string, string, string) {
+	sub := parseOADPAnnotation(log, m)
 
 	name := valueOrDefault(sub.Package, defaultOADPName)
 	channel := getOADPChannel(sub.Channel)

--- a/pkg/rendering/renderer_test.go
+++ b/pkg/rendering/renderer_test.go
@@ -4,13 +4,11 @@
 package renderer
 
 import (
-
-	// "reflect"
-
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	v1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 
@@ -20,6 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+var testLog = logr.Discard()
 
 const (
 	chartsDir = "/charts/toggle"
@@ -105,7 +105,7 @@ func TestRender(t *testing.T) {
 
 	// multiple charts
 	chartsDir := chartsDir
-	templates, errs := RenderCharts(chartsDir, testMCH, testImages, templateOverrides, false, "v0")
+	templates, errs := RenderCharts(testLog, chartsDir, testMCH, testImages, templateOverrides, false, "v0")
 	if len(errs) > 0 {
 		for _, err := range errs {
 			t.Log(err.Error())
@@ -180,7 +180,7 @@ func TestRender(t *testing.T) {
 
 	for _, chartsPath := range chartPaths {
 		chartsPath := chartsPath
-		singleChartTemplates, errs := RenderChart(chartsPath, testMCH, singleChartTestImages, templateOverrides, false, "v0")
+		singleChartTemplates, errs := RenderChart(testLog, chartsPath, testMCH, singleChartTestImages, templateOverrides, false, "v0")
 		if len(errs) > 0 {
 			for _, err := range errs {
 				t.Log(err.Error())
@@ -317,7 +317,7 @@ func TestOADPAnnotation(t *testing.T) {
 		},
 	}
 
-	test1, test2, test3, test4, test5, test6 := GetOADPConfig(mch)
+	test1, test2, test3, test4, test5, test6 := GetOADPConfig(testLog, mch)
 
 	if test1 != "redhat-oadp-operator2" {
 		t.Error("Cluster Backup missing OADP overrides for name")
@@ -351,14 +351,14 @@ func TestOADPAnnotation(t *testing.T) {
 
 	// These should all be the defaults (no overrides)
 	// no ACM_HUB_OCP_VERSION set, should return stable channel
-	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(testLog, mch)
 	if test2 != defaultOADPStableChannel {
 		t.Error("Cluster Backup missing OADP overrides for 1.4 channel on unknown version of ocp")
 	}
 
 	// fake the ocp version to 4.18.0, it should result in stable-1.4 channel
 	os.Setenv("ACM_HUB_OCP_VERSION", "4.18.0")
-	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(testLog, mch)
 
 	if test1 != defaultOADPName {
 		t.Error("Cluster Backup missing OADP overrides for name")
@@ -386,14 +386,14 @@ func TestOADPAnnotation(t *testing.T) {
 
 	// fake the ocp version to 4.30.0, it should result in stable channel
 	os.Setenv("ACM_HUB_OCP_VERSION", "4.30.0")
-	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(testLog, mch)
 	if test2 != defaultOADPStableChannel {
 		t.Error("Cluster Backup missing OADP overrides for stable channel on ocp 4.30")
 	}
 
 	// fake the ocp version to something starting with anything other than 1.4, it should result in stable channel
 	os.Setenv("ACM_HUB_OCP_VERSION", "5.1.0")
-	test1, test2, test3, test4, test5, test6 = GetOADPConfig(mch)
+	test1, test2, test3, test4, test5, test6 = GetOADPConfig(testLog, mch)
 	if test2 != defaultOADPStableChannel {
 		t.Error("Cluster Backup missing OADP overrides for stable channel on ocp 5.1.0")
 	}
@@ -409,7 +409,7 @@ func TestOADPAnnotation(t *testing.T) {
 		},
 	}
 
-	overrides := parseOADPClusterExtensionAnnotation(mchV1)
+	overrides := parseOADPClusterExtensionAnnotation(testLog, mchV1)
 	if overrides == nil {
 		t.Error("Expected OADP ClusterExtension overrides, got nil")
 	} else {
@@ -430,7 +430,7 @@ func TestOADPAnnotation(t *testing.T) {
 			Namespace: "test",
 		},
 	}
-	overridesNil := parseOADPClusterExtensionAnnotation(mchNoAnnotation)
+	overridesNil := parseOADPClusterExtensionAnnotation(testLog, mchNoAnnotation)
 	if overridesNil != nil {
 		t.Error("Expected nil for no annotation, got overrides")
 	}
@@ -453,7 +453,7 @@ func TestOADPAnnotation(t *testing.T) {
 	}
 
 	// Render with v0 - should use v0 annotation (stable-1.0), NOT v1 annotation (stable-1.5)
-	templatesV0, errsV0 := RenderChart(utils.ClusterBackupChartLocation, mchBothAnnotations,
+	templatesV0, errsV0 := RenderChart(testLog, utils.ClusterBackupChartLocation, mchBothAnnotations,
 		map[string]string{"cluster_backup_controller": "quay.io/test:test"},
 		map[string]string{}, false, "v0")
 	if len(errsV0) > 0 {
@@ -506,7 +506,7 @@ func TestRenderChartOLMv1(t *testing.T) {
 	// Render cluster-backup chart with OLM v1 — OADP should still use v0 Subscription
 	// because OADP bundles don't yet support OLM v1
 	chartPath := utils.ClusterBackupChartLocation
-	templates, errs := RenderChart(chartPath, testMCH, testImages, templateOverrides, false, "v1")
+	templates, errs := RenderChart(testLog, chartPath, testMCH, testImages, templateOverrides, false, "v1")
 	if len(errs) > 0 {
 		for _, err := range errs {
 			t.Log(err.Error())
@@ -557,7 +557,7 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 			},
 		}
 
-		result := parseProbeConfigFromAnnotations(mch)
+		result := parseProbeConfigFromAnnotations(testLog, mch)
 		if result != nil {
 			t.Error("Expected nil when no annotations present")
 		}
@@ -576,7 +576,7 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 			},
 		}
 
-		result := parseProbeConfigFromAnnotations(mch)
+		result := parseProbeConfigFromAnnotations(testLog, mch)
 		if result == nil {
 			t.Fatal("Expected ProbeConfig, got nil")
 		}
@@ -603,7 +603,7 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 			},
 		}
 
-		result := parseProbeConfigFromAnnotations(mch)
+		result := parseProbeConfigFromAnnotations(testLog, mch)
 		if result == nil {
 			t.Fatal("Expected ProbeConfig, got nil")
 		}
@@ -631,7 +631,7 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 			},
 		}
 
-		result := parseProbeConfigFromAnnotations(mch)
+		result := parseProbeConfigFromAnnotations(testLog, mch)
 		if result == nil {
 			t.Fatal("Expected ProbeConfig, got nil")
 		}
@@ -657,7 +657,7 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 			},
 		}
 
-		result := parseProbeConfigFromAnnotations(mch)
+		result := parseProbeConfigFromAnnotations(testLog, mch)
 		if result == nil {
 			t.Fatal("Expected ProbeConfig, got nil")
 		}
@@ -686,7 +686,7 @@ func TestParseProbeConfigFromAnnotations(t *testing.T) {
 			},
 		}
 
-		result := parseProbeConfigFromAnnotations(mch)
+		result := parseProbeConfigFromAnnotations(testLog, mch)
 		if result == nil {
 			t.Fatal("Expected ProbeConfig, got nil")
 		}

--- a/pkg/templates/rbac.go
+++ b/pkg/templates/rbac.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/go-logr/logr"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	renderer "github.com/stolostron/multiclusterhub-operator/pkg/rendering"
 	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
@@ -97,7 +98,7 @@ func main() {
 	// Render charts for both OLM v0 and v1 to generate complete RBAC markers
 	var allTemplates []*unstructured.Unstructured
 	for _, olmVersion := range []string{"v0", "v1"} {
-		templates, errs := renderer.RenderCharts(chartsDir, testMCH, testImages, testTemplateOverrides, false, olmVersion)
+		templates, errs := renderer.RenderCharts(logr.Discard(), chartsDir, testMCH, testImages, testTemplateOverrides, false, olmVersion)
 		if len(errs) > 0 {
 			panic(errs)
 		}


### PR DESCRIPTION
# Description

Comprehensive logging cleanup that establishes a single hierarchical logger tree rooted at `mch-controller`, eliminates package-level loggers, and converts `fmt.Sprintf` calls in log statements to structured key-value pairs.

## Related Issue

N/A — technical debt cleanup to improve log observability and debugging.

## Changes Made

- **Eliminated package-level loggers** in `pkg/` packages — functions now accept `logr.Logger` as a parameter, callers provide named loggers via `r.Log.WithName("subsystem")`
- **Removed dual-logger problem** in `controllers/` — deleted package-level `log` and `configLog` variables, all controller methods now use `r.Log` consistently
- **Established hierarchical logger naming**:
  - `mch-controller` → reconciler base
  - `mch-controller.deployer` → `pkg/deploying/`
  - `mch-controller.renderer` → `pkg/rendering/`
  - `mch-controller.overrides` → `pkg/overrides/`
  - `mch-controller.mce` → `pkg/multiclusterengine/`
  - `mch-controller.mce.olm` → `pkg/multiclusterengine/olm/`
  - `mch-controller.predicate` → `pkg/predicate/`
  - `mch-webhook` → `api/v1/` webhooks
- **Converted ~57 `fmt.Sprintf` calls** in log statements to structured logging with key-value pairs
- **Removed `WithName("WARNING")`** abuse for severity indication
- **Updated all test files** — controller tests use `testr.New(t)` so logs appear on test failure for easier debugging; pkg tests use `logr.Discard()`

### Files changed: 39

## Screenshots (if applicable)

N/A — no UI changes.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- `pkg/predicate/` retains a package-level logger since predicates are registered at setup time, not from the reconcile loop. It was renamed to `mch-controller.predicate`.
- `pkg/manifest/` had an unused logger variable that was simply removed.
- All tests pass with full coverage maintained.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized application logging across controllers and supporting components.
  * Improved log consistency through structured fields and clearer component-specific logger names.
  * Logging is now scoped and passed through relevant operations for more accurate context.
* **Bug Fixes**
  * Improved visibility into reconciliation, deployment, override, status, and resource-management events without changing operational behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->