### PR TITLE
Fix misleading OADP webhook error message on OLM v1 clusters

### DIFF
--- a/api/v1/multiclusterhub_webhook.go
+++ b/api/v1/multiclusterhub_webhook.go
@@ -430,22 +430,24 @@ func validateOLMAnnotations(ctx context.Context, mch *MultiClusterHub) error {
 	}
 
 	// Validate MCE annotations
-	if err := validateOLMAnnotationPair(olmVersion, annotations,
+	if err := validateOLMAnnotationPair(olmVersion, "", annotations,
 		annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec); err != nil {
 		return fmt.Errorf("validating MCE OLM annotations: %w", err)
 	}
 
 	// OADP always uses v0 Subscription until OADP team ships OLM v1-ready bundles.
-	if err := validateOLMAnnotationPair("v0", annotations,
-		annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec); err != nil {
+	if err := validateOLMAnnotationPair("v0",
+		"OADP requires a v0 Subscription and does not yet support OLM v1",
+		annotations, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec); err != nil {
 		return fmt.Errorf("validating OADP OLM annotations: %w", err)
 	}
 
 	return nil
 }
 
-// validateOLMAnnotationPair validates that a v0/v1 annotation pair matches the detected OLM version
-func validateOLMAnnotationPair(olmVersion string, annotations map[string]string, v0Annotation, v1Annotation string) error {
+// validateOLMAnnotationPair validates that a v0/v1 annotation pair matches the expected OLM version.
+// When reason is non-empty it replaces the default cluster-version explanation in error messages.
+func validateOLMAnnotationPair(olmVersion, reason string, annotations map[string]string, v0Annotation, v1Annotation string) error {
 	hasV0 := annotations[v0Annotation] != ""
 	hasV1 := annotations[v1Annotation] != ""
 
@@ -453,14 +455,26 @@ func validateOLMAnnotationPair(olmVersion string, annotations map[string]string,
 		return nil
 	}
 
+	var explanation string
+	if reason != "" {
+		explanation = reason
+	} else {
+		switch olmVersion {
+		case "v1":
+			explanation = "This cluster uses OLM v1"
+		case "v0":
+			explanation = "This cluster uses OLM v0"
+		}
+	}
+
 	if olmVersion == "v1" && hasV0 {
-		return fmt.Errorf("annotation %q is only valid for OLM v0 clusters. This cluster uses OLM v1. Use %q instead",
-			v0Annotation, v1Annotation)
+		return fmt.Errorf("annotation %q is only valid for OLM v0 clusters. %s. Use %q instead",
+			v0Annotation, explanation, v1Annotation)
 	}
 
 	if olmVersion == "v0" && hasV1 {
-		return fmt.Errorf("annotation %q is only valid for OLM v1 clusters. This cluster uses OLM v0. Use %q instead",
-			v1Annotation, v0Annotation)
+		return fmt.Errorf("annotation %q is only valid for OLM v1 clusters. %s. Use %q instead",
+			v1Annotation, explanation, v0Annotation)
 	}
 
 	if olmVersion == "" && hasV1 {

--- a/api/v1/multiclusterhub_webhook_test.go
+++ b/api/v1/multiclusterhub_webhook_test.go
@@ -417,13 +417,13 @@ var _ = Describe("Multiclusterhub webhook", func() {
 
 	Context("validateOLMAnnotationPair", func() {
 		It("Should return nil when no annotations set", func() {
-			err := validateOLMAnnotationPair("v1", map[string]string{},
+			err := validateOLMAnnotationPair("v1", "", map[string]string{},
 				annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
 			Expect(err).ToNot(HaveOccurred(), "empty annotations should pass validation for any OLM version")
 		})
 
 		It("Should reject MCE v0 annotation on v1 cluster", func() {
-			err := validateOLMAnnotationPair("v1", map[string]string{
+			err := validateOLMAnnotationPair("v1", "", map[string]string{
 				annotationMCESubscriptionSpec: `{"channel": "stable-2.6"}`,
 			}, annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
 			Expect(err).To(HaveOccurred(), "MCE subscription-spec should be rejected on OLM v1 cluster")
@@ -432,7 +432,7 @@ var _ = Describe("Multiclusterhub webhook", func() {
 		})
 
 		It("Should reject MCE v1 annotation on v0 cluster", func() {
-			err := validateOLMAnnotationPair("v0", map[string]string{
+			err := validateOLMAnnotationPair("v0", "", map[string]string{
 				annotationMCEClusterExtensionSpec: `{"channels": ["stable-2.6"]}`,
 			}, annotationMCESubscriptionSpec, annotationMCEClusterExtensionSpec)
 			Expect(err).To(HaveOccurred(), "MCE clusterextension-spec should be rejected on OLM v0 cluster")
@@ -441,7 +441,7 @@ var _ = Describe("Multiclusterhub webhook", func() {
 		})
 
 		It("Should reject OADP v1 annotation when no OLM detected", func() {
-			err := validateOLMAnnotationPair("", map[string]string{
+			err := validateOLMAnnotationPair("", "", map[string]string{
 				annotationOADPClusterExtensionSpec: `{"channels": ["stable"]}`,
 			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
 			Expect(err).To(HaveOccurred(), "OADP clusterextension-spec should be rejected when no OLM detected")
@@ -450,17 +450,26 @@ var _ = Describe("Multiclusterhub webhook", func() {
 		})
 
 		It("Should allow OADP v0 annotation on v0 cluster", func() {
-			err := validateOLMAnnotationPair("v0", map[string]string{
+			err := validateOLMAnnotationPair("v0", "", map[string]string{
 				annotationOADPSubscriptionSpec: `{"channel": "stable-1.4"}`,
 			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
 			Expect(err).ToNot(HaveOccurred(), "OADP subscription-spec should be allowed on OLM v0 cluster")
 		})
 
 		It("Should allow OADP v1 annotation on v1 cluster", func() {
-			err := validateOLMAnnotationPair("v1", map[string]string{
+			err := validateOLMAnnotationPair("v1", "", map[string]string{
 				annotationOADPClusterExtensionSpec: `{"channels": ["stable"]}`,
 			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
 			Expect(err).ToNot(HaveOccurred(), "OADP clusterextension-spec should be allowed on OLM v1 cluster")
+		})
+
+		It("Should use custom reason in error message when provided", func() {
+			err := validateOLMAnnotationPair("v0", "OADP requires a v0 Subscription and does not yet support OLM v1", map[string]string{
+				annotationOADPClusterExtensionSpec: `{"channels": ["stable"]}`,
+			}, annotationOADPSubscriptionSpec, annotationOADPClusterExtensionSpec)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("OADP requires a v0 Subscription"),
+				"error should use custom reason instead of default cluster version message")
 		})
 	})
 


### PR DESCRIPTION
# Description

Fix the OADP annotation webhook error message that incorrectly tells users "This cluster uses OLM v0" when they are on an OLM v1 cluster. OADP validation is hardcoded to v0 since OADP does not yet support OLM v1, but the error should reflect that rather than misrepresenting the cluster's OLM version.

## Related Issue

ACM-34317

## Changes Made

- Added a `reason` parameter to `validateOLMAnnotationPair` so callers can provide context-specific error messages
- OADP validation now shows: *"OADP requires a v0 Subscription and does not yet support OLM v1"* instead of *"This cluster uses OLM v0"*
- MCE validation unchanged — still uses default cluster-version messages
- Added test for custom reason in error message

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Tested on an OLM v1 cluster — MCE annotation validation works correctly (v0 annotation rejected, v1 accepted). OADP annotation validation also correct (v0 accepted, v1 rejected with accurate message).