### PR TITLE
ACM to ART: Change art.yaml version replacement target to 2.16.4

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -3,7 +3,7 @@ updates:
 - file: "manifests/advanced-cluster-management.clusterserviceversion.yaml"
   update_list:
   - search: "2.16.3"
-    replace: "2.16.5"
+    replace: "2.16.4"
 external-images:
 - name: configmap_reloader
   search: "image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest"


### PR DESCRIPTION
Per ART team: no z-stream has shipped to prod yet, so the version should be 2.16.4 rather than 2.16.5.
