### PR TITLE
Improve automated PR bodies and use shallow clones in bundle-automation tooling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/automated-bundle-update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/automated-bundle-update.md
@@ -1,0 +1,31 @@
+# Automated Operator Bundle/Chart Update
+
+_This PR was generated automatically by a scheduled workflow. Do not hand-edit
+this branch directly — fix the source (the upstream component repo or the
+`hack/bundle-automation` tooling) and let the workflow regenerate it instead._
+
+## Triggered by
+
+<!-- AUTOMATION:TRIGGER -->
+
+## What changed
+
+<!-- AUTOMATION:DIFFSTAT -->
+
+## Manifests skipped during CRD scan
+
+_Files listed here could not be parsed as plain YAML (for example, a bundle
+manifest that embeds Helm/Go template syntax) and were skipped rather than
+failing the whole run. This does **not** necessarily mean anything is wrong —
+see the [addCRDs() docs](https://github.com/stolostron/installer-dev-tools/blob/main/scripts/bundle-generation/bundles-to-charts.py)
+for why this can't be resolved by filename alone — but it does mean nobody
+has confirmed the skipped file doesn't define a CRD._
+
+<!-- AUTOMATION:WARNINGS -->
+
+## Review checklist
+
+- [ ] Diff matches the expected upstream changes for this branch/component
+- [ ] No unexpected CRD, RBAC, or webhook changes
+- [ ] If any files are listed above, confirm none of them define a `CustomResourceDefinition`
+- [ ] Remove `do-not-merge/hold` only after the above are confirmed

--- a/.github/PULL_REQUEST_TEMPLATE/automated-owners-resync.md
+++ b/.github/PULL_REQUEST_TEMPLATE/automated-owners-resync.md
@@ -1,0 +1,18 @@
+# Automated OWNERS Resync
+
+_This PR was generated automatically to sync this branch's `OWNERS` file with
+`main`. Do not hand-edit this branch directly — update `OWNERS` on `main`
+instead and let this workflow propagate the change._
+
+## Triggered by
+
+<!-- AUTOMATION:TRIGGER -->
+
+## What changed
+
+<!-- AUTOMATION:DIFFSTAT -->
+
+## Review checklist
+
+- [ ] Diff only touches the `OWNERS` file
+- [ ] Added/removed reviewers and approvers are correct and intentional

--- a/.github/workflows/regenerate-bundles.yml
+++ b/.github/workflows/regenerate-bundles.yml
@@ -63,21 +63,19 @@ jobs:
       # The sync step will run regenerate-charts-from-bundles, detect any new variables,
       # add them to config.yaml, then re-run regeneration to apply proper escaping
       - name: Regenerate Operator Charts From Bundles with Variable Sync
+        id: regenerate
         env:
           BRANCH: ${{ github.event.inputs.branch_arg || 'main' }}
           ORG: ${{ github.event.inputs.org_arg || 'stolostron' }}
         run: |
+          set -o pipefail
+
           # First regenerate to pull latest upstream changes
-          make regenerate-charts-from-bundles
-
           # Then sync variables (will re-run regeneration if new variables found)
-          make -f Makefile.dev sync-template-vars
-
-          exit_code=$?
-          if [ $exit_code -ne 0 ]; then
-            echo "Regenerate step failed with exit code $exit_code"
-            exit $exit_code
-          fi
+          {
+            make regenerate-charts-from-bundles
+            make -f Makefile.dev sync-template-vars
+          } 2>&1 | tee /tmp/regenerate.log
 
       - name: Generate code
         run: |
@@ -88,6 +86,41 @@ jobs:
         run: |
           echo "Generating manifests..."
           make manifests
+
+      - name: Render Pull Request body
+        run: |
+          {
+            echo "- **Workflow run:** [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo "- **Event:** ${GITHUB_EVENT_NAME}"
+            echo "- **Branch:** ${{ matrix.branch }}"
+          } > /tmp/trigger.txt
+
+          {
+            echo '```'
+            git diff --stat || echo "No changes detected"
+            echo '```'
+          } > /tmp/diffstat.txt
+
+          # Only surface the specific "a manifest could not be parsed and was
+          # skipped" condition here, not every routine WARNING the tooling
+          # logs on a normal run (there are dozens of those and they aren't
+          # actionable).
+          if grep -q "UNPARSEABLE_MANIFEST" /tmp/regenerate.log; then
+            {
+              echo '```'
+              grep "UNPARSEABLE_MANIFEST" /tmp/regenerate.log
+              echo '```'
+            } > /tmp/warnings.txt
+          else
+            : > /tmp/warnings.txt
+          fi
+
+          python3 hack/scripts/render_pr_body.py \
+            --template .github/PULL_REQUEST_TEMPLATE/automated-bundle-update.md \
+            --output /tmp/pr-body.md \
+            --set-file TRIGGER=/tmp/trigger.txt \
+            --set-file DIFFSTAT=/tmp/diffstat.txt \
+            --set-file WARNINGS=/tmp/warnings.txt
 
       - name: Send Slack Message on Failure
         if: ${{ failure() }}
@@ -112,6 +145,7 @@ jobs:
           title: "Operator Bundle Update [${{ matrix.branch }}]"
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          body-path: /tmp/pr-body.md
           labels: |
             do-not-merge/hold
             ok-to-test

--- a/.github/workflows/regenerate-charts.yml
+++ b/.github/workflows/regenerate-charts.yml
@@ -68,17 +68,14 @@ jobs:
           BRANCH: ${{ github.event.inputs.branch_arg || 'main' }}
           ORG: ${{ github.event.inputs.org_arg || 'stolostron' }}
         run: |
+          set -o pipefail
+
           # First regenerate to pull latest upstream changes
-          make regenerate-charts
-
           # Then sync variables (will re-run 'make regenerate-charts' if new variables found)
-          make -f Makefile.dev sync-template-vars-charts
-
-          exit_code=$?
-          if [ $exit_code -ne 0 ]; then
-            echo "Regenerate Charts step failed with exit code $exit_code"
-            exit $exit_code
-          fi
+          {
+            make regenerate-charts
+            make -f Makefile.dev sync-template-vars-charts
+          } 2>&1 | tee /tmp/regenerate.log
 
       - name: Generate code
         run: |
@@ -89,6 +86,41 @@ jobs:
         run: |
           echo "Generating manifests..."
           make manifests
+
+      - name: Render Pull Request body
+        run: |
+          {
+            echo "- **Workflow run:** [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo "- **Event:** ${GITHUB_EVENT_NAME}"
+            echo "- **Branch:** ${{ matrix.branch }}"
+          } > /tmp/trigger.txt
+
+          {
+            echo '```'
+            git diff --stat || echo "No changes detected"
+            echo '```'
+          } > /tmp/diffstat.txt
+
+          # Only surface the specific "a manifest could not be parsed and was
+          # skipped" condition here, not every routine WARNING the tooling
+          # logs on a normal run (there are dozens of those and they aren't
+          # actionable).
+          if grep -q "UNPARSEABLE_MANIFEST" /tmp/regenerate.log; then
+            {
+              echo '```'
+              grep "UNPARSEABLE_MANIFEST" /tmp/regenerate.log
+              echo '```'
+            } > /tmp/warnings.txt
+          else
+            : > /tmp/warnings.txt
+          fi
+
+          python3 hack/scripts/render_pr_body.py \
+            --template .github/PULL_REQUEST_TEMPLATE/automated-bundle-update.md \
+            --output /tmp/pr-body.md \
+            --set-file TRIGGER=/tmp/trigger.txt \
+            --set-file DIFFSTAT=/tmp/diffstat.txt \
+            --set-file WARNINGS=/tmp/warnings.txt
 
       - name: Send Slack Message on Failure
         if: ${{ failure() }}
@@ -113,6 +145,7 @@ jobs:
           title: "Chart Update [${{ matrix.branch }}]"
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          body-path: /tmp/pr-body.md
           labels: |
             do-not-merge/hold
             ok-to-test

--- a/.github/workflows/resync-owner-file.yml
+++ b/.github/workflows/resync-owner-file.yml
@@ -56,6 +56,26 @@ jobs:
             cp workflow/OWNERS ./OWNERS
             rm -rf workflow
 
+      - name: Render Pull Request body
+        run: |
+          {
+            echo "- **Workflow run:** [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo "- **Event:** ${GITHUB_EVENT_NAME}"
+            echo "- **Branch:** ${{ matrix.branch }}"
+          } > /tmp/trigger.txt
+
+          {
+            echo '```'
+            git diff --stat OWNERS || echo "No changes detected"
+            echo '```'
+          } > /tmp/diffstat.txt
+
+          python3 hack/scripts/render_pr_body.py \
+            --template .github/PULL_REQUEST_TEMPLATE/automated-owners-resync.md \
+            --output /tmp/pr-body.md \
+            --set-file TRIGGER=/tmp/trigger.txt \
+            --set-file DIFFSTAT=/tmp/diffstat.txt
+
       - name: Send Slack Message on Failure
         if: ${{ failure() }}
         env:
@@ -79,6 +99,7 @@ jobs:
           title: "Resync OWNERS [${{ matrix.branch }}]"
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          body-path: /tmp/pr-body.md
           labels: |
             do-not-merge/hold
             ok-to-test

--- a/.github/workflows/update-pregenerated-charts.yml
+++ b/.github/workflows/update-pregenerated-charts.yml
@@ -63,21 +63,19 @@ jobs:
       # The sync step will run copy-charts, detect any new variables,
       # add them to config.yaml, then re-run copy-charts to apply proper escaping
       - name: Copy Charts for Operator Bundles with Variable Sync
+        id: copy_charts
         env:
           BRANCH: ${{ github.event.inputs.branch_arg || 'main' }}
           ORG: ${{ github.event.inputs.org_arg || 'stolostron' }}
         run: |
+          set -o pipefail
+
           # First copy charts to pull latest upstream changes
-          make copy-charts
-
           # Then sync variables (will re-run 'make copy-charts' if new variables found)
-          make -f Makefile.dev sync-template-vars-copy
-
-          exit_code=$?
-          if [ $exit_code -ne 0 ]; then
-            echo "Copy Charts step failed with exit code $exit_code"
-            exit $exit_code
-          fi
+          {
+            make copy-charts
+            make -f Makefile.dev sync-template-vars-copy
+          } 2>&1 | tee /tmp/regenerate.log
 
       - name: Generate code
         run: |
@@ -88,6 +86,41 @@ jobs:
         run: |
           echo "Generating manifests..."
           make manifests
+
+      - name: Render Pull Request body
+        run: |
+          {
+            echo "- **Workflow run:** [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo "- **Event:** ${GITHUB_EVENT_NAME}"
+            echo "- **Branch:** ${{ matrix.branch }}"
+          } > /tmp/trigger.txt
+
+          {
+            echo '```'
+            git diff --stat || echo "No changes detected"
+            echo '```'
+          } > /tmp/diffstat.txt
+
+          # Only surface the specific "a manifest could not be parsed and was
+          # skipped" condition here, not every routine WARNING the tooling
+          # logs on a normal run (there are dozens of those and they aren't
+          # actionable).
+          if grep -q "UNPARSEABLE_MANIFEST" /tmp/regenerate.log; then
+            {
+              echo '```'
+              grep "UNPARSEABLE_MANIFEST" /tmp/regenerate.log
+              echo '```'
+            } > /tmp/warnings.txt
+          else
+            : > /tmp/warnings.txt
+          fi
+
+          python3 hack/scripts/render_pr_body.py \
+            --template .github/PULL_REQUEST_TEMPLATE/automated-bundle-update.md \
+            --output /tmp/pr-body.md \
+            --set-file TRIGGER=/tmp/trigger.txt \
+            --set-file DIFFSTAT=/tmp/diffstat.txt \
+            --set-file WARNINGS=/tmp/warnings.txt
 
       - name: Send Slack Message on Failure
         if: ${{ failure() }}
@@ -112,6 +145,7 @@ jobs:
           title: "Operator Chart Copy Update [${{ matrix.branch }}]"
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          body-path: /tmp/pr-body.md
           labels: |
             do-not-merge/hold
             ok-to-test

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -65,7 +65,13 @@ SUPPORTED_OPERATIONS = {
 }
 
 def clone_repository(git_url, repo_path, branch):
-    """Clones a Git repository to a specific path.
+    """Clones a single branch of a Git repository to a specific path.
+
+    Only the tip commit of the given branch is fetched (a shallow, single-
+    branch clone). This tooling only ever reads the current file contents on
+    one branch — it never inspects history, blames a line, or diffs against a
+    prior commit — so the full commit history isn't needed and skipping it
+    substantially reduces clone time/bandwidth for repos with long histories.
 
     Args:
         git_url (_type_): _description_
@@ -78,8 +84,7 @@ def clone_repository(git_url, repo_path, branch):
 
     logging.info(f"Cloning repository: {git_url} (branch={branch}) to {repo_path}")
     try:
-        repository = Repo.clone_from(git_url, repo_path)
-        repository.git.checkout(branch)
+        Repo.clone_from(git_url, repo_path, branch=branch, depth=1)
         logging.info(f"Git repository: {git_url} successfully cloned.")
 
     except Exception as e:

--- a/hack/scripts/render_pr_body.py
+++ b/hack/scripts/render_pr_body.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Render a GitHub PR body from a `.github/PULL_REQUEST_TEMPLATE/*.md` template.
+
+Automated workflows (bundle/chart regeneration, OWNERS resync, etc.) use this
+to fill in a purpose-built PR template instead of relying on the default text
+from the `create-pull-request` action or hand-rolling markdown inline in YAML.
+
+Marker lines in the template of the form:
+
+    <!-- AUTOMATION:NAME -->
+
+are replaced with either a literal string (--set NAME=VALUE) or the contents
+of a file (--set-file NAME=PATH). Markers with no value provided fall back to
+--fallback (default: "_None reported._") so the template still renders
+cleanly if a workflow doesn't populate every section.
+
+Example:
+    python3 hack/scripts/render_pr_body.py \\
+        --template .github/PULL_REQUEST_TEMPLATE/automated-bundle-update.md \\
+        --output /tmp/pr-body.md \\
+        --set-file TRIGGER=/tmp/trigger.txt \\
+        --set-file DIFFSTAT=/tmp/diffstat.txt \\
+        --set-file WARNINGS=/tmp/warnings.txt
+"""
+import argparse
+import re
+import sys
+
+MARKER_PATTERN = re.compile(r"<!--\s*AUTOMATION:([A-Z0-9_]+)\s*-->")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--template", required=True, help="Path to the PR template to render")
+    parser.add_argument("--output", required=True, help="Path to write the rendered PR body to")
+    parser.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="Replace marker NAME with a literal string VALUE",
+    )
+    parser.add_argument(
+        "--set-file",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help="Replace marker NAME with the (stripped) contents of the file at PATH",
+    )
+    parser.add_argument(
+        "--fallback",
+        default="_None reported._",
+        help="Text used when a --set-file value is missing or empty",
+    )
+    return parser.parse_args()
+
+
+def collect_values(args):
+    values = {}
+
+    for item in args.set:
+        if "=" not in item:
+            sys.exit(f"error: --set value '{item}' is not in NAME=VALUE format")
+        name, _, value = item.partition("=")
+        values[name.strip()] = value
+
+    for item in args.set_file:
+        if "=" not in item:
+            sys.exit(f"error: --set-file value '{item}' is not in NAME=PATH format")
+        name, _, path = item.partition("=")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+        except FileNotFoundError:
+            content = ""
+        values[name.strip()] = content if content else args.fallback
+
+    return values
+
+
+def render(template_text, values):
+    def replace(match):
+        name = match.group(1)
+        if name not in values:
+            sys.stderr.write(f"warning: no value provided for marker '{name}', leaving it blank.\n")
+            return ""
+        return values[name]
+
+    return MARKER_PATTERN.sub(replace, template_text)
+
+
+def main():
+    args = parse_args()
+    values = collect_values(args)
+
+    with open(args.template, "r", encoding="utf-8") as f:
+        template_text = f.read()
+
+    rendered = render(template_text, values)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/scripts/render_pr_body.py
+++ b/hack/scripts/render_pr_body.py
@@ -79,12 +79,12 @@ def collect_values(args):
     return values
 
 
-def render(template_text, values):
+def render(template_text, values, fallback):
     def replace(match):
         name = match.group(1)
         if name not in values:
-            sys.stderr.write(f"warning: no value provided for marker '{name}', leaving it blank.\n")
-            return ""
+            sys.stderr.write(f"warning: no value provided for marker '{name}', using fallback.\n")
+            return fallback
         return values[name]
 
     return MARKER_PATTERN.sub(replace, template_text)
@@ -97,7 +97,7 @@ def main():
     with open(args.template, "r", encoding="utf-8") as f:
         template_text = f.read()
 
-    rendered = render(template_text, values)
+    rendered = render(template_text, values, args.fallback)
 
     with open(args.output, "w", encoding="utf-8") as f:
         f.write(rendered)


### PR DESCRIPTION
# Description

Two related improvements to the scheduled bundle/chart/OWNERS automation workflows: give the PRs they open a meaningful, reviewable body instead of the generic default text, and stop doing full (unbounded-history) git clones in the tooling that generates them.

## Related Issue

Follows from investigating a failing scheduled "Regenerate Operator Bundles" run (workflow run 31521675972), which crashed on a bundle manifest that couldn't be parsed as plain YAML. That specific fix lives in `stolostron/installer-dev-tools` (stolostron/installer-dev-tools#169); this PR covers the multiclusterhub-operator side of the surrounding work.

## Changes Made

1. **Meaningful PR bodies.** The four automated PR workflows (`regenerate-bundles.yml`, `regenerate-charts.yml`, `update-pregenerated-charts.yml`, `resync-owner-file.yml`) create PRs via `peter-evans/create-pull-request` with no `body:` set, so every one gets the generic "Automated changes by create-pull-request GitHub action" text. Added two purpose-built templates under `.github/PULL_REQUEST_TEMPLATE/` (kept separate from this default human template, since a bot can't honestly claim things like "I tested this locally") and a small renderer (`hack/scripts/render_pr_body.py`) that fills in the triggering run, a `git diff --stat` summary, and — for the three chart/bundle workflows — any manifest files skipped during CRD scanning.
2. **Shallow clones.** `generate-shell.py`'s `clone_repository()` did a full, unbounded clone of `installer-dev-tools` and then checked out the target branch locally. Since this tooling only ever reads current file contents on one branch (no git log/blame/history usage anywhere), switched to a shallow, single-branch clone (`depth=1`, `branch=<target>`). The identical fix is also being applied in `stolostron/backplane-operator`, which vendors the same file.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- Rendered both new PR body templates locally against real data (a real `git diff --stat` and a real captured warning) to confirm the marker substitution produces correct output.
- Ran the actual `hack/bundle-automation/generate-shell.py --update-charts-from-bundles` pipeline end-to-end against a scratch checkout pointed at a patched fork of `installer-dev-tools`, confirming it completes successfully (exit code 0) instead of crashing, the regenerated charts are correct, and `.git` directory size for a cloned component repo dropped from 6.2M to 992K with the shallow clone.
- `actionlint` run against all four modified workflow files — no new findings (one pre-existing, unrelated shellcheck warning in the Slack-notification step).
- All modified/new Python files pass `python3 -m py_compile`.
- Depends on stolostron/installer-dev-tools#169 for the "manifest skipped during CRD scan" warning surfaced in the new template to ever be populated.

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated update pull requests now include workflow details, change statistics, relevant manifest warnings, and review checklists.
  - Chart regeneration workflows support targeting a single component or all components.
  - Owner-file synchronization pull requests now include a summary of ownership changes.
  - Additional release branches are supported for chart and owner-file automation.

- **Bug Fixes**
  - Improved handling of command failures and preserved whitespace in automation inputs.
  - Unknown command-line options are now forwarded correctly.
  - Unrecognized pull-request template markers receive configured fallback text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->