### PR TITLE
Bump Go to 1.26.3 (release-2.15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Build the multiclusterhub-operator binary
-FROM golang:1.24 as builder
+FROM golang:1.26 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/build/Dockerfile.prow
+++ b/build/Dockerfile.prow
@@ -5,7 +5,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as cloner
 RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -5,7 +5,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as cloner
 RUN microdnf install -y git findutils
 COPY hack/scripts hack/scripts
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /workspace
 

--- a/build/Dockerfile.test.prow
+++ b/build/Dockerfile.test.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
 RUN go install github.com/mikefarah/yq/v3@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multiclusterhub-operator
 
-go 1.25.8
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
# Description

Bumps `release-2.15` from Go 1.25.8 to Go 1.26.3, part of a broader effort to resync Go versions to 1.26.3 across active `backplane-operator`, `discovery`, and `multiclusterhub-operator` release branches (see `stolostron/backplane-operator#3907`, `#4635`-`#4637`).

## Related Issue

Part of the same resync effort as #4635-#4637. This branch's `controller-tools` is already `v0.19.0` (confirmed compatible with Go 1.26.3), so this is purely a Go/Dockerfile version bump.

## Changes Made

- `go.mod`: `go 1.25.8` → `go 1.26.3`
- `Dockerfile`: builder image `golang:1.24` → `golang:1.26` (this file was already inconsistent with `go.mod` before this change — `go.mod` was on 1.25.8 while `Dockerfile` was still on `golang:1.24`; both are now aligned)
- `build/Dockerfile.prow`, `build/Dockerfile.test.prow`: builder image `go1.25-linux` → `go1.26-linux`
- `build/Dockerfile.rhtap` (Konflux/RHTAP hermetic build): `openshift-golang-builder:rhel_9_1.25` → `rhel_9_1.26`
- No `Makefile`/`controller-tools` change needed — already on `v0.19.0`.
- `go mod tidy` run; `make manifests generate fmt vet` run and produced **no diff**.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Local `make test` was not run for this PR — deferring to CI per team preference.

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [x] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
