### PR TITLE
Remove unused MultiClusterHub parameters from receiver methods

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -503,7 +503,7 @@ func (r *MultiClusterHubReconciler) listDeployments(namespaces []string) ([]*app
 }
 
 // listCustomResources gets custom resources the installer observes
-func (r *MultiClusterHubReconciler) listCustomResources(m *operatorv1.MultiClusterHub) (map[string]*unstructured.Unstructured, error) {
+func (r *MultiClusterHubReconciler) listCustomResources() (map[string]*unstructured.Unstructured, error) {
 	ret := make(map[string]*unstructured.Unstructured)
 
 	// List OLM resources based on detected version
@@ -938,7 +938,7 @@ func (r *MultiClusterHubReconciler) addPluginToConsole(multiClusterHub *operator
 }
 
 // removePluginFromConsoleResource ...
-func (r *MultiClusterHubReconciler) removePluginFromConsole(multiClusterHub *operatorv1.MultiClusterHub) (ctrl.Result, error) {
+func (r *MultiClusterHubReconciler) removePluginFromConsole() (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log
 	console := &consolev1.Console{}

--- a/controllers/common_olm_test.go
+++ b/controllers/common_olm_test.go
@@ -742,14 +742,7 @@ func TestListCustomResources(t *testing.T) {
 				OLMVersion: tt.olmVersion,
 			}
 
-			mch := &operatorsv1.MultiClusterHub{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-mch",
-					Namespace: "test-ns",
-				},
-			}
-
-			result, err := reconciler.listCustomResources(mch)
+			result, err := reconciler.listCustomResources()
 			if err != nil {
 				t.Errorf("listCustomResources() unexpected error: %v", err)
 				return

--- a/controllers/components.go
+++ b/controllers/components.go
@@ -251,7 +251,7 @@ func (r *MultiClusterHubReconciler) ensureNoComponent(ctx context.Context, m *op
 			return ctrl.Result{}, nil
 		}
 
-		result, err := r.removePluginFromConsole(m)
+		result, err := r.removePluginFromConsole()
 		if result != (ctrl.Result{}) {
 			return result, err
 		}

--- a/controllers/infrastructure.go
+++ b/controllers/infrastructure.go
@@ -284,10 +284,7 @@ func (r *MultiClusterHubReconciler) createMetricsServiceMonitor(ctx context.Cont
 }
 
 // ingressDomain is discovered from Openshift cluster configuration resources
-func (r *MultiClusterHubReconciler) ingressDomain(
-	ctx context.Context,
-	m *operatorv1.MultiClusterHub,
-) (ctrl.Result, error) {
+func (r *MultiClusterHubReconciler) ingressDomain(ctx context.Context) (ctrl.Result, error) {
 	ingress := &configv1.Ingress{}
 	err := r.Client.Get(ctx, types.NamespacedName{
 		Name: "cluster",
@@ -318,8 +315,7 @@ func (r *MultiClusterHubReconciler) ingressDomain(
 }
 
 // openShiftApiUrl is discovered from Openshift cluster configuration resources
-func (r *MultiClusterHubReconciler) openShiftApiUrl(ctx context.Context, m *operatorv1.MultiClusterHub) (
-	ctrl.Result, error) {
+func (r *MultiClusterHubReconciler) openShiftApiUrl(ctx context.Context) (ctrl.Result, error) {
 	infrastructure := &configv1.Infrastructure{}
 	err := r.Client.Get(ctx, types.NamespacedName{
 		Name: "cluster",

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -96,7 +96,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	allCRs, err := r.listCustomResources(multiClusterHub)
+	allCRs, err := r.listCustomResources()
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -328,12 +328,12 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
-	result, err = r.ingressDomain(ctx, multiClusterHub)
+	result, err = r.ingressDomain(ctx)
 	if result != (ctrl.Result{}) {
 		return result, err
 	}
 
-	result, err = r.openShiftApiUrl(ctx, multiClusterHub)
+	result, err = r.openShiftApiUrl(ctx)
 	if err != nil {
 		return result, err
 	}

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -112,7 +112,7 @@ func (r *MultiClusterHubReconciler) ComponentsAreRunning(m *operatorsv1.MultiClu
 	trackedNamespaces := utils.TrackedNamespaces(m)
 
 	deployList, _ := r.listDeployments(trackedNamespaces)
-	crList, _ := r.listCustomResources(m)
+	crList, _ := r.listCustomResources()
 	componentStatuses := getComponentStatuses(m, deployList, crList, ocpConsole, isSTSEnabled, r.OLMVersion)
 
 	delete(componentStatuses, m.Spec.LocalClusterName)


### PR DESCRIPTION
# Description

Remove unused `*operatorv1.MultiClusterHub` parameters from four receiver methods that never reference the MCH object. These functions access cluster state via `r.Client` and `r.Log` from the receiver — the MCH parameter was passed for consistency but never used.

## Related Issue

Code cleanup identified during log quality audit (#4530).

## Changes Made

**Functions cleaned up:**
- `ingressDomain(ctx, m)` → `ingressDomain(ctx)` — reads cluster ingress config, no MCH data needed
- `openShiftApiUrl(ctx, m)` → `openShiftApiUrl(ctx)` — reads cluster infrastructure config, no MCH data needed
- `listCustomResources(m)` → `listCustomResources()` — lists OLM resources (subscriptions, CSVs, MCE), no MCH data needed
- `removePluginFromConsole(multiClusterHub)` → `removePluginFromConsole()` — manages console plugins, no MCH data needed

**Callers updated:**
- `controllers/reconcile.go` — 3 call sites
- `controllers/status.go` — 1 call site
- `controllers/components.go` — 1 call site
- `controllers/common_olm_test.go` — 1 call site (also removed now-unused `mch` variable)

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- No behavioral changes — purely signature cleanup
- 6 files changed, 10 insertions, 21 deletions

## Reviewers

/cc @cameronmwall @ngraham20