### PR TITLE
ACM-8659: Report Waiting phase/message while MCE upgrades

### DIFF
--- a/api/v1/multiclusterhub_types.go
+++ b/api/v1/multiclusterhub_types.go
@@ -156,6 +156,9 @@ const (
 	HubUninstalling    HubPhaseType = "Uninstalling"
 	HubUpdatingBlocked HubPhaseType = "UpdatingBlocked"
 	HubError           HubPhaseType = "Error"
+	// HubWaitingForMCE indicates the hub is blocked waiting for MultiClusterEngine to reach the
+	// version required by the current MCH release (either not yet installed or not yet upgraded).
+	HubWaitingForMCE HubPhaseType = "Waiting"
 )
 
 // MCEVersionComplianceStatus tracks MultiClusterEngine version compliance against required channel

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -77,6 +77,9 @@ const (
 	// RequirementsNotMetReason is when there is something missing or misconfigured
 	// that is preventing progress
 	RequirementsNotMetReason = "RequirementsNotMet"
+	// WaitingForMCEUpgradeReason is added when the hub is blocked waiting for MultiClusterEngine
+	// to reach the version required by the current MCH release
+	WaitingForMCEUpgradeReason = "WaitingForMCEUpgrade"
 
 	FailedApplyingComponent = "FailedApplyingComponent"
 )
@@ -184,8 +187,20 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 	conditions := hub.Status.HubConditions
 	status.HubConditions = append(status.HubConditions, conditions...)
 
+	// Determine if the hub should report that it's blocked waiting for MultiClusterEngine to
+	// reach the required version (either not yet installed or not yet upgraded). This takes
+	// priority over the normal successful/progressing conditions below so that `oc get mch`
+	// surfaces the true blocking condition instead of a generic Running/Installing/Updating
+	// message while reconciliation is silently stuck in waitForMCEReady. Skipped for unit tests
+	// (which don't run a real MCE) and paused hubs (whose own paused condition takes priority).
+	waitingForMCECond := mceUpgradeWaitCondition(mceVersionCompliance, utils.IsCommunityMode())
+	reportMCEWait := !utils.IsUnitTest() && !utils.IsPaused(hub) && waitingForMCECond != nil
+
 	// Update hub conditions
