### PR TITLE
chore: sync GRC CRDs

### DIFF
--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_placementbindings.yaml
@@ -56,6 +56,21 @@ spec:
             description: >-
               PlacementSubject defines the placement resource that is being bound to the subjects defined in
               the placement binding.
+            oneOf:
+            - properties:
+                apiGroup:
+                  enum:
+                  - cluster.open-cluster-management.io
+                kind:
+                  enum:
+                  - Placement
+            - properties:
+                apiGroup:
+                  enum:
+                  - apps.open-cluster-management.io
+                kind:
+                  enum:
+                  - PlacementRule
             properties:
               apiGroup:
                 description: >-
@@ -86,8 +101,7 @@ spec:
             - name
             type: object
           status:
-            description: PlacementBindingStatus defines the observed state of the
-              PlacementBinding resource.
+            description: PlacementBindingStatus defines the observed state of the PlacementBinding resource.
             type: object
           subFilter:
             description: >-
@@ -120,8 +134,7 @@ spec:
                   minLength: 1
                   type: string
                 name:
-                  description: Name is the name of the policy or policy set to bind
-                    to the placement resource.
+                  description: Name is the name of the policy or policy set to bind to the placement resource.
                   minLength: 1
                   type: string
               required:

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policies.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policies.yaml
@@ -72,7 +72,7 @@ spec:
                   compliance that should be fulfilled before applying the policies to the managed clusters.
                 items:
                   description: >-
-                    Each PolicyDependency defines an object reference which must be in a certain compliance
+                    PolicyDependency defines an object reference which must be in a certain compliance
                     state before the policy should be created.
                   oneOf:
                   - properties:
@@ -112,16 +112,16 @@ spec:
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: Name is the name of the object that the policy
-                        depends on.
+                      description: Name is the name of the object that the policy depends on.
                       type: string
                     namespace:
-                      description: Namespace is the namespace of the object that the
-                        policy depends on (optional).
+                      description: Namespace is the namespace of the object that the policy depends on (optional).
                       type: string
                   required:
-                  - compliance
+                  - apiVersion
+                  - kind
                   - name
+                  - compliance
                   type: object
                 type: array
               disabled:
@@ -130,8 +130,7 @@ spec:
                   the policy is removed from managed clusters.
                 type: boolean
               hubTemplateOptions:
-                description: HubTemplateOptions changes the default behavior of hub
-                  templates.
+                description: HubTemplateOptions changes the default behavior of hub templates.
                 properties:
                   serviceAccountName:
                     description: >-
@@ -158,7 +157,7 @@ spec:
                         clusters.
                       items:
                         description: >-
-                          Each PolicyDependency defines an object reference which must be in a certain compliance
+                          PolicyDependency defines an object reference which must be in a certain compliance
                           state before the policy should be created.
                         oneOf:
                         - properties:
@@ -198,16 +197,16 @@ spec:
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: Name is the name of the object that the policy
-                              depends on.
+                            description: Name is the name of the object that the policy depends on.
                             type: string
                           namespace:
-                            description: Namespace is the namespace of the object
-                              that the policy depends on (optional).
+                            description: Namespace is the namespace of the object that the policy depends on (optional).
                             type: string
                         required:
-                        - compliance
+                        - apiVersion
+                        - kind
                         - name
+                        - compliance
                         type: object
                       type: array
                     ignorePending:
@@ -217,8 +216,7 @@ spec:
                         "Pending" status.
                       type: boolean
                     objectDefinition:
-                      description: A Kubernetes object defining the policy to apply
-                        to a managed cluster
+                      description: A Kubernetes object defining the policy to apply to a managed cluster
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   required:
@@ -242,8 +240,7 @@ spec:
             - policy-templates
             type: object
           status:
-            description: PolicyStatus reports the observed status of the policy resulting
-              from its policy templates.
+            description: PolicyStatus reports the observed status of the policy resulting from its policy templates.
             properties:
               compliant:
                 description: >-
@@ -264,8 +261,7 @@ spec:
                     for a given policy template.
                   properties:
                     compliant:
-                      description: ComplianceState reports the observed status resulting
-                        from the definitions of the policy.
+                      description: ComplianceState reports the observed status resulting from the definitions of the policy.
                       enum:
                       - Compliant
                       - Pending
@@ -273,21 +269,17 @@ spec:
                       type: string
                     history:
                       items:
-                        description: ComplianceHistory reports a compliance message
-                          from a given time and event.
+                        description: ComplianceHistory reports a compliance message from a given time and event.
                         properties:
                           eventName:
-                            description: EventName is the name of the event attached
-                              to the message.
+                            description: EventName is the name of the event attached to the message.
                             type: string
                           lastTimestamp:
-                            description: LastTimestamp is the timestamp of the event
-                              that reported the message.
+                            description: LastTimestamp is the timestamp of the event that reported the message.
                             format: date-time
                             type: string
                           message:
-                            description: Message is the compliance message resulting
-                              from evaluating the policy resource.
+                            description: Message is the compliance message resulting from evaluating the policy resource.
                             type: string
                         type: object
                       type: array
@@ -301,19 +293,25 @@ spec:
                   Placement is a list of managed cluster placement resources bound to the policy. This status
                   field is only used in the root policy on the hub cluster.
                 items:
-                  description: Placement reports how and what managed cluster placement
-                    resources are attached to the policy.
+                  description: Placement reports how and what managed cluster placement resources are attached to the policy.
                   properties:
                     decisions:
-                      description: Decisions is the list of managed clusters returned
-                        by the placement resource for this binding.
+                      description: Decisions is the list of managed clusters returned by the placement resource for this binding.
                       items:
-                        description: PlacementDecision is the cluster name returned
-                          by the placement resource.
+                        description: PlacementDecision is the cluster name returned by the placement resource.
                         properties:
                           clusterName:
                             type: string
                           clusterNamespace:
+                            type: string
+                        type: object
+                      type: array
+                    exclusions:
+                      description: Exclusions lists managed clusters where the policy is excluded from propagation.
+                      items:
+                        description: PolicyExclusion reports a managed cluster excluded from propagation by a policy set exclusion.
+                        properties:
+                          clusterName:
                             type: string
                         type: object
                       type: array
@@ -354,13 +352,22 @@ spec:
                     clusternamespace:
                       type: string
                     compliant:
-                      description: ComplianceState reports the observed status resulting
-                        from the definitions of the policy.
+                      description: ComplianceState reports the observed status resulting from the definitions of the policy.
                       enum:
                       - Compliant
                       - Pending
                       - NonCompliant
                       type: string
+                    remainingBindings:
+                      items:
+                        description: >-
+                          RemainingBinding reports a placement binding that still places the policy on a managed cluster
+                          when the policy is excluded on a policy set.
+                        properties:
+                          placementBinding:
+                            type: string
+                        type: object
+                      type: array
                   type: object
                 type: array
             type: object

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policyautomations.yaml
@@ -43,25 +43,23 @@ spec:
           metadata:
             type: object
           spec:
-            description: PolicyAutomationSpec defines how and when automation is initiated
-              for the referenced policy.
+            description: PolicyAutomationSpec defines how and when automation is initiated for the referenced policy.
             properties:
               automationDef:
                 description: AutomationDef defines the automation to invoke.
                 properties:
                   extra_vars:
-                    description: ExtraVars is passed to the Ansible job at execution
-                      time and is a known Ansible entity.
+                    description: ExtraVars is passed to the Ansible job at execution time and is a known Ansible entity.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   jobTtl:
                     description: >-
                       JobTTL sets the time to live for the Kubernetes Job object after the Ansible job playbook run
                       has finished.
+                    minimum: 0
                     type: integer
                   name:
-                    description: Name of the Ansible Template to run in Ansible Automation
-                      Platform as a job.
+                    description: Name of the Ansible Template to run in Ansible Automation Platform as a job.
                     minLength: 1
                     type: string
                   policyViolationsLimit:
@@ -72,8 +70,7 @@ spec:
                     minimum: 0
                     type: integer
                   secret:
-                    description: TowerSecret is the name of the secret that contains
-                      the Ansible Automation Platform credential.
+                    description: TowerSecret is the name of the secret that contains the Ansible Automation Platform credential.
                     minLength: 1
                     type: string
                   type:
@@ -100,7 +97,7 @@ spec:
                 type: string
               mode:
                 description: >-
-                  Mode specifies how often automation is initiated. The supported values are "once", "everyEvent",
+                  PolicyAutomationMode specifies how often automation is initiated. The supported values are "once", "everyEvent",
                   and "disabled".
                 enum:
                 - once
@@ -108,12 +105,11 @@ spec:
                 - disabled
                 type: string
               policyRef:
-                description: PolicyRef is the name of the policy that this automation
-                  resource is bound to.
+                description: PolicyRef is the name of the policy that this automation resource is bound to.
+                minLength: 1
                 type: string
               rescanAfter:
-                description: RescanAfter is reserved for future use and should not
-                  be set.
+                description: RescanAfter is reserved for future use and should not be set.
                 type: string
             required:
             - automationDef
@@ -121,21 +117,17 @@ spec:
             - policyRef
             type: object
           status:
-            description: PolicyAutomationStatus defines the observed state of the
-              PolicyAutomation resource.
+            description: PolicyAutomationStatus defines the observed state of the PolicyAutomation resource.
             properties:
               clustersWithEvent:
                 additionalProperties:
-                  description: ClusterEvent shows the PolicyAutomation event on each
-                    target cluster.
+                  description: ClusterEvent shows the PolicyAutomation event on each target cluster.
                   properties:
                     automationStartTime:
-                      description: AutomationStartTime is the policy automation start
-                        time for everyEvent mode.
+                      description: AutomationStartTime is the policy automation start time for everyEvent mode.
                       type: string
                     eventTime:
-                      description: EventTime is the last policy compliance transition
-                        event time.
+                      description: EventTime is the last policy compliance transition event time.
                       type: string
                   required:
                   - automationStartTime

--- a/pkg/templates/crds/grc/policy.open-cluster-management.io_policysets.yaml
+++ b/pkg/templates/crds/grc/policy.open-cluster-management.io_policysets.yaml
@@ -49,16 +49,45 @@ spec:
           metadata:
             type: object
           spec:
-            description: PolicySetSpec defines the group of policies to be included
-              in the policy set.
+            description: PolicySetSpec defines the group of policies to be included in the policy set.
             properties:
               description:
                 description: Description is the description of this policy set.
                 type: string
-              policies:
-                description: Policies is a list of policy names that are contained
-                  within the policy set.
+              exclusions:
+                description: >-
+                  Exclusions lists policies that should not be propagated to specific managed clusters
+                  through this PolicySet's placement binding. Other policies in the PolicySet and other
+                  placement bindings are not affected.
                 items:
+                  description: >-
+                    PolicySetExclusion defines a policy in the set that should not be propagated to
+                    specific managed clusters while keeping the PolicySet association intact.
+                  properties:
+                    clusterNames:
+                      description: ClusterNames is a list of managed cluster names where the policy should not be propagated.
+                      items:
+                        description: NonEmptyString is a string that must contain at least one character.
+                        minLength: 1
+                        type: string
+                      minItems: 1
+                      type: array
+                    policyName:
+                      description: PolicyName is the name of a policy in the PolicySet.
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: Reason is an optional explanation for the exclusion.
+                      type: string
+                  required:
+                  - clusterNames
+                  - policyName
+                  type: object
+                type: array
+              policies:
+                description: Policies is a list of policy names that are contained within the policy set.
+                items:
+                  description: NonEmptyString is a string that must contain at least one character.
                   minLength: 1
                   type: string
                 type: array
@@ -66,17 +95,37 @@ spec:
             - policies
             type: object
           status:
-            description: PolicySetStatus reports the observed status of the policy
-              set resulting from its policies.
+            description: PolicySetStatus reports the observed status of the policy set resulting from its policies.
             properties:
               compliant:
-                description: Compliant reports the observed status resulting from
-                  the compliance of the policies within.
+                description: Compliant reports the observed status resulting from the compliance of the policies within.
                 enum:
                 - Compliant
                 - Pending
                 - NonCompliant
                 type: string
+              exclusions:
+                description: Exclusions reports cluster-level exclusions the controller has applied for policies in the set.
+                items:
+                  description: PolicySetStatusExclusion reports active cluster exclusions observed for a policy in the set.
+                  properties:
+                    clusters:
+                      description: Clusters lists managed cluster names where the policy is excluded from propagation.
+                      items:
+                        description: NonEmptyString is a string that must contain at least one character.
+                        minLength: 1
+                        type: string
+                      minItems: 1
+                      type: array
+                    policyName:
+                      description: PolicyName is the name of the excluded policy.
+                      minLength: 1
+                      type: string
+                  required:
+                  - clusters
+                  - policyName
+                  type: object
+                type: array
               placement:
                 items:
                   description: >-
@@ -102,8 +151,7 @@ spec:
                   type: object
                 type: array
               statusMessage:
-                description: StatusMessge reports the current state while determining
-                  the compliance of the policy set.
+                description: StatusMessage reports the current state while determining the compliance of the policy set.
                 type: string
             type: object
         required:


### PR DESCRIPTION
Sync changes from:
- https://github.com/stolostron/governance-policy-propagator/pull/1406
- https://github.com/stolostron/governance-policy-propagator/pull/1414
- https://github.com/stolostron/governance-policy-propagator/pull/1433


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Policy sets now support defining policy exclusions for specific clusters, including optional reasons.
  * Policy and placement status reports active exclusions and remaining placement bindings.
* **Validation Improvements**
  * Placement references now accept only supported placement resource types.
  * Policy dependencies require complete API, kind, name, and compliance details.
  * Automation job retention values cannot be negative, and policy references cannot be empty.
  * Policy, cluster, and exclusion names must be non-empty.
* **Documentation**
  * Updated and clarified CRD field descriptions and corrected a status message label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->