### PR TITLE
fix: allow GRC to query insights metrics

### DIFF
--- a/pkg/templates/charts/toggle/insights/templates/insights-metrics-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/insights/templates/insights-metrics-networkpolicy.yaml
@@ -22,6 +22,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: openshift-monitoring
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-ingress
     ports:
     - port: 8443
       protocol: TCP


### PR DESCRIPTION
Fix GRC framework test time out when querying the insights metrics

Alternative suggestions welcome as I am relatively new to network policies

# Description

Please provide a brief description of the purpose of this pull request.

See error https://github.com/stolostron/multiclusterhub-operator/pull/4551#issuecomment-5258611471

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

https://redhat.atlassian.net/browse/ACM-31161

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

With fix:
<img width="1185" height="985" alt="Screenshot From 2026-08-11 14-58-03" src="https://github.com/user-attachments/assets/4e124bf6-b475-4c3c-8bd7-ef68e8dd8b8b" />

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules to allow Insights Metrics traffic from the OpenShift ingress namespace, in addition to the monitoring namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->