### PR TITLE
ACM to ART: Align multiclusterhub-operator image-references from.name with CSV

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -94,7 +94,7 @@ spec:
   - name: multiclusterhub-rhel9
     from:
       kind: DockerImage
-      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-rhel9:latest
+      name: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
   - name: acm-multicluster-observability-addon-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
The CSV uses open-cluster-management/multiclusterhub-operator:latest as the deployment image reference, but image-references has from.name set to multiclusterhub-rhel9:latest (the delivery repo name). ART matches CSV placeholders against image-references from.name to perform replacement. This mismatch leaves the placeholder unreplaced, causing olm.allowed_registries, olm.unmapped_references, and olm.unpinned_references conforma violations.
