### PR TITLE
HYPBLD-847 - ACM to ART: Align image-references with delivery repo names

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -7,22 +7,22 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cli-rhel9:latest
-  - name: must-gather-rhel9
+  - name: acm-must-gather-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/must-gather-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
   - name: cert-policy-controller-rhel9
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cert-policy-controller-rhel9:latest
-  - name: cluster-backup-controller-rhel9
+  - name: cluster-backup-rhel9-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-controller-rhel9:latest
-  - name: cluster-permission-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-rhel9-operator:latest
+  - name: acm-cluster-permission-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-permission-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cluster-permission-rhel9:latest
   - name: config-policy-controller-rhel9
     from:
       kind: DockerImage
@@ -31,26 +31,26 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/console-rhel9:latest
-  - name: endpoint-monitoring-operator-rhel9
+  - name: endpoint-monitoring-rhel9-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-operator-rhel9:latest
-  - name: governance-policy-addon-controller-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-rhel9-operator:latest
+  - name: acm-governance-policy-addon-controller-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-addon-controller-rhel9:latest
-  - name: governance-policy-framework-addon-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-addon-controller-rhel9:latest
+  - name: acm-governance-policy-framework-addon-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-framework-addon-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-framework-addon-rhel9:latest
   - name: governance-policy-propagator-rhel9
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-propagator-rhel9:latest
-  - name: grafana-rhel9
+  - name: acm-grafana-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-grafana-rhel9:latest
   - name: grafana-dashboard-loader-rhel9
     from:
       kind: DockerImage
@@ -91,18 +91,18 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
-  - name: multiclusterhub-operator
+  - name: multiclusterhub-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
-  - name: multicluster-observability-addon-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-rhel9:latest
+  - name: acm-multicluster-observability-addon-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-addon-rhel9:latest
-  - name: multicluster-observability-operator-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-multicluster-observability-addon-rhel9:latest
+  - name: multicluster-observability-rhel9-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-operator-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-rhel9-operator:latest
   - name: multicluster-operators-application-rhel9
     from:
       kind: DockerImage
@@ -131,10 +131,10 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
-  - name: observatorium-operator-rhel9
+  - name: observatorium-rhel9-operator
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-operator-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9-operator:latest
   - name: prometheus-rhel9
     from:
       kind: DockerImage
@@ -143,14 +143,14 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-alertmanager-rhel9:latest
-  - name: prometheus-config-reloader-rhel9
+  - name: acm-prometheus-config-reloader-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-config-reloader-rhel9:latest
-  - name: prometheus-operator-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-config-reloader-rhel9:latest
+  - name: acm-prometheus-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-operator-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-rhel9:latest
   - name: rbac-query-proxy-rhel9
     from:
       kind: DockerImage
@@ -159,22 +159,22 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-collector-rhel9:latest
-  - name: search-indexer-rhel9
+  - name: acm-search-indexer-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-indexer-rhel9:latest
-  - name: search-v2-api-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-indexer-rhel9:latest
+  - name: acm-search-v2-api-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-v2-api-rhel9:latest
-  - name: search-v2-operator-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-api-rhel9:latest
+  - name: acm-search-v2-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-v2-operator-rhel9:latest
-  - name: siteconfig-rhel9
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-rhel9:latest
+  - name: acm-siteconfig-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/siteconfig-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-siteconfig-rhel9:latest
   - name: submariner-addon-rhel9
     from:
       kind: DockerImage
@@ -187,10 +187,10 @@ spec:
     from:
       kind: DockerImage
       name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-receive-controller-rhel9:latest
-  - name: volsync-addon-controller-rhel9
+  - name: acm-volsync-addon-controller-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync-addon-controller-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-volsync-addon-controller-rhel9:latest
   - name: configmap_reloader
     from:
       kind: DockerImage

--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: 'false'
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.22"}]'
     olm.skipRange: '>=2.15.0 <2.16.3'
