### PR TITLE
feat: add grc network policies

### DIFF
--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-controller-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-controller-networkpolicy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Copyright Contributors to the Open Cluster Management project
+# NetworkPolicy for governance-policy-addon-controller.
+#
+# Ingress:
+#   - None
+#
+# Egress:
+#   - DNS for name resolution (port 53 and 5353)
+#   - Kubernetes API server communication (port 443 and 6443)
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grc-policy-addon-controller-network-policy
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
+    component: "ocm-policy-addon-ctrl"
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
+spec:
+  podSelector:
+    matchLabels:
+      app: grc
+      component: "ocm-policy-addon-ctrl"
+      release: grc
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # DNS egress for name resolution
+  # Port 5353 is needed because OVN-Kubernetes evaluates NetworkPolicy post-DNAT
+  # and CoreDNS pods listen on 5353 while the DNS service exposes port 53
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API server egress for cluster and addon management operations
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-addon-deployment.yaml
@@ -94,6 +94,8 @@ spec:
           value: {{ .Values.global.imageOverrides.config_policy_controller }}
         - name: GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE
           value: {{ .Values.global.imageOverrides.governance_policy_framework_addon }}
+        - name: NETWORK_POLICIES_ENABLED
+          value: "{{ .Values.global.networkPolicies.enabled }}"
         image: {{ .Values.global.imageOverrides.governance_policy_addon_controller }}
         imagePullPolicy: "{{ .Values.global.pullPolicy }}"
         name: manager

--- a/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/grc/templates/grc-policy-propagator-networkpolicy.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.global.networkPolicies.enabled }}
+# Copyright Contributors to the Open Cluster Management project
+#
+# NetworkPolicy for governance-policy-propagator pods.
+#
+# Ingress:
+#   - Metrics collection on port 8443 from monitoring namespace (Prometheus)
+#   - Webhook validation on port 9443 (from Kubernetes API server)
+#
+# Egress:
+#   - DNS for name resolution (port 53 and 5353)
+#   - Kubernetes API server communication (port 443 and 6443)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grc-policy-propagator-network-policy
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app: grc
+    chart: grc-chart-{{ .Values.hubconfig.hubVersion }}
+    component: "ocm-policy-propagator"
+    release: grc
+    app.kubernetes.io/instance: grc
+    app.kubernetes.io/name: grc
+spec:
+  podSelector:
+    matchLabels:
+      app: grc
+      component: "ocm-policy-propagator"
+      release: grc
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Metrics ingress from multiple components on port 8443
+  - ports:
+    - protocol: TCP
+      port: 8443
+  # Webhook ingress from Kubernetes API server on port 9443
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+    ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  # DNS egress for all pods (required for name resolution)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API server egress
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # Insights metrics queries
+  - ports:
+    - protocol: TCP
+      port: 8443
+{{- end }}


### PR DESCRIPTION
# Description

Add network policies for GRC
Assisted by Cursor

> [!NOTE]
Test results posted in https://github.com/stolostron/governance-policy-addon-controller/pull/1325

## Related Issue

ref: https://redhat.atlassian.net/browse/ACM-37743

## Changes Made

Add two network policies, one for each GRC pod on hub cluster:  policy propagator and policy addon controller

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional network policies for governance policy controllers, configurable through the global network policy setting.
  - Improved workload security by restricting inbound and outbound traffic to required services, including DNS, the Kubernetes API, metrics collection, and policy webhooks.
  - Network policy behavior is now communicated to the controller components automatically when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->