### PR TITLE
[release-2.16] fix: remove main branch reference from tekton CEL expression

### DIFF
--- a/.tekton/multiclusterhub-operator-acm-216-pull-request.yaml
+++ b/.tekton/multiclusterhub-operator-acm-216-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch == "release-2.16")
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.16"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-216


### PR DESCRIPTION
# Description

Remove incorrect `main` branch reference from the tekton CEL expression on release-2.16. The PR pipeline should only trigger on PRs targeting `release-2.16`, not `main`.

## Related Issue

N/A

## Changes Made

- `.tekton/multiclusterhub-operator-acm-216-pull-request.yaml`: Changed CEL expression from `event == "pull_request" && (target_branch == "main" || target_branch == "release-2.16")` to `event == "pull_request" && target_branch == "release-2.16"`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

N/A

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.