-    operators.openshift.io/must-gather-image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/must-gather-rhel9:latest
+    operators.openshift.io/must-gather-image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
   name: advanced-cluster-management.v2.16.3
   namespace: placeholder
   labels:
@@ -1907,27 +1907,27 @@ spec:
                 - name: OPERAND_IMAGE_ACM_CLI
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cli-rhel9:latest
                 - name: OPERAND_IMAGE_ACM_MUST_GATHER
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/must-gather-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
                 - name: OPERAND_IMAGE_CERT_POLICY_CONTROLLER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cert-policy-controller-rhel9:latest
                 - name: OPERAND_IMAGE_CLUSTER_BACKUP_CONTROLLER
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-controller-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-rhel9-operator:latest
                 - name: OPERAND_IMAGE_CLUSTER_PERMISSION
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-permission-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cluster-permission-rhel9:latest
                 - name: OPERAND_IMAGE_CONFIG_POLICY_CONTROLLER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/config-policy-controller-rhel9:latest
                 - name: OPERAND_IMAGE_CONSOLE
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/console-rhel9:latest
                 - name: OPERAND_IMAGE_ENDPOINT_MONITORING_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-operator-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-rhel9-operator:latest
                 - name: OPERAND_IMAGE_GOVERNANCE_POLICY_ADDON_CONTROLLER
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-addon-controller-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-addon-controller-rhel9:latest
                 - name: OPERAND_IMAGE_GOVERNANCE_POLICY_FRAMEWORK_ADDON
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-framework-addon-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-framework-addon-rhel9:latest
                 - name: OPERAND_IMAGE_GOVERNANCE_POLICY_PROPAGATOR
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-propagator-rhel9:latest
                 - name: OPERAND_IMAGE_GRAFANA
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-grafana-rhel9:latest
                 - name: OPERAND_IMAGE_GRAFANA_DASHBOARD_LOADER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-dashboard-loader-rhel9:latest
                 - name: OPERAND_IMAGE_INSIGHTS_CLIENT
@@ -1949,9 +1949,9 @@ spec:
                 - name: OPERAND_IMAGE_MULTICLOUD_INTEGRATIONS
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
                 - name: OPERAND_IMAGE_MULTICLUSTER_OBSERVABILITY_ADDON
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-addon-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-multicluster-observability-addon-rhel9:latest
                 - name: OPERAND_IMAGE_MULTICLUSTER_OBSERVABILITY_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-operator-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-rhel9-operator:latest
                 - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_APPLICATION
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-application-rhel9:latest
                 - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_CHANNEL
@@ -1967,27 +1967,27 @@ spec:
                 - name: OPERAND_IMAGE_OBSERVATORIUM
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
                 - name: OPERAND_IMAGE_OBSERVATORIUM_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-operator-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9-operator:latest
                 - name: OPERAND_IMAGE_PROMETHEUS
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-rhel9:latest
                 - name: OPERAND_IMAGE_PROMETHEUS_ALERTMANAGER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-alertmanager-rhel9:latest
                 - name: OPERAND_IMAGE_PROMETHEUS_CONFIG_RELOADER
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-config-reloader-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-config-reloader-rhel9:latest
                 - name: OPERAND_IMAGE_PROMETHEUS_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-operator-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-rhel9:latest
                 - name: OPERAND_IMAGE_RBAC_QUERY_PROXY
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/rbac-query-proxy-rhel9:latest
                 - name: OPERAND_IMAGE_SEARCH_COLLECTOR
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-collector-rhel9:latest
                 - name: OPERAND_IMAGE_SEARCH_INDEXER
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-indexer-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-indexer-rhel9:latest
                 - name: OPERAND_IMAGE_SEARCH_V2_API
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-v2-api-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-api-rhel9:latest
                 - name: OPERAND_IMAGE_SEARCH_V2_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-v2-operator-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-rhel9:latest
                 - name: OPERAND_IMAGE_SITECONFIG_OPERATOR
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/siteconfig-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-siteconfig-rhel9:latest
                 - name: OPERAND_IMAGE_SUBMARINER_ADDON
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/submariner-addon-rhel9:latest
                 - name: OPERAND_IMAGE_THANOS
@@ -1995,7 +1995,7 @@ spec:
                 - name: OPERAND_IMAGE_THANOS_RECEIVE_CONTROLLER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-receive-controller-rhel9:latest
                 - name: OPERAND_IMAGE_VOLSYNC_ADDON_CONTROLLER
-                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync-addon-controller-rhel9:latest
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-volsync-addon-controller-rhel9:latest
                 - name: OPERAND_IMAGE_CONFIGMAP_RELOADER
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest
                 - name: OPERAND_IMAGE_FLIGHTCTL_API
@@ -2080,27 +2080,27 @@ spec:
   - name: acm_cli
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cli-rhel9:latest
   - name: acm_must_gather
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/must-gather-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
   - name: cert_policy_controller
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cert-policy-controller-rhel9:latest
   - name: cluster_backup_controller
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-controller-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-rhel9-operator:latest
   - name: cluster_permission
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-permission-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cluster-permission-rhel9:latest
   - name: config_policy_controller
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/config-policy-controller-rhel9:latest
   - name: console
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/console-rhel9:latest
   - name: endpoint_monitoring_operator
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-operator-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-rhel9-operator:latest
   - name: governance_policy_addon_controller
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-addon-controller-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-addon-controller-rhel9:latest
   - name: governance_policy_framework_addon
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-framework-addon-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-framework-addon-rhel9:latest
   - name: governance_policy_propagator
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-propagator-rhel9:latest
   - name: grafana
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-grafana-rhel9:latest
   - name: grafana_dashboard_loader
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-dashboard-loader-rhel9:latest
   - name: insights_client
@@ -2122,9 +2122,9 @@ spec:
   - name: multicloud_integrations
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
   - name: multicluster_observability_addon
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-addon-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-multicluster-observability-addon-rhel9:latest
   - name: multicluster_observability_operator
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-operator-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-rhel9-operator:latest
   - name: multicluster_operators_application
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-application-rhel9:latest
   - name: multicluster_operators_channel
@@ -2140,27 +2140,27 @@ spec:
   - name: observatorium
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
   - name: observatorium_operator
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-operator-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9-operator:latest
   - name: prometheus
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-rhel9:latest
   - name: prometheus_alertmanager
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-alertmanager-rhel9:latest
   - name: prometheus_config_reloader
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-config-reloader-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-config-reloader-rhel9:latest
   - name: prometheus_operator
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-operator-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-rhel9:latest
   - name: rbac_query_proxy
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/rbac-query-proxy-rhel9:latest
   - name: search_collector
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-collector-rhel9:latest
   - name: search_indexer
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-indexer-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-indexer-rhel9:latest
   - name: search_v2_api
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-v2-api-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-api-rhel9:latest
   - name: search_v2_operator
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-v2-operator-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-rhel9:latest
   - name: siteconfig_operator
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/siteconfig-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-siteconfig-rhel9:latest
   - name: submariner_addon
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/submariner-addon-rhel9:latest
   - name: thanos
@@ -2168,7 +2168,7 @@ spec:
   - name: thanos_receive_controller
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-receive-controller-rhel9:latest
   - name: volsync_addon_controller
-    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync-addon-controller-rhel9:latest
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-volsync-addon-controller-rhel9:latest
   - name: configmap_reloader
     image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest
   - name: flightctl_api


### PR DESCRIPTION
Update bundle/image-references and CSV to use the canonical delivery repo names registered in the Konflux product registry. This ensures ART's bundle rebaser correctly maps operand images to their delivery repos during stage/prod release.

18 entries renamed to match registry.redhat.io/rhacm2/* delivery names.
