### PR TITLE
Fix RBAC for consolenotification

### DIFF
--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -1136,6 +1136,7 @@ spec:
           - search.open-cluster-management.io
           resources:
           - consolelinks
+          - consolenotifications
           - consoleplugins
           - searches
           verbs:

--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -160,9 +160,13 @@ func (r *MultiClusterHubReconciler) removeBanner(ctx context.Context, name strin
 	return r.Client.Delete(ctx, notification)
 }
 
-func (r *MultiClusterHubReconciler) cleanupConsoleNotifications(_ logr.Logger, m *operatorsv1.MultiClusterHub) error {
-	return r.Client.DeleteAllOf(context.TODO(), &consolev1.ConsoleNotification{}, client.MatchingLabels{
-		"installer.name":      m.GetName(),
-		"installer.namespace": m.GetNamespace(),
-	})
+func (r *MultiClusterHubReconciler) cleanupConsoleNotifications(_ logr.Logger, _ *operatorsv1.MultiClusterHub) error {
+	// Only two ConsoleNotifications are ever created by this operator (the MCE
+	// and OCP compliance banners), so remove them directly by name instead of
+	// using DeleteAllOf, which requires the cluster-scoped "deletecollection"
+	// verb.
+	if err := r.removeBanner(context.TODO(), mceComplianceBannerName); err != nil {
+		return err
+	}
+	return r.removeBanner(context.TODO(), ocpComplianceBannerName)
 }


### PR DESCRIPTION
Add consolenotifications to the console.openshift.io RBAC resources in the CSV so the operator can create/get/update/patch/delete the MCE and OCP compliance ConsoleNotification banners.

Also fix cleanupConsoleNotifications to remove the banners by name (Get+Delete) instead of DeleteAllOf, since DeleteAllOf requires the cluster-scoped deletecollection verb, which is intentionally not granted (only two ConsoleNotifications are ever created by this operator, so no collection delete is needed).

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
