### PR TITLE
Inject version info via ldflags at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,20 @@ COPY pkg/ pkg/
 # Copy required files
 COPY pkg/templates/ templates/
 
+# Version information for ldflags
+ARG GIT_VERSION="v0.0.1-alpha.0"
+ARG GIT_COMMIT="unknown"
+ARG GIT_TREE_STATE="unknown"
+ARG BUILD_DATE="unknown"
+ARG VERSION_PKG=github.com/stolostron/multiclusterhub-operator/pkg/version
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o multiclusterhub-operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a \
+    -ldflags "-X ${VERSION_PKG}.gitVersion=${GIT_VERSION} \
+              -X ${VERSION_PKG}.gitCommit=${GIT_COMMIT} \
+              -X ${VERSION_PKG}.gitTreeState=${GIT_TREE_STATE} \
+              -X ${VERSION_PKG}.buildDate=${BUILD_DATE}" \
+    -o multiclusterhub-operator main.go
 
 # Use ubi minimal base image to package the multiclusterhub-operator binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -ldflags "$(LDFLAGS)" -o bin/multiclusterhub-operator main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	CRDS_PATH="bin/crds" POD_NAMESPACE="open-cluster-management" go run ./main.go
+	CRDS_PATH="bin/crds" POD_NAMESPACE="open-cluster-management" go run -ldflags "$(LDFLAGS)" ./main.go
 
 DOCKER_BUILD_ARGS = --build-arg GIT_VERSION=$(GIT_VERSION) \
                     --build-arg GIT_COMMIT=$(GIT_COMMIT) \

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ CRD_OPTIONS ?= "crd:crdVersions=v1"
 VERSION_PKG = github.com/stolostron/multiclusterhub-operator/pkg/version
 GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "v0.0.1-alpha.0")
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
-GIT_TREE_STATE ?= $(shell if [ -z "$$(git status --porcelain 2>/dev/null)" ]; then echo "clean"; else echo "dirty"; fi)
+GIT_TREE_STATE ?= $(shell \
+	status="$$(git status --porcelain 2>/dev/null)"; rc=$$?; \
+	if [ $$rc -ne 0 ]; then echo "unknown"; \
+	elif [ -z "$$status" ]; then echo "clean"; else echo "dirty"; fi)
 BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS = -X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
           -X $(VERSION_PKG).gitCommit=$(GIT_COMMIT) \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,17 @@ IMG ?= $(REGISTRY)/multiclusterhub-operator:$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
+# Version information for ldflags
+VERSION_PKG = github.com/stolostron/multiclusterhub-operator/pkg/version
+GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "v0.0.1-alpha.0")
+GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
+GIT_TREE_STATE ?= $(shell if [ -z "$$(git status --porcelain 2>/dev/null)" ]; then echo "clean"; else echo "dirty"; fi)
+BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS = -X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
+          -X $(VERSION_PKG).gitCommit=$(GIT_COMMIT) \
+          -X $(VERSION_PKG).gitTreeState=$(GIT_TREE_STATE) \
+          -X $(VERSION_PKG).buildDate=$(BUILD_DATE)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -100,19 +111,24 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/multiclusterhub-operator main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/multiclusterhub-operator main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	CRDS_PATH="bin/crds" POD_NAMESPACE="open-cluster-management" go run ./main.go
 
+DOCKER_BUILD_ARGS = --build-arg GIT_VERSION=$(GIT_VERSION) \
+                    --build-arg GIT_COMMIT=$(GIT_COMMIT) \
+                    --build-arg GIT_TREE_STATE=$(GIT_TREE_STATE) \
+                    --build-arg BUILD_DATE=$(BUILD_DATE)
+
 docker-build: ## test ## Build docker image with the manager.
-	docker build --no-cache -t ${IMG} .
+	docker build --no-cache $(DOCKER_BUILD_ARGS) -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
 podman-build: ## test ## Build podman image with the manager.
-	podman build --no-cache -t ${IMG} .
+	podman build --no-cache $(DOCKER_BUILD_ARGS) -t ${IMG} .
 
 podman-push: ## Push podman image with the manager.
 	podman push ${IMG}

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -25,8 +25,20 @@ COPY pkg/ pkg/
 
 COPY pkg/templates/ templates/
 
+# Version information for ldflags
+ARG GIT_VERSION="v0.0.1-alpha.0"
+ARG GIT_COMMIT="unknown"
+ARG GIT_TREE_STATE="unknown"
+ARG BUILD_DATE="unknown"
+ARG VERSION_PKG=github.com/stolostron/multiclusterhub-operator/pkg/version
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o multiclusterhub-operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a \
+    -ldflags "-X ${VERSION_PKG}.gitVersion=${GIT_VERSION} \
+              -X ${VERSION_PKG}.gitCommit=${GIT_COMMIT} \
+              -X ${VERSION_PKG}.gitTreeState=${GIT_TREE_STATE} \
+              -X ${VERSION_PKG}.buildDate=${BUILD_DATE}" \
+    -o multiclusterhub-operator main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -24,8 +24,20 @@ COPY pkg/templates/ templates/
 # Copy license
 COPY LICENSE LICENSE
 
+# Version information for ldflags
+ARG GIT_VERSION="v0.0.1-alpha.0"
+ARG GIT_COMMIT="unknown"
+ARG GIT_TREE_STATE="unknown"
+ARG BUILD_DATE="unknown"
+ARG VERSION_PKG=github.com/stolostron/multiclusterhub-operator/pkg/version
+
 # Build
-RUN CGO_ENABLED=1 go build -mod=readonly -o multiclusterhub-operator main.go
+RUN CGO_ENABLED=1 go build -mod=readonly \
+    -ldflags "-X ${VERSION_PKG}.gitVersion=${GIT_VERSION} \
+              -X ${VERSION_PKG}.gitCommit=${GIT_COMMIT} \
+              -X ${VERSION_PKG}.gitTreeState=${GIT_TREE_STATE} \
+              -X ${VERSION_PKG}.buildDate=${BUILD_DATE}" \
+    -o multiclusterhub-operator main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
# Description

The operator binary logs placeholder version values (`v0.0.1-alpha.0`, `unknown`) because `go build` commands in the Makefile and Dockerfiles do not pass `-ldflags` to set `pkg/version` variables. This PR injects real git metadata at build time.

## Related Issue

N/A — observed in operator logs:
```
version.Info{GitVersion:"v0.0.1-alpha.0", GitCommit:"unknown", GitTreeState:"unknown", BuildDate:"unknown", ...}
```

## Changes Made

- Added `LDFLAGS` variable to Makefile with `-X` flags for `gitVersion`, `gitCommit`, `gitTreeState`, `buildDate`
- Updated `make build` target to pass `-ldflags "$(LDFLAGS)"`
- Added `DOCKER_BUILD_ARGS` to pass version info via `--build-arg` to `docker-build` and `podman-build` targets
- Added `ARG` declarations and `-ldflags` to `Dockerfile`, `build/Dockerfile.prow`, and `build/Dockerfile.rhtap`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Build output now shows real values:
```
go build -ldflags "-X .../pkg/version.gitVersion=v2.5.0-... -X .../pkg/version.gitCommit=e51b9693... -X .../pkg/version.gitTreeState=clean -X .../pkg/version.buildDate=2026-08-08T15:43:23Z" ...
```

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [x] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build artifacts now include version, commit, repository state, and build-date metadata.
  * Container images and locally compiled binaries consistently carry the same release information.
  * Release metadata is available for identifying the source and build associated with a running version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->