-	if successful {
+	if reportMCEWait {
+		SetHubCondition(&status, *waitingForMCECond)
+		RemoveHubCondition(&status, operatorsv1.Complete)
+	} else if successful {
 		// don't label as complete until component pruning succeeds
 		if !hubPruning(status) && !utils.IsPaused(hub) {
 			available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
@@ -221,16 +236,45 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 	// Set overall phase
 	isHubMarkedToBeDeleted := hub.GetDeletionTimestamp() != nil
 	hasComponentFailure := HubConditionPresentWithSubstring(status, string(operatorsv1.ComponentFailure))
-	if isHubMarkedToBeDeleted {
+	switch {
+	case isHubMarkedToBeDeleted:
 		// Hub cleaning up
 		status.Phase = operatorsv1.HubUninstalling
-	} else if hasComponentFailure {
+	case hasComponentFailure:
 		status.Phase = operatorsv1.HubError
-	} else {
+	case reportMCEWait:
+		status.Phase = operatorsv1.HubWaitingForMCE
+	default:
 		status.Phase = aggregatePhase(status)
 	}
 
 	return status
+}
+
+// mceUpgradeWaitCondition returns a HubCondition describing that the hub is waiting for
+// MultiClusterEngine to reach the version required by the current MCH release, or nil if MCE
+// already satisfies that requirement (or compliance could not be determined, e.g. an error
+// reaching the API server). isCommunityMode selects which required version to quote in the
+// message.
+func mceUpgradeWaitCondition(
+	compliance *operatorsv1.MCEVersionComplianceStatus, isCommunityMode bool) *operatorsv1.HubCondition {
+	if compliance == nil || compliance.IsCompliant {
+		return nil
+	}
+
+	requiredVersion := version.RequiredMCEVersion
+	if isCommunityMode {
+		requiredVersion = version.RequiredCommunityMCEVersion
+	}
+
+	currentVersion := compliance.CurrentVersion
+	if currentVersion == "" {
+		currentVersion = "none"
+	}
+
+	message := fmt.Sprintf(
+		"Waiting for MultiClusterEngine to upgrade to %s (current: %s)", requiredVersion, currentVersion)
+	return NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, WaitingForMCEUpgradeReason, message)
 }
 
 // getComponentStatuses populates a complete list of the hub component statuses

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -200,36 +200,47 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 	if reportMCEWait {
 		SetHubCondition(&status, *waitingForMCECond)
 		RemoveHubCondition(&status, operatorsv1.Complete)
-	} else if successful {
-		// don't label as complete until component pruning succeeds
-		if !hubPruning(status) && !utils.IsPaused(hub) {
-			available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
-			SetHubCondition(&status, *available)
-			RemoveHubCondition(&status, operatorsv1.Progressing)
-		} else if hubPruning(status) && !utils.IsPaused(hub) {
-			// All components successful but pruning condition exists - pruning must be complete
-			// Set AllOldComponentsRemovedReason so hubPruning() returns false on next reconcile
-			complete := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, AllOldComponentsRemovedReason, "All old resources pruned")
-			SetHubCondition(&status, *complete)
-			log.Info("Component pruning complete - all resources successfully removed")
-		} else {
-			// only add unavailable status if complete status already present
-			if HubConditionPresent(status, operatorsv1.Complete) {
-				unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, OldComponentNotRemovedReason, "Not all components successfully pruned.")
-				SetHubCondition(&status, *unavailable)
-			}
-		}
 	} else {
-		// hub is progressing unless otherwise specified
-		if !HubConditionPresent(status, operatorsv1.Progressing) {
-			progressing := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, ReconcileReason, "Hub is reconciling.")
-			SetHubCondition(&status, *progressing)
+		// MCE wait no longer applies (MCE is compliant, paused, or a unit test). Clear any
+		// lingering WaitingForMCEUpgrade condition so it doesn't block the normal
+		// progressing/complete logic below via the Type-only HubConditionPresent check, and
+		// so `oc get mch` doesn't keep reporting a stale "waiting for MCE" message once MCE
+		// has caught up but the hub hasn't finished reconciling other components yet.
+		if waiting := GetHubCondition(status, operatorsv1.Progressing); waiting != nil && waiting.Reason == WaitingForMCEUpgradeReason {
+			RemoveHubCondition(&status, operatorsv1.Progressing)
 		}
 
-		// only add unavailable status if complete status already present
-		if HubConditionPresent(status, operatorsv1.Complete) {
-			unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, ComponentsUnavailableReason, "Not all hub components ready.")
-			SetHubCondition(&status, *unavailable)
+		if successful {
+			// don't label as complete until component pruning succeeds
+			if !hubPruning(status) && !utils.IsPaused(hub) {
+				available := NewHubCondition(operatorsv1.Complete, metav1.ConditionTrue, ComponentsAvailableReason, "All hub components ready.")
+				SetHubCondition(&status, *available)
+				RemoveHubCondition(&status, operatorsv1.Progressing)
+			} else if hubPruning(status) && !utils.IsPaused(hub) {
+				// All components successful but pruning condition exists - pruning must be complete
+				// Set AllOldComponentsRemovedReason so hubPruning() returns false on next reconcile
+				complete := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, AllOldComponentsRemovedReason, "All old resources pruned")
+				SetHubCondition(&status, *complete)
+				log.Info("Component pruning complete - all resources successfully removed")
+			} else {
+				// only add unavailable status if complete status already present
+				if HubConditionPresent(status, operatorsv1.Complete) {
+					unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, OldComponentNotRemovedReason, "Not all components successfully pruned.")
+					SetHubCondition(&status, *unavailable)
+				}
+			}
+		} else {
+			// hub is progressing unless otherwise specified
+			if !HubConditionPresent(status, operatorsv1.Progressing) {
+				progressing := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, ReconcileReason, "Hub is reconciling.")
+				SetHubCondition(&status, *progressing)
+			}
+
+			// only add unavailable status if complete status already present
+			if HubConditionPresent(status, operatorsv1.Complete) {
+				unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, ComponentsUnavailableReason, "Not all hub components ready.")
+				SetHubCondition(&status, *unavailable)
+			}
 		}
 	}
 

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -159,6 +159,9 @@ func (r *MultiClusterHubReconciler) syncHubStatus(ctx context.Context, m *operat
 	}
 }
 
+// calculateStatus derives the full MultiClusterHubStatus (components, conditions, and phase) from
+// the current set of component deployments/custom resources and MultiClusterEngine version
+// compliance. It does not mutate the cluster; callers are responsible for persisting the result.
 func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *operatorsv1.MultiClusterHub, allDeps []*appsv1.Deployment,
 	allCRs map[string]*unstructured.Unstructured, ocpConsole, isSTSEnabled bool) operatorsv1.MultiClusterHubStatus {
 
@@ -718,9 +721,14 @@ func NewHubCondition(condType operatorsv1.HubConditionType, status metav1.Condit
 }
 
 // SetHubCondition sets the status condition. It either overwrites the existing one or creates a new one.
+// A condition is treated as unchanged (a no-op) only when Type, Status, Reason, AND Message all
+// match the existing condition. Message is included so that conditions whose message varies
+// independently of their reason (e.g. WaitingForMCEUpgrade, which embeds the live current MCE
+// version) get updated on every reconcile instead of freezing at their first-observed message.
 func SetHubCondition(status *operatorsv1.MultiClusterHubStatus, condition operatorsv1.HubCondition) {
 	currentCond := GetHubCondition(*status, condition.Type)
-	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
+	if currentCond != nil && currentCond.Status == condition.Status &&
+		currentCond.Reason == condition.Reason && currentCond.Message == condition.Message {
 		return
 	}
 	// Do not update lastTransitionTime if the status of the condition doesn't change.

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -193,6 +193,43 @@ func TestSetHubCondition(t *testing.T) {
 			t.Errorf("AddCondition() expected lastTransitionTime of %v, got %v", old2.LastTransitionTime, ltt)
 		}
 	})
+
+	t.Run("Updates message when type, status, and reason are unchanged", func(t *testing.T) {
+		// Regression test: a condition whose Message varies independently of its Reason (e.g.
+		// WaitingForMCEUpgrade, which embeds the live current MCE version) must not freeze at
+		// its first-observed message on subsequent reconciles.
+		m := &operatorsv1.MultiClusterHub{}
+		firstMessage := operatorsv1.HubCondition{
+			Type:               operatorsv1.Progressing,
+			Reason:             WaitingForMCEUpgradeReason,
+			Status:             metav1.ConditionTrue,
+			Message:            "Waiting for MultiClusterEngine to upgrade to 5.0.0 (current: none)",
+			LastTransitionTime: metav1.NewTime(time.Date(2020, 5, 29, 0, 0, 0, 0, time.UTC)),
+		}
+		updatedMessage := operatorsv1.HubCondition{
+			Type:               operatorsv1.Progressing,
+			Reason:             WaitingForMCEUpgradeReason,
+			Status:             metav1.ConditionTrue,
+			Message:            "Waiting for MultiClusterEngine to upgrade to 5.0.0 (current: 2.17.1)",
+			LastTransitionTime: metav1.NewTime(time.Date(2020, 5, 29, 0, 1, 0, 0, time.UTC)),
+		}
+		SetHubCondition(&m.Status, firstMessage)
+		SetHubCondition(&m.Status, updatedMessage)
+
+		if len(m.Status.HubConditions) != 1 {
+			t.Fatalf("expected 1 hub condition, got %d", len(m.Status.HubConditions))
+		}
+		got := m.Status.HubConditions[0]
+		if got.Message != updatedMessage.Message {
+			t.Errorf("expected message to update to %q, got %q", updatedMessage.Message, got.Message)
+		}
+		// Status did not change, so LastTransitionTime should still be preserved from the
+		// original condition even though Message changed.
+		if !got.LastTransitionTime.Equal(&firstMessage.LastTransitionTime) {
+			t.Errorf("expected lastTransitionTime to be preserved at %v, got %v",
+				firstMessage.LastTransitionTime, got.LastTransitionTime)
+		}
+	})
 }
 
 func TestGetHubCondition(t *testing.T) {

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -466,7 +466,7 @@ func TestCalculateStatus_RemovesStaleProgressingCondition(t *testing.T) {
 			},
 		},
 		Status: mcev1.MultiClusterEngineStatus{
-			CurrentVersion: "1.0.0",
+			CurrentVersion: version.RequiredCommunityMCEVersion,
 			Conditions: []mcev1.MultiClusterEngineCondition{
 				{
 					Type:    mcev1.MultiClusterEngineAvailable,
@@ -634,7 +634,8 @@ func TestCalculateStatus_WaitingForMCEUpgrade(t *testing.T) {
 	if waitingCondition.Reason != WaitingForMCEUpgradeReason {
 		t.Errorf("Expected condition reason %s, got %s", WaitingForMCEUpgradeReason, waitingCondition.Reason)
 	}
-	wantMessage := "Waiting for MultiClusterEngine to upgrade to 1.0.0 (current: 0.9.0)"
+	wantMessage := fmt.Sprintf(
+		"Waiting for MultiClusterEngine to upgrade to %s (current: 0.9.0)", version.RequiredCommunityMCEVersion)
 	if waitingCondition.Message != wantMessage {
 		t.Errorf("Expected condition message %q, got %q", wantMessage, waitingCondition.Message)
 	}
@@ -654,7 +655,7 @@ func TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling(t *testing.T
 	registerScheme()
 	ctx := context.TODO()
 
-	// This test suite defaults to community mode, so 1.0.0 satisfies RequiredCommunityMCEVersion
+	// This test suite defaults to community mode, so RequiredCommunityMCEVersion satisfies itself
 	// (see TestCalculateMCEVersionCompliance) -- MCE is compliant.
 	mce := &mcev1.MultiClusterEngine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -664,7 +665,7 @@ func TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling(t *testing.T
 			},
 		},
 		Status: mcev1.MultiClusterEngineStatus{
-			CurrentVersion: "1.0.0",
+			CurrentVersion: version.RequiredCommunityMCEVersion,
 			Conditions: []mcev1.MultiClusterEngineCondition{
 				{
 					Type:    mcev1.MultiClusterEngineAvailable,
@@ -697,10 +698,11 @@ func TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling(t *testing.T
 			// Simulates a condition set by a prior reconcile while MCE was still non-compliant.
 			HubConditions: []operatorsv1.HubCondition{
 				{
-					Type:    operatorsv1.Progressing,
-					Status:  metav1.ConditionTrue,
-					Reason:  WaitingForMCEUpgradeReason,
-					Message: "Waiting for MultiClusterEngine to upgrade to 1.0.0 (current: none)",
+					Type:   operatorsv1.Progressing,
+					Status: metav1.ConditionTrue,
+					Reason: WaitingForMCEUpgradeReason,
+					Message: fmt.Sprintf(
+						"Waiting for MultiClusterEngine to upgrade to %s (current: none)", version.RequiredCommunityMCEVersion),
 				},
 			},
 		},

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -607,6 +607,97 @@ func TestCalculateStatus_WaitingForMCEUpgrade(t *testing.T) {
 	}
 }
 
+// TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling verifies that once MCE becomes
+// compliant, a previously-set WaitingForMCEUpgrade condition is cleared even if the hub hasn't
+// finished reconciling its other components yet (i.e. calculateStatus takes the generic "hub is
+// reconciling" branch, not the fully-successful branch). Without this fix, the stale condition
+// would linger -- via the Type-only HubConditionPresent(Progressing) check -- until the hub
+// reached full Running, or indefinitely if some other component never became ready.
+func TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	// This test suite defaults to community mode, so 0.10.0 satisfies RequiredCommunityMCEVersion
+	// (see TestCalculateMCEVersionCompliance) -- MCE is compliant.
+	mce := &mcev1.MultiClusterEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multiclusterengine",
+			Labels: map[string]string{
+				multiclusterengineutils.MCEManagedByLabel: "true",
+			},
+		},
+		Status: mcev1.MultiClusterEngineStatus{
+			CurrentVersion: "0.10.0",
+			Conditions: []mcev1.MultiClusterEngineCondition{
+				{
+					Type:    mcev1.MultiClusterEngineAvailable,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Available",
+					Message: "MCE is available",
+				},
+			},
+		},
+	}
+	if err := recon.Client.Create(ctx, mce); err != nil {
+		t.Fatalf("failed to create MCE: %v", err)
+	}
+	defer func() {
+		if err := recon.Client.Delete(ctx, mce); err != nil {
+			t.Errorf("failed to delete MCE: %v", err)
+		}
+	}()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multiclusterhub",
+			Namespace: "open-cluster-management",
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			DisableHubSelfManagement: true, // Disable local-cluster requirement
+		},
+		Status: operatorsv1.MultiClusterHubStatus{
+			CurrentVersion: version.Version,
+			// Simulates a condition set by a prior reconcile while MCE was still non-compliant.
+			HubConditions: []operatorsv1.HubCondition{
+				{
+					Type:    operatorsv1.Progressing,
+					Status:  metav1.ConditionTrue,
+					Reason:  WaitingForMCEUpgradeReason,
+					Message: "Waiting for MultiClusterEngine to upgrade to 0.10.0 (current: none)",
+				},
+			},
+		},
+	}
+
+	// Deliberately omit the "mce" entry from allCRs (and pass empty allDeps), and pass
+	// ocpConsole=true so the always-Available console fallback isn't injected either. With no
+	// components enabled on this bare hub, the resulting component map is empty, so
+	// allComponentsSuccessful() returns false, keeping the hub NOT fully successful. This
+	// exercises the generic "hub is reconciling" branch rather than the fully-successful
+	// branch, which already clears Progressing on its own (see
+	// TestCalculateStatus_RemovesStaleProgressingCondition).
+	allDeps := []*appsv1.Deployment{}
+	allCRs := map[string]*unstructured.Unstructured{}
+
+	newStatus := recon.calculateStatus(ctx, hub, allDeps, allCRs, true, false)
+
+	if newStatus.Phase == operatorsv1.HubWaitingForMCE {
+		t.Errorf("Expected phase not to be %s once MCE is compliant, got %s", operatorsv1.HubWaitingForMCE, newStatus.Phase)
+	}
+
+	if waiting := GetHubCondition(newStatus, operatorsv1.Progressing); waiting != nil && waiting.Reason == WaitingForMCEUpgradeReason {
+		t.Errorf("Expected stale WaitingForMCEUpgrade condition to be cleared, but it's still present with message %q", waiting.Message)
+	}
+
+	reconciling := GetHubCondition(newStatus, operatorsv1.Progressing)
+	if reconciling == nil {
+		t.Fatal("Expected a Progressing condition describing hub reconciliation to replace the cleared MCE-wait condition, got none")
+	}
+	if reconciling.Reason != ReconcileReason {
+		t.Errorf("Expected condition reason %s, got %s", ReconcileReason, reconciling.Reason)
+	}
+}
+
 // TestMCEUpgradeWaitCondition unit tests the extracted helper in isolation, independent of a
 // live client or the rest of calculateStatus.
 func TestMCEUpgradeWaitCondition(t *testing.T) {

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -429,7 +429,7 @@ func TestCalculateStatus_RemovesStaleProgressingCondition(t *testing.T) {
 			},
 		},
 		Status: mcev1.MultiClusterEngineStatus{
-			CurrentVersion: "0.10.0",
+			CurrentVersion: "1.0.0",
 			Conditions: []mcev1.MultiClusterEngineCondition{
 				{
 					Type:    mcev1.MultiClusterEngineAvailable,
@@ -597,7 +597,7 @@ func TestCalculateStatus_WaitingForMCEUpgrade(t *testing.T) {
 	if waitingCondition.Reason != WaitingForMCEUpgradeReason {
 		t.Errorf("Expected condition reason %s, got %s", WaitingForMCEUpgradeReason, waitingCondition.Reason)
 	}
-	wantMessage := "Waiting for MultiClusterEngine to upgrade to 0.10.0 (current: 0.9.0)"
+	wantMessage := "Waiting for MultiClusterEngine to upgrade to 1.0.0 (current: 0.9.0)"
 	if waitingCondition.Message != wantMessage {
 		t.Errorf("Expected condition message %q, got %q", wantMessage, waitingCondition.Message)
 	}
@@ -617,7 +617,7 @@ func TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling(t *testing.T
 	registerScheme()
 	ctx := context.TODO()
 
-	// This test suite defaults to community mode, so 0.10.0 satisfies RequiredCommunityMCEVersion
+	// This test suite defaults to community mode, so 1.0.0 satisfies RequiredCommunityMCEVersion
 	// (see TestCalculateMCEVersionCompliance) -- MCE is compliant.
 	mce := &mcev1.MultiClusterEngine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -627,7 +627,7 @@ func TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling(t *testing.T
 			},
 		},
 		Status: mcev1.MultiClusterEngineStatus{
-			CurrentVersion: "0.10.0",
+			CurrentVersion: "1.0.0",
 			Conditions: []mcev1.MultiClusterEngineCondition{
 				{
 					Type:    mcev1.MultiClusterEngineAvailable,
@@ -663,7 +663,7 @@ func TestCalculateStatus_ClearsStaleMCEWaitConditionWhenReconciling(t *testing.T
 					Type:    operatorsv1.Progressing,
 					Status:  metav1.ConditionTrue,
 					Reason:  WaitingForMCEUpgradeReason,
-					Message: "Waiting for MultiClusterEngine to upgrade to 0.10.0 (current: none)",
+					Message: "Waiting for MultiClusterEngine to upgrade to 1.0.0 (current: none)",
 				},
 			},
 		},

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -417,7 +418,9 @@ func TestCalculateStatus_RemovesStaleProgressingCondition(t *testing.T) {
 	registerScheme()
 	ctx := context.TODO()
 
-	// Create MCE for version compliance check
+	// Create MCE for version compliance check. This test suite defaults to community mode
+	// (no OPERATOR_PACKAGE env var set), so the version must satisfy RequiredCommunityMCEVersion
+	// (see TestCalculateMCEVersionCompliance) for calculateStatus to consider MCE compliant.
 	mce := &mcev1.MultiClusterEngine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "multiclusterengine",
@@ -426,7 +429,7 @@ func TestCalculateStatus_RemovesStaleProgressingCondition(t *testing.T) {
 			},
 		},
 		Status: mcev1.MultiClusterEngineStatus{
-			CurrentVersion: "5.0.0",
+			CurrentVersion: "0.10.0",
 			Conditions: []mcev1.MultiClusterEngineCondition{
 				{
 					Type:    mcev1.MultiClusterEngineAvailable,
@@ -515,6 +518,160 @@ func TestCalculateStatus_RemovesStaleProgressingCondition(t *testing.T) {
 		if phase != operatorsv1.HubRunning {
 			t.Errorf("Expected phase to be HubRunning after fix, got %v", phase)
 		}
+	}
+}
+
+// TestCalculateStatus_WaitingForMCEUpgrade verifies the fix for ACM-8659: when MCH's own
+// components are healthy but MultiClusterEngine has not reached the required version, `oc get
+// mch` should report a distinct Waiting phase and an actionable message instead of Running with
+// a generic "All hub components ready" message.
+func TestCalculateStatus_WaitingForMCEUpgrade(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	// This test suite defaults to community mode (no OPERATOR_PACKAGE env var set), so use a
+	// version that satisfies neither RequiredCommunityMCEVersion nor RequiredMCEVersion.
+	mce := &mcev1.MultiClusterEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multiclusterengine",
+			Labels: map[string]string{
+				multiclusterengineutils.MCEManagedByLabel: "true",
+			},
+		},
+		Status: mcev1.MultiClusterEngineStatus{
+			CurrentVersion: "0.9.0",
+			Conditions: []mcev1.MultiClusterEngineCondition{
+				{
+					Type:    mcev1.MultiClusterEngineAvailable,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Available",
+					Message: "MCE is available",
+				},
+			},
+		},
+	}
+
+	if err := recon.Client.Create(ctx, mce); err != nil {
+		t.Fatalf("failed to create MCE: %v", err)
+	}
+	defer func() {
+		if err := recon.Client.Delete(ctx, mce); err != nil {
+			t.Errorf("failed to delete MCE: %v", err)
+		}
+	}()
+
+	mceUnstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(mce)
+	if err != nil {
+		t.Fatalf("failed to convert MCE to unstructured: %v", err)
+	}
+	mceUnstructured := &unstructured.Unstructured{Object: mceUnstructuredObj}
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multiclusterhub",
+			Namespace: "open-cluster-management",
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			DisableHubSelfManagement: true, // Disable local-cluster requirement
+		},
+		Status: operatorsv1.MultiClusterHubStatus{
+			CurrentVersion: version.Version,
+		},
+	}
+
+	allDeps := []*appsv1.Deployment{}
+	allCRs := map[string]*unstructured.Unstructured{
+		"mce": mceUnstructured,
+	}
+
+	newStatus := recon.calculateStatus(ctx, hub, allDeps, allCRs, false, false)
+
+	if newStatus.Phase != operatorsv1.HubWaitingForMCE {
+		t.Errorf("Expected phase to be %s, got %s", operatorsv1.HubWaitingForMCE, newStatus.Phase)
+	}
+
+	waitingCondition := GetHubCondition(newStatus, operatorsv1.Progressing)
+	if waitingCondition == nil {
+		t.Fatal("Expected a Progressing condition describing the MCE wait, got none")
+	}
+	if waitingCondition.Reason != WaitingForMCEUpgradeReason {
+		t.Errorf("Expected condition reason %s, got %s", WaitingForMCEUpgradeReason, waitingCondition.Reason)
+	}
+	wantMessage := "Waiting for MultiClusterEngine to upgrade to 0.10.0 (current: 0.9.0)"
+	if waitingCondition.Message != wantMessage {
+		t.Errorf("Expected condition message %q, got %q", wantMessage, waitingCondition.Message)
+	}
+
+	if completeCondition := GetHubCondition(newStatus, operatorsv1.Complete); completeCondition != nil {
+		t.Errorf("Expected no Complete condition while waiting for MCE, got %+v", completeCondition)
+	}
+}
+
+// TestMCEUpgradeWaitCondition unit tests the extracted helper in isolation, independent of a
+// live client or the rest of calculateStatus.
+func TestMCEUpgradeWaitCondition(t *testing.T) {
+	tests := []struct {
+		name            string
+		compliance      *operatorsv1.MCEVersionComplianceStatus
+		isCommunityMode bool
+		wantNil         bool
+		wantMessage     string
+	}{
+		{
+			name:       "nil compliance returns nil",
+			compliance: nil,
+			wantNil:    true,
+		},
+		{
+			name:       "compliant MCE returns nil",
+			compliance: &operatorsv1.MCEVersionComplianceStatus{IsCompliant: true, CurrentVersion: "5.0.0"},
+			wantNil:    true,
+		},
+		{
+			name:            "non-compliant MCE in production mode",
+			compliance:      &operatorsv1.MCEVersionComplianceStatus{IsCompliant: false, CurrentVersion: "4.9.0"},
+			isCommunityMode: false,
+			wantMessage: fmt.Sprintf(
+				"Waiting for MultiClusterEngine to upgrade to %s (current: 4.9.0)", version.RequiredMCEVersion),
+		},
+		{
+			name:            "non-compliant MCE in community mode",
+			compliance:      &operatorsv1.MCEVersionComplianceStatus{IsCompliant: false, CurrentVersion: "0.9.0"},
+			isCommunityMode: true,
+			wantMessage: fmt.Sprintf(
+				"Waiting for MultiClusterEngine to upgrade to %s (current: 0.9.0)", version.RequiredCommunityMCEVersion),
+		},
+		{
+			name:            "non-compliant MCE with no current version reports 'none'",
+			compliance:      &operatorsv1.MCEVersionComplianceStatus{IsCompliant: false, CurrentVersion: ""},
+			isCommunityMode: false,
+			wantMessage: fmt.Sprintf(
+				"Waiting for MultiClusterEngine to upgrade to %s (current: none)", version.RequiredMCEVersion),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mceUpgradeWaitCondition(tt.compliance, tt.isCommunityMode)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Expected nil condition, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("Expected a non-nil condition, got nil")
+			}
+			if got.Type != operatorsv1.Progressing {
+				t.Errorf("Expected condition type %s, got %s", operatorsv1.Progressing, got.Type)
+			}
+			if got.Reason != WaitingForMCEUpgradeReason {
+				t.Errorf("Expected condition reason %s, got %s", WaitingForMCEUpgradeReason, got.Reason)
+			}
+			if got.Message != tt.wantMessage {
+				t.Errorf("Expected message %q, got %q", tt.wantMessage, got.Message)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# Description

When MCH finishes upgrading manually but MultiClusterEngine (MCE) has not yet reached the required version, `oc get mch` previously showed a misleading `Running`/`Installing`/`Updating` phase with a generic message (e.g. "All hub components ready."), even though reconciliation was silently blocked in `waitForMCEReady`. This made it impossible for a CLI user to discover that MCH was actually waiting on MCE to upgrade, without also checking the ConsoleNotification banner.

This PR wires the existing MCE version compliance data (added for the compliance banner in #4394) into `calculateStatus` so the same information is surfaced via `oc get multiclusterhub` directly.

**Draft PR opened primarily to let CI run envtest** (the local envtest run in my sandbox required `KUBEBUILDER_ASSETS`, which wasn't obviously configured for a plain `go test` invocation outside the Makefile target — opening this draft to validate against CI's properly configured environment while I finish local verification).

## Related Issue

Closes ACM-8659 (https://issues.redhat.com/browse/ACM-8659)

## Changes Made

- `api/v1/multiclusterhub_types.go`: add new `HubWaitingForMCE` phase (`"Waiting"`).
- `controllers/status.go`:
  - add `WaitingForMCEUpgradeReason` condition reason.
  - add extracted, pure helper `mceUpgradeWaitCondition(compliance, isCommunityMode)` that returns a `Progressing` condition with message `"Waiting for MultiClusterEngine to upgrade to <version> (current: <version|none>)"`, or `nil` when MCE is compliant.
  - `calculateStatus` now sets this condition and forces `status.Phase = HubWaitingForMCE` whenever MCE is non-compliant (missing, still installing, or lagging behind after an MCH upgrade) — applies during both initial install and upgrade. Skipped for unit tests (no real MCE present) and paused hubs (whose own paused condition takes priority), matching existing guard patterns in this file.
- `controllers/status_test.go`:
  - new `TestMCEUpgradeWaitCondition` table test for the extracted helper.
  - new `TestCalculateStatus_WaitingForMCEUpgrade` end-to-end test asserting the new phase/condition/message.
  - fixed a latent bug in `TestCalculateStatus_RemovesStaleProgressingCondition`: its MCE fixture (`5.0.0`) was only compliant in production mode, but this test suite defaults to community mode (no `OPERATOR_PACKAGE` env set) — this only became visible once compliance started feeding phase/conditions. Updated fixture to `0.10.0` to match the suite's community default (consistent with `TestCalculateMCEVersionCompliance`).

No CRD/API changes beyond the new Go const (phase is a plain string field, not enum-validated).

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- All non-ginkgo unit tests in `controllers` pass locally (`go test ./controllers/... -run '<all Test funcs except TestController>'`).
- The full ginkgo envtest suite (`TestController`) has not been confirmed green locally in my sandbox due to an environment-specific envtest binary path issue unrelated to this change (confirmed by reproducing the same failure on a clean `main` checkout). Opening as draft so CI — which has proper envtest tooling — can validate the full suite, including the "Should Manage Preexisting MCE" spec and the `HubRunning` assertions in `multiclusterhub_controller_test.go`.
- Design rationale/discussion: the phase-gating logic is intentionally isolated to `calculateStatus` (not `waitForMCEReady`) so it's covered by fast unit tests instead of requiring envtest.

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hub status now indicates when it is waiting for MultiClusterEngine installation or upgrade.
  * Progress details include the required and current MultiClusterEngine versions.
  * Waiting status clears automatically once the required version is available.

* **Bug Fixes**
  * Prevented stale MultiClusterEngine upgrade warnings from persisting after the issue is resolved.
  * Status messages now refresh when the reported version changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->