### PR TITLE
chore: rework acm-cli networking

### DIFF
--- a/pkg/templates/charts/toggle/console/templates/acm-cli-deployment.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-deployment.yaml
@@ -22,8 +22,6 @@ spec:
     spec:
       containers:
         - name: acm-cli-downloads
-          args:
-            - --secure=true
           image: "{{ .Values.global.imageOverrides.acm_cli }}"
           imagePullPolicy: "{{ .Values.global.pullPolicy }}"
           resources:
@@ -34,23 +32,19 @@ spec:
               memory: "128Mi"
               cpu: "50m"
           ports:
-            - containerPort: 8443
+            - containerPort: 8080
               name: downloads
               protocol: TCP
-          volumeMounts:
-            - mountPath: "/var/run/acm-cli-cert"
-              name: acm-cli-cert
-              readOnly: true
           livenessProbe:
             httpGet:
               port: downloads
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 5
           readinessProbe:
             httpGet:
               port: downloads
-              scheme: HTTPS
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 5
           securityContext:
@@ -61,10 +55,6 @@ spec:
             capabilities:
               drop:
               - ALL
-      volumes:
-        - name: acm-cli-cert
-          secret:
-            secretName: acm-cli-cert
       automountServiceAccountToken: false
       hostNetwork: false
       hostPID: false

--- a/pkg/templates/charts/toggle/console/templates/acm-cli-networkpolicy.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-networkpolicy.yaml
@@ -1,0 +1,55 @@
+# Copyright Contributors to the Open Cluster Management project
+#
+# NetworkPolicy for acm-cli-downloads pod.
+#
+# All requests (ingress and egress) are handled on port 8080 through the
+# Openshift ingress router.
+#
+{{- if .Values.global.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: acm-cli-downloads-network-policy
+  labels:
+    app: console-chart-v2
+    chart: "console-chart-{{ .Values.hubconfig.hubVersion }}"
+    component: console
+    subcomponent: acm-cli-downloads
+spec:
+  podSelector:
+    matchLabels:
+      subcomponent: acm-cli-downloads
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/ingress: ""
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/host-network: ""
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/ingress: ""
+      ports:
+        - protocol: TCP
+          port: 8080
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/host-network: ""
+      ports:
+        - protocol: TCP
+          port: 8080
+{{- end }}

--- a/pkg/templates/charts/toggle/console/templates/acm-cli-route.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-route.yaml
@@ -14,10 +14,10 @@ metadata:
 spec:
   host: "acm-cli-downloads.{{ .Values.hubconfig.ocpIngress }}"
   port:
-    targetPort: https-8443
+    targetPort: downloads
   tls:
     insecureEdgeTerminationPolicy: Redirect
-    termination: reencrypt
+    termination: edge
   to:
     kind: Service
     name: acm-cli-downloads

--- a/pkg/templates/charts/toggle/console/templates/acm-cli-service.yaml
+++ b/pkg/templates/charts/toggle/console/templates/acm-cli-service.yaml
@@ -9,15 +9,13 @@ metadata:
     release: console
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console-chart
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: acm-cli-cert
   name: acm-cli-downloads
 spec:
   ports:
-    - name: https-8443
-      port: 443
+    - name: downloads
+      port: 8080
       protocol: TCP
-      targetPort: 8443
+      targetPort: 8080
   type: ClusterIP
   internalTrafficPolicy: Cluster
   sessionAffinity: None


### PR DESCRIPTION
- Remove HTTPS since requests to/from `acm-cli-downloads` are internal.
- Add NetworkPolicy for `acm-cli-downloads`.

Related to:
- https://github.com/stolostron/acm-cli/pull/494
- https://issues.redhat.com/browse/ACM-30176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated CLI download access to use port 8080 with HTTP-based health checks.
  * Added network controls to restrict download traffic to approved ingress paths.
  * Updated routing and service configuration for the new download endpoint.
  * Preserved automatic HTTPS redirection for external access while simplifying backend connectivity.
  * Improved download service monitoring through HTTP-based readiness and liveness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->