### PR TITLE
fix: preserve COMPONENT/CONFIG as well-formed, single argv entries (release-2.14)

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -3,8 +3,8 @@
 ORG ?= stolostron
 REPO ?= installer-dev-tools
 BRANCH ?= main
-COMPONENT ?= ""
-CONFIG ?= ""
+COMPONENT ?=
+CONFIG ?=
 
 PIPELINE_REPO ?= pipeline
 PIPELINE_BRANCH ?= 2.14-integration
@@ -74,17 +74,17 @@ install-requirements:
 ## Lints the operator bundles
 .PHONY: lint-operator-bundles
 lint-operator-bundles: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --lint-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component $(COMPONENT) --config $(CONFIG)
+	python3 ./hack/bundle-automation/generate-shell.py --lint-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Regenerates the operator bundles
 .PHONY: refresh-image-aliases
 refresh-image-aliases: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --refresh-image-aliases --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component $(COMPONENT)
+	python3 ./hack/bundle-automation/generate-shell.py --refresh-image-aliases --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component "$(COMPONENT)"
 
 ## Regenerates the operator charts from bundles
 .PHONY: regenerate-charts-from-bundles
 regenerate-charts-from-bundles: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --update-charts-from-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component $(COMPONENT) --config $(CONFIG)
+	python3 ./hack/bundle-automation/generate-shell.py --update-charts-from-bundles --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Validates that all template variables are declared in config.yaml
 .PHONY: validate-template-vars
@@ -109,22 +109,22 @@ sync-template-vars-copy:
 ## Regenerates the operator bundles
 .PHONY: regenerate-operator-sha-commits
 regenerate-operator-sha-commits: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --update-commits --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component $(COMPONENT) --config $(CONFIG)
+	python3 ./hack/bundle-automation/generate-shell.py --update-commits --org $(ORG) --repo $(REPO) --branch $(BRANCH) --pipeline-repo $(PIPELINE_REPO) --pipeline-branch $(PIPELINE_BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Regenerates the charts
 .PHONY: regenerate-charts
 regenerate-charts: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --update-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component $(COMPONENT) --config $(CONFIG)
+	python3 ./hack/bundle-automation/generate-shell.py --update-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Regenerates the operator bundles
 .PHONY: copy-charts
 copy-charts: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --copy-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component $(COMPONENT) --config $(CONFIG)
+	python3 ./hack/bundle-automation/generate-shell.py --copy-charts --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)" --config "$(CONFIG)"
 
 ## Onboard new OLM/Chart component
 .PHONY: onboard-new-component
 onboard-new-component: install-requirements
-	python3 ./hack/bundle-automation/generate-shell.py --onboard-new-component --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component $(COMPONENT)
+	python3 ./hack/bundle-automation/generate-shell.py --onboard-new-component --org $(ORG) --repo $(REPO) --branch $(BRANCH) --component "$(COMPONENT)"
 
 ## Validate that all required image keys exist in the bundle
 .PHONY: validate-image-keys

--- a/hack/bundle-automation/generate-shell.py
+++ b/hack/bundle-automation/generate-shell.py
@@ -7,6 +7,7 @@ import argparse
 import coloredlogs
 import os
 import logging
+import shlex
 import subprocess
 import shutil
 import sys
@@ -144,16 +145,26 @@ def prepare_and_execute(operation, operation_data, args):
     script_name = Path(script_path).name
     script_file = DEST_DIR / script_name
 
-    operations_args = operation_data.get("args", "").format(
-        pipeline_repo=args.pipeline_repo,
-        pipeline_branch=args.pipeline_branch
-    ) if "args" in operation_data else ""
+    # SUPPORTED_OPERATIONS' "args" templates are developer-authored, static
+    # strings (with {placeholder} substitution), so it's safe to tokenize
+    # them once here with shlex. From this point on, operations_args is a
+    # real list - COMPONENT/CONFIG (which can contain arbitrary user-
+    # supplied values, e.g. a config file path with spaces) are appended as
+    # individual list elements rather than being joined into a string, so
+    # there's no lossy re-split later that could break a value containing
+    # whitespace into multiple argv entries.
+    operations_args = shlex.split(
+        operation_data.get("args", "").format(
+            pipeline_repo=args.pipeline_repo,
+            pipeline_branch=args.pipeline_branch
+        )
+    ) if "args" in operation_data else []
 
     if args.component:
-        operations_args += " --component {}".format(args.component)
+        operations_args += ["--component", args.component]
 
     if args.config:
-        operations_args += " --config {}".format(args.config)
+        operations_args += ["--config", args.config]
 
     # Execute the script
     execute_script(script_file, operations_args)
@@ -165,7 +176,9 @@ def execute_script(script_path, args):
 
     Args:
         script_path (Path): Path to the script to execute
-        args (str): Command-line arguments for the script
+        args (list[str]): Command-line arguments for the script, as
+            individual argv entries (not a shell-joined string) so a value
+            containing whitespace is passed through intact.
     """
     if not script_path.exists():
         logging.error(f"Script {script_path} not found.")
@@ -175,7 +188,7 @@ def execute_script(script_path, args):
     env = os.environ.copy()
     env['PYTHONPATH'] = str(DEST_DIR) + os.pathsep + env.get('PYTHONPATH', '')
 
-    command = ["python3", str(script_path)] + args.split()
+    command = ["python3", str(script_path)] + args
     try:
         subprocess.run(command, check=True, env=env)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
# Description

Backport of the fixes from `main` (#4583 and its CodeRabbit follow-up) to `release-2.14`.

## Related Issue

The scheduled regenerate workflows' `COMPONENT` input (added in #4580) broke this branch's scheduled runs. The workflow YAML lives only on `main` and passes `COMPONENT="${COMPONENT}"` uniformly to every branch in the matrix, but this branch's `Makefile.dev`/`generate-shell.py` still had the unfixed, pre-#4583 code, so every scheduled run against `release-2.14` started failing with:

```
generate-shell.py: error: argument --component: expected one argument
```

## Changes Made

Two fixes, both required (identical to #4583):
1. `Makefile.dev`: quote `$(COMPONENT)`/`$(CONFIG)` in the recipes so an empty value produces a well-formed, empty-but-present argument instead of no token at all.
2. `generate-shell.py`: build the subprocess argv as an actual list instead of round-tripping through a joined string + `args.split()`, so a value containing whitespace can't be torn into multiple argv entries.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest release-2.14 branch.

## Additional Notes

Verified end-to-end against this branch specifically: `make regenerate-charts-from-bundles COMPONENT=""` now completes successfully instead of failing.

## Reviewers

/cc @cameronmwall

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the release-2.14 branch.