### PR TITLE
Add release-5.0 to CI branch matrices

### DIFF
--- a/.github/workflows/regenerate-bundles.yml
+++ b/.github/workflows/regenerate-bundles.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.26"]
-        branch: ['main', 'release-2.11', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
+        branch: ['main', 'release-2.11', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17', 'release-5.0']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/regenerate-charts.yml
+++ b/.github/workflows/regenerate-charts.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.26"]
-        branch: ['main', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
+        branch: ['main', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17', 'release-5.0']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/resync-owner-file.yml
+++ b/.github/workflows/resync-owner-file.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         branch: [
+            'release-5.0',
             'release-2.17',
             'release-2.16',
             'release-2.15',

--- a/.github/workflows/update-pregenerated-charts.yml
+++ b/.github/workflows/update-pregenerated-charts.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         python-version: [3.13]
         go-version: ["1.26"]
-        branch: ['main', 'release-2.11', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17']
+        branch: ['main', 'release-2.11', 'release-2.13', 'release-2.14', 'release-2.15', 'release-2.16', 'release-2.17', 'release-5.0']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
## Summary
Adds `release-5.0` to the branch matrix in the scheduled/automated regeneration workflows so they also run against the `release-5.0` branch.

## Changes
- `.github/workflows/regenerate-bundles.yml`: added `release-5.0` to branch matrix
- `.github/workflows/regenerate-charts.yml`: added `release-5.0` to branch matrix
- `.github/workflows/update-pregenerated-charts.yml`: added `release-5.0` to branch matrix
- `.github/workflows/resync-owner-file.yml`: added `release-5.0` to branch matrix

No behavioral changes for existing branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automated bundle, chart, and ownership-file synchronization workflows to support the `release-5.0` branch.
  * Ensured pre-generated chart updates also run for `release-5.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->