### PR TITLE
Regenerate submariner-addon operator bundles

### DIFF
--- a/.github/workflows/regenerate-bundles.yml
+++ b/.github/workflows/regenerate-bundles.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: 'stolostron'
         type: string
+      component_arg:
+        description: 'COMPONENT to regenerate (e.g. submariner-addon). Leave empty for all.'
+        required: false
+        default: ''
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -66,9 +71,10 @@ jobs:
         env:
           BRANCH: ${{ github.event.inputs.branch_arg || 'main' }}
           ORG: ${{ github.event.inputs.org_arg || 'stolostron' }}
+          COMPONENT: ${{ github.event.inputs.component_arg || '' }}
         run: |
           # First regenerate to pull latest upstream changes
-          make regenerate-charts-from-bundles
+          make regenerate-charts-from-bundles COMPONENT="${COMPONENT}"
 
           # Then sync variables (will re-run regeneration if new variables found)
           make -f Makefile.dev sync-template-vars

--- a/.github/workflows/regenerate-charts.yml
+++ b/.github/workflows/regenerate-charts.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: 'stolostron'
         type: string
+      component_arg:
+        description: 'COMPONENT to regenerate (e.g. submariner-addon). Leave empty for all.'
+        required: false
+        default: ''
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -67,9 +72,10 @@ jobs:
         env:
           BRANCH: ${{ github.event.inputs.branch_arg || 'main' }}
           ORG: ${{ github.event.inputs.org_arg || 'stolostron' }}
+          COMPONENT: ${{ github.event.inputs.component_arg || '' }}
         run: |
           # First regenerate to pull latest upstream changes
-          make regenerate-charts
+          make regenerate-charts COMPONENT="${COMPONENT}"
 
           # Then sync variables (will re-run 'make regenerate-charts' if new variables found)
           make -f Makefile.dev sync-template-vars-charts

--- a/.github/workflows/update-pregenerated-charts.yml
+++ b/.github/workflows/update-pregenerated-charts.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: 'stolostron'
         type: string
+      component_arg:
+        description: 'COMPONENT to regenerate (e.g. submariner-addon). Leave empty for all.'
+        required: false
+        default: ''
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -66,9 +71,10 @@ jobs:
         env:
           BRANCH: ${{ github.event.inputs.branch_arg || 'main' }}
           ORG: ${{ github.event.inputs.org_arg || 'stolostron' }}
+          COMPONENT: ${{ github.event.inputs.component_arg || '' }}
         run: |
           # First copy charts to pull latest upstream changes
-          make copy-charts
+          make copy-charts COMPONENT="${COMPONENT}"
 
           # Then sync variables (will re-run 'make copy-charts' if new variables found)
           make -f Makefile.dev sync-template-vars-copy

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=multiclusterhub-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -17,9 +17,9 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-08-04T21:19:06Z"
+    createdAt: "2026-08-11T21:49:10Z"
     description: Open management of Openshift and Kubernetes clusters
-    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/open-cluster-management/multiclusterhub-operator
     support: The Open Cluster Management Project
@@ -1645,6 +1645,7 @@ spec:
           - collectorconfigs
           verbs:
           - create
+          - delete
           - get
           - list
           - patch

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: multiclusterhub-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/pkg/templates/charts/toggle/submariner-addon/templates/submariner-addon-clusterrole.yaml
+++ b/pkg/templates/charts/toggle/submariner-addon/templates/submariner-addon-clusterrole.yaml
@@ -274,3 +274,14 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete

--- a/pkg/templates/charts/toggle/submariner-addon/templates/submariner-addon.yaml
+++ b/pkg/templates/charts/toggle/submariner-addon/templates/submariner-addon.yaml
@@ -58,16 +58,16 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8443
-            scheme: HTTPS
+            port: 8081
+            scheme: HTTP
           initialDelaySeconds: 2
           periodSeconds: 10
         name: submariner-addon
         readinessProbe:
           httpGet:
-            path: /healthz
-            port: 8443
-            scheme: HTTPS
+            path: /readyz
+            port: 8081
+            scheme: HTTP
           initialDelaySeconds: 2
         resources:
           requests:

--- a/pkg/templates/crds/submariner-addon/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
+++ b/pkg/templates/crds/submariner-addon/submarineraddon.open-cluster-management.io_submarinerconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   name: submarinerconfigs.submarineraddon.open-cluster-management.io
 spec:

--- a/pkg/templates/crds/submariner-addon/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
+++ b/pkg/templates/crds/submariner-addon/submarineraddon.open-cluster-management.io_submarinerdiagnoseconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   creationTimestamp: null
   name: submarinerdiagnoseconfigs.submarineraddon.open-cluster-management.io
 spec:

--- a/pkg/templates/rbac_gen.go
+++ b/pkg/templates/rbac_gen.go
@@ -466,6 +466,8 @@ package main
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;patch;update
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;patch;update
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=oadp.openshift.io,resources=dataprotectionapplications,verbs=get;list;watch
 //+kubebuilder:rbac:groups=oadp.openshift.io,resources=dataprotectionapplications,verbs=get;list;watch
 //+kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthclients,verbs=create;delete;get;list;patch;update;watch


### PR DESCRIPTION
## Summary
- Regenerated submariner-addon operator bundles to pick up upstream changes
- Adds `networkpolicies` RBAC permissions to submariner-addon clusterrole
- Updates health/readiness probes to HTTP on port 8081
- Bumps controller-gen version from v0.20.0 to v0.21.0 in CRDs

## Test plan
- [x] Ran `make regenerate-operator-bundles` successfully
- [ ] CI passes

/cc @cameronmwall @ngraham20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added permissions to manage Kubernetes network policies, enabling improved network configuration capabilities.

- **Bug Fixes**
  - Updated add-on health checks to use the correct readiness endpoint while retaining the existing liveness check.
  - Configured health probes to communicate over HTTP on port 8081.

- **Chores**
  - Refreshed CRD generation metadata without changing the available schema or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->