### PR TITLE
ACM to ART: Add OPERATOR_VERSION and OPERATOR_PACKAGE env vars to CSV

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,4 +1,9 @@
 ---
+updates:
+- file: "manifests/advanced-cluster-management.clusterserviceversion.yaml"
+  update_list:
+  - search: "2.16.3"
+    replace: "2.16.5"
 external-images:
 - name: configmap_reloader
   search: "image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest"

--- a/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
+++ b/bundle/manifests/advanced-cluster-management.clusterserviceversion.yaml
@@ -2033,6 +2033,10 @@ spec:
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/ose_kube_rbac_proxy:latest
                 - name: OPERAND_IMAGE_VOLSYNC
                   value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync:latest
+                - name: OPERATOR_VERSION
+                  value: "2.16.3"
+                - name: OPERATOR_PACKAGE
+                  value: advanced-cluster-management
                 image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
The operator panics at startup with "OPERATOR_VERSION not defined" because these required env vars are missing from the CSV deployment spec. Add them with the current version (2.16.3) which will be updated to the build version by ART's update-csv during bundle generation.
