### PR TITLE
[ACM-38014] Fix OADP operator group template rendering on STS clusters

### DIFF
--- a/pkg/templates/charts/toggle/cluster-backup/templates/oadp-operators-group.yaml
+++ b/pkg/templates/charts/toggle/cluster-backup/templates/oadp-operators-group.yaml
@@ -5,7 +5,6 @@
 # All resources will be installed under the open-cluster-management-backup namespace
 
 {{- if .Values.hubconfig.clusterSTSEnabled }}
-{{- /* STS-enabled clusters: store config in ConfigMap */ -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
# Description

Fix a Helm template rendering bug that caused recurring `"unstructured object has no version"` errors on every reconcile loop for STS-enabled clusters (ROSA/ROSA HCP).

## Related Issue

- https://redhat.atlassian.net/browse/ACM-38014

## Changes Made

Removed a Helm comment (`{{- /* STS-enabled clusters: store config in ConfigMap */ -}}`) from the OADP operator group template whose trailing `-}}` whitespace trimming concatenated `apiVersion: v1` onto the preceding YAML comment line. Since YAML treats everything after `#` to end-of-line as a comment, `apiVersion` was invisible to the parser — resulting in an unstructured object with `kind: ConfigMap` but no `apiVersion`.

This only affected the STS-enabled code path (`clusterSTSEnabled = true`), which is why the error was exclusive to ROSA/ROSA HCP clusters. Regular OCP clusters take the `else` branch (OperatorGroup) which had no such comment.

**Before (Helm output):**
```
# All resources will be installed under the open-cluster-management-backup namespaceapiVersion: v1
kind: ConfigMap
```

**After (Helm output):**
```
# All resources will be installed under the open-cluster-management-backup namespace
apiVersion: v1
kind: ConfigMap
```

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Verified fix on a live ROSA HCP cluster (ACM 5.0.0-189). After patching the CSV with the fixed operator image:
- OADP ConfigMap `acm-redhat-oadp-operator-group` created successfully
- Reconcile completed with no errors
- `Requeuing after 5m0s` — healthy

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an internal template comment; resource generation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->