### PR TITLE
Sync MCH NetworkPolicies configuration to MCE

### DIFF
--- a/pkg/multiclusterengine/multiclusterengine.go
+++ b/pkg/multiclusterengine/multiclusterengine.go
@@ -129,6 +129,15 @@ func RenderMultiClusterEngine(existingMCE *mcev1.MultiClusterEngine, m *operator
 	copy.Spec.NodeSelector = m.Spec.NodeSelector
 	copy.Spec.LocalClusterName = m.Spec.LocalClusterName
 
+	// Sync NetworkPolicies configuration from MCH to MCE so that disabling/enabling
+	// NetworkPolicy deployment on the MCH resource is honored by MCE. MCH defaults
+	// to enabled (see controllers/config.go), so mirror that default here as well.
+	if m.Spec.NetworkPolicies != nil {
+		copy.Spec.NetworkPolicies = mcev1.NetworkPoliciesConfig{Enabled: m.Spec.NetworkPolicies.Enabled}
+	} else {
+		copy.Spec.NetworkPolicies = mcev1.NetworkPoliciesConfig{Enabled: true}
+	}
+
 	for _, component := range utils.GetMCEComponents(m) {
 		if component.Enabled {
 			copy.Enable(component.Name)

--- a/pkg/multiclusterengine/multiclusterengine_test.go
+++ b/pkg/multiclusterengine/multiclusterengine_test.go
@@ -386,6 +386,25 @@ func TestRenderMultiClusterEngine(t *testing.T) {
 		g.Expect(got.Annotations["imageRepository"]).To(gomega.Equal(mch.Annotations["mch-imageRepository"]), "Override annotations should be updated")
 	})
 
+	t.Run("NetworkPolicies defaults to enabled when MCH does not specify", func(t *testing.T) {
+		g.Expect(mch.Spec.NetworkPolicies).To(gomega.BeNil(), "test setup: MCH should not specify NetworkPolicies")
+		g.Expect(got.Spec.NetworkPolicies.Enabled).To(gomega.BeTrue(), "NetworkPolicies should default to enabled")
+	})
+
+	// MCH explicitly disables NetworkPolicies
+	mch.Spec.NetworkPolicies = &operatorv1.NetworkPoliciesConfig{Enabled: false}
+	got = RenderMultiClusterEngine(existingMCE, mch)
+	t.Run("NetworkPolicies disabled on MCH is synced to MCE", func(t *testing.T) {
+		g.Expect(got.Spec.NetworkPolicies.Enabled).To(gomega.BeFalse(), "MCE should inherit MCH's disabled NetworkPolicies setting")
+	})
+
+	// MCH explicitly enables NetworkPolicies
+	mch.Spec.NetworkPolicies = &operatorv1.NetworkPoliciesConfig{Enabled: true}
+	got = RenderMultiClusterEngine(existingMCE, mch)
+	t.Run("NetworkPolicies enabled on MCH is synced to MCE", func(t *testing.T) {
+		g.Expect(got.Spec.NetworkPolicies.Enabled).To(gomega.BeTrue(), "MCE should inherit MCH's enabled NetworkPolicies setting")
+	})
+
 	// Annotation on MCE but not MCH
 	existingMCE.Annotations["imageRepository"] = "quay.io"
 	mch.SetAnnotations(map[string]string{})


### PR DESCRIPTION
# Description

MCH creates and continuously reconciles a managed MCE resource via `RenderMultiClusterEngine`, syncing most spec fields (availability config, image pull secret, tolerations, node selector, component overrides) on every reconcile. However, `.spec.networkPolicies` was never synced, so MCE's NetworkPolicy configuration was permanently stuck at whatever was set on initial creation (`enabled: true`), regardless of what the user later configured on MCH.

## Related Issue

Follow-up to stolostron/backplane-operator#3877, which fixed the MCE-side label selector used to delete NetworkPolicies when `.spec.networkPolicies.enabled` is `false`. That fix is inert for MCH-managed installs unless MCH actually propagates the disabled state to MCE — which this PR addresses.

## Changes Made

- `pkg/multiclusterengine/multiclusterengine.go`: `RenderMultiClusterEngine` now syncs `m.Spec.NetworkPolicies.Enabled` (MCH) to `copy.Spec.NetworkPolicies` (MCE) on every render. If MCH does not specify `.spec.networkPolicies`, MCE defaults to `enabled: true`, matching MCH's own default behavior (`controllers/config.go`).
- `pkg/multiclusterengine/multiclusterengine_test.go`: Added test cases covering:
  - MCE defaults to `enabled: true` when MCH doesn't specify `.spec.networkPolicies`
  - MCE inherits `enabled: false` when set on MCH
  - MCE inherits `enabled: true` when explicitly set on MCH

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Verified via `go test ./pkg/multiclusterengine/...`: all existing tests plus 3 new NetworkPolicies sync test cases pass. `go vet` and `go fmt` clean.

Note: `mcev1.NetworkPoliciesConfig` on the MCE side is a value type (not a pointer) in the currently vendored `backplane-operator` dependency, matching the existing pattern in `NewMultiClusterEngine`.

## Reviewers

/cc

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network policy settings now remain consistent between the hub configuration and the rendered multicluster engine.
  * Network policies are enabled by default when no setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->