### PR TITLE
[release-2.14] Add multicluster-integrations deployment to status tracking

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -441,6 +441,7 @@ func GetDeploymentsForStatus(m *operatorsv1.MultiClusterHub, ocpConsole, isSTSEn
 		nn = append(nn, types.NamespacedName{Name: "multicluster-operators-hub-subscription", Namespace: m.Namespace})
 		nn = append(nn, types.NamespacedName{Name: "multicluster-operators-standalone-subscription", Namespace: m.Namespace})
 		nn = append(nn, types.NamespacedName{Name: "multicluster-operators-subscription-report", Namespace: m.Namespace})
+		nn = append(nn, types.NamespacedName{Name: "multicluster-integrations", Namespace: m.Namespace})
 	}
 	if m.Enabled(operatorsv1.ClusterLifecycle) {
 		nn = append(nn, types.NamespacedName{Name: "klusterlet-addon-controller-v2", Namespace: m.Namespace})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -207,7 +207,7 @@ var _ = Describe("utility functions", func() {
 			mch := resources.EmptyMCH()
 			mch.Enable(mchv1.Appsub)
 			d := GetDeploymentsForStatus(&mch, true, false)
-			Expect(len(d)).To(Equal(5))
+			Expect(len(d)).To(Equal(6))
 		})
 		It("gets deployments for status with console enabled", func() {
 			mch := resources.EmptyMCH()
@@ -698,7 +698,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 			name:       "should get deployment status for MCH components",
 			mch:        resources.EmptyMCH(),
 			stsEnabled: false,
-			want:       20,
+			want:       21,
 		},
 		{
 			name: "should get deployment status for MCH components with STS enabled",
@@ -715,7 +715,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: true,
-			want:       21,
+			want:       22,
 		},
 		{
 			name: "should get deployment status for MCH components with STS disabled",
@@ -732,7 +732,7 @@ func Test_GetDeploymentsForStatus(t *testing.T) {
 				},
 			},
 			stsEnabled: false,
-			want:       22,
+			want:       23,
 		},
 	}
 


### PR DESCRIPTION
# Description

The `multicluster-integrations` deployment (part of the App Subscription / `Appsub` chart) was not included in `GetDeploymentsForStatus()`, so it never appeared in the `MultiClusterHub` CR's `status.components` map even though it is deployed and owned by MCH.

## Related Issue

N/A

## Changes Made

- Added `multicluster-integrations` to the `Appsub` block in `GetDeploymentsForStatus()` (`pkg/utils/utils.go`)
- Updated `pkg/utils/utils_test.go` expected deployment counts (+1) across the affected test cases

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Backport of #4673 to `release-2.14`.

## Reviewers

/cc @cameronmwall @ngraham20 

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
