### PR TITLE
[ACM-42783] Detect container port changes to avoid duplicate port name errors

### DIFF
--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2455,6 +2455,365 @@ func Test_detectContainerChanges(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		},
+		{
+			name: "should detect no changes when ports are identical",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "downloads",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "downloads",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "should detect when containerPort changes with the same name (acm-cli-downloads 2.17 -> 5.0)",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "acm-cli-downloads",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "acm-cli-downloads",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8443),
+												"name":          "downloads",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "acm-cli-downloads",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "acm-cli-downloads",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "downloads",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "should detect when port name changes",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "old-port",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "new-port",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "should detect when protocol changes",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "downloads",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "downloads",
+												"protocol":      "UDP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "should detect when port count changes on an existing container",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "downloads",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "container1",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8080),
+												"name":          "downloads",
+												"protocol":      "TCP",
+											},
+											map[string]interface{}{
+												"containerPort": int64(9090),
+												"name":          "metrics",
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "should handle no ports field on either container",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "container1",
+										"image": "image1:v1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test-deployment",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "container1",
+										"image": "image1:v2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 
 	registerScheme()

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2877,6 +2877,60 @@ func Test_detectContainerChanges(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		},
+		{
+			// Regression test: multicluster-role-assignment-controller's "manager" container
+			// declares `ports: []` explicitly in its chart template, which decodes to a present
+			// but empty slice. The live Deployment, however, omits the "ports" key entirely once
+			// fetched from the API, since corev1.Container.Ports has `json:"ports,omitempty"` and
+			// drops zero-length slices during serialization. That asymmetry alone must not trigger
+			// an Update.
+			name: "should not detect change when existing has no ports field and desired has an explicit empty ports array",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "multicluster-role-assignment-controller",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "manager",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "multicluster-role-assignment-controller",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "manager",
+										"ports": []interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 
 	registerScheme()

--- a/controllers/multiclusterhub_controller_test.go
+++ b/controllers/multiclusterhub_controller_test.go
@@ -2578,7 +2578,7 @@ func Test_detectContainerChanges(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "should detect when port name changes",
+			name: "should not detect change when only port name differs",
 			existing: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "apps/v1",
@@ -2635,11 +2635,11 @@ func Test_detectContainerChanges(t *testing.T) {
 					},
 				},
 			},
-			want:    true,
+			want:    false,
 			wantErr: false,
 		},
 		{
-			name: "should detect when protocol changes",
+			name: "should not detect change when only protocol differs",
 			existing: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "apps/v1",
@@ -2696,7 +2696,70 @@ func Test_detectContainerChanges(t *testing.T) {
 					},
 				},
 			},
-			want:    true,
+			want:    false,
+			wantErr: false,
+		},
+		{
+			// Regression test: multicluster-operators-hub-subscription's port is defined without
+			// an explicit protocol in the desired template, but Kubernetes defaults an existing
+			// pod's port to protocol "TCP" on the cluster. That difference alone must not trigger
+			// an Update, since containerPort (the only thing that can break via strategic merge)
+			// is unchanged.
+			name: "should not detect change when desired port omits protocol defaulted by Kubernetes",
+			existing: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "multicluster-operators-hub-subscription",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "multicluster-operators-hub-subscription",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8443),
+												"protocol":      "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "multicluster-operators-hub-subscription",
+						"namespace": "test-ns",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name": "multicluster-operators-hub-subscription",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(8443),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    false,
 			wantErr: false,
 		},
 		{

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -483,10 +483,17 @@ func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *un
 // they are metadata that a strategic merge patch reconciles correctly on its own, so differences in
 // those fields alone shouldn't force an Update. Numeric types are coerced to int64 since decoded
 // unstructured content may represent numbers as float64, int64, or int depending on the source.
+//
+// Always returns a non-nil slice, even when ports is absent. corev1.Container's Ports field has
+// `json:"ports,omitempty"`, so a live Deployment fetched from the API omits the "ports" key
+// entirely once it has zero ports, while a chart template that explicitly declares `ports: []`
+// decodes to a present-but-empty slice. Without normalizing both cases to the same (non-nil)
+// value here, reflect.DeepEqual(nil, []int64{}) in detectContainerChanges would report them as
+// different, causing a spurious Update on every reconcile.
 func containerPortNumbers(ports interface{}) []int64 {
 	portsSlice, ok := ports.([]interface{})
 	if !ok {
-		return nil
+		return []int64{}
 	}
 
 	numbers := make([]int64, 0, len(portsSlice))

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/helpers"
@@ -375,15 +376,17 @@ func (r *MultiClusterHubReconciler) logAndSetCondition(err error, message string
 	return ctrl.Result{}, wrappedError
 }
 
-// detectContainerChanges checks if containers have been added, removed, or had their port
-// configuration changed between existing and desired deployments. Returns true if Update should be
-// used instead of Patch.
+// detectContainerChanges checks if containers have been added, removed, or had their exposed port
+// numbers changed between existing and desired deployments. Returns true if Update should be used
+// instead of Patch.
 //
 // Server-side apply cannot remove elements from arrays, so Update is required when containers are
-// removed. Similarly, a container's port configuration (containerPort/name/protocol) cannot be
-// changed via a strategic merge patch: Kubernetes merges the ports list by name instead of replacing
-// it, so renaming or renumbering a port (e.g. 8443 "downloads" -> 8080 "downloads") would otherwise
-// result in two entries with the same name, which fails API validation.
+// removed. Similarly, a container's containerPort cannot be changed via a strategic merge patch:
+// Kubernetes merges the ports list by name instead of replacing it, so renumbering a port while
+// keeping the same name (e.g. 8443 "downloads" -> 8080 "downloads") would otherwise result in two
+// entries with the same name, which fails API validation. Only the port *number* is compared here;
+// fields like protocol or name are metadata that Kubernetes/strategic-merge already reconciles
+// correctly on Patch and don't warrant the heavier-handed Update.
 func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *unstructured.Unstructured) (bool, error) {
 	// Get existing containers
 	existingContainers, found, err := unstructured.NestedSlice(existing.Object,
@@ -449,12 +452,14 @@ func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *un
 			return true, nil
 		}
 
-		if !reflect.DeepEqual(existingContainer["ports"], desiredContainer["ports"]) {
-			log.Info("Container port configuration changed",
+		existingPorts := containerPortNumbers(existingContainer["ports"])
+		desiredPorts := containerPortNumbers(desiredContainer["ports"])
+		if !reflect.DeepEqual(existingPorts, desiredPorts) {
+			log.Info("Container port number changed",
 				"Deployment", existing.GetName(),
 				"Container", name,
-				"Existing", existingContainer["ports"],
-				"Desired", desiredContainer["ports"])
+				"Existing", existingPorts,
+				"Desired", desiredPorts)
 			return true, nil
 		}
 	}
@@ -471,4 +476,42 @@ func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *un
 
 	// No container changes detected
 	return false, nil
+}
+
+// containerPortNumbers extracts the sorted, multiset of containerPort values declared in a
+// container's ports list. Other port fields (name, protocol, hostPort) are intentionally ignored:
+// they are metadata that a strategic merge patch reconciles correctly on its own, so differences in
+// those fields alone shouldn't force an Update. Numeric types are coerced to int64 since decoded
+// unstructured content may represent numbers as float64, int64, or int depending on the source.
+func containerPortNumbers(ports interface{}) []int64 {
+	portsSlice, ok := ports.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	numbers := make([]int64, 0, len(portsSlice))
+	for _, p := range portsSlice {
+		port, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		var containerPort int64
+		switch v := port["containerPort"].(type) {
+		case int64:
+			containerPort = v
+		case int32:
+			containerPort = int64(v)
+		case int:
+			containerPort = int64(v)
+		case float64:
+			containerPort = int64(v)
+		default:
+			continue
+		}
+		numbers = append(numbers, containerPort)
+	}
+
+	sort.Slice(numbers, func(i, j int) bool { return numbers[i] < numbers[j] })
+	return numbers
 }

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/helpers"
@@ -169,7 +170,7 @@ func (r *MultiClusterHubReconciler) applyTemplate(ctx context.Context, m *operat
 						log.Error(err, "Failed to detect container changes", "Name", template.GetName())
 
 					} else if containersChanged {
-						log.Info("Container set changed (added/removed) - using Update instead of Patch",
+						log.Info("Container set or port configuration changed - using Update instead of Patch",
 							"Kind", template.GetKind(), "Name", template.GetName())
 						useUpdate = true
 					}
@@ -374,9 +375,15 @@ func (r *MultiClusterHubReconciler) logAndSetCondition(err error, message string
 	return ctrl.Result{}, wrappedError
 }
 
-// detectContainerChanges checks if containers have been added or removed between existing and desired deployments.
-// Returns true if the container set differs (by name or count), indicating Update should be used instead of Patch.
-// Server-side apply cannot remove elements from arrays, so we must use Update when containers are removed.
+// detectContainerChanges checks if containers have been added, removed, or had their port
+// configuration changed between existing and desired deployments. Returns true if Update should be
+// used instead of Patch.
+//
+// Server-side apply cannot remove elements from arrays, so Update is required when containers are
+// removed. Similarly, a container's port configuration (containerPort/name/protocol) cannot be
+// changed via a strategic merge patch: Kubernetes merges the ports list by name instead of replacing
+// it, so renaming or renumbering a port (e.g. 8443 "downloads" -> 8080 "downloads") would otherwise
+// result in two entries with the same name, which fails API validation.
 func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *unstructured.Unstructured) (bool, error) {
 	// Get existing containers
 	existingContainers, found, err := unstructured.NestedSlice(existing.Object,
@@ -407,59 +414,58 @@ func (r *MultiClusterHubReconciler) detectContainerChanges(existing, desired *un
 		return true, nil
 	}
 
-	// Build set of existing container names
-	existingNames := make(map[string]bool)
+	// Build a lookup of existing containers by name
+	existingByName := make(map[string]map[string]interface{})
 	for _, c := range existingContainers {
 		container, ok := c.(map[string]interface{})
 		if !ok {
 			continue
 		}
 		if name, ok := container["name"].(string); ok {
-			existingNames[name] = true
+			existingByName[name] = container
 		}
 	}
 
-	// Check if all desired containers exist in current deployment
-	for _, c := range desiredContainers {
-		container, ok := c.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if name, ok := container["name"].(string); ok {
-			if !existingNames[name] {
-				log.Info("New container detected in desired spec",
-					"Deployment", existing.GetName(),
-					"Container", name)
-				return true, nil
-			}
-		}
-	}
-
-	// Build set of desired container names
+	// Check if all desired containers exist in current deployment, and whether the port
+	// configuration has changed for containers that exist in both.
 	desiredNames := make(map[string]bool)
 	for _, c := range desiredContainers {
-		container, ok := c.(map[string]interface{})
+		desiredContainer, ok := c.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		if name, ok := container["name"].(string); ok {
-			desiredNames[name] = true
+
+		name, ok := desiredContainer["name"].(string)
+		if !ok {
+			continue
+		}
+		desiredNames[name] = true
+
+		existingContainer, found := existingByName[name]
+		if !found {
+			log.Info("New container detected in desired spec",
+				"Deployment", existing.GetName(),
+				"Container", name)
+			return true, nil
+		}
+
+		if !reflect.DeepEqual(existingContainer["ports"], desiredContainer["ports"]) {
+			log.Info("Container port configuration changed",
+				"Deployment", existing.GetName(),
+				"Container", name,
+				"Existing", existingContainer["ports"],
+				"Desired", desiredContainer["ports"])
+			return true, nil
 		}
 	}
 
 	// Check if any existing containers are missing from desired (removed containers)
-	for _, c := range existingContainers {
-		container, ok := c.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if name, ok := container["name"].(string); ok {
-			if !desiredNames[name] {
-				log.Info("Container removed in desired spec",
-					"Deployment", existing.GetName(),
-					"Container", name)
-				return true, nil
-			}
+	for name := range existingByName {
+		if !desiredNames[name] {
+			log.Info("Container removed in desired spec",
+				"Deployment", existing.GetName(),
+				"Container", name)
+			return true, nil
 		}
 	}
 

--- a/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-hub-subscription.yaml
+++ b/pkg/templates/charts/toggle/multicloud-operators-subscription/templates/multicluster-operators-hub-subscription.yaml
@@ -82,6 +82,7 @@ spec:
         name: multicluster-operators-hub-subscription
         ports:
         - containerPort: 8443
+          protocol: TCP
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
# Description

Fixes a Deployment validation failure that blocks upgrades when a container's port configuration changes (e.g. `acm-cli-downloads` moving from port 8443 to 8080 between 2.17 and 5.0).

Kubernetes strategic merge patches merge a container's `ports` list by matching entries on `name` instead of replacing the list outright. When a port is renamed/renumbered but keeps the same port `name` (e.g. `8443 "downloads"` -> `8080 "downloads"`), the merge produces two `ports` entries with the same name, which fails API validation:

```
Deployment.apps "acm-cli-downloads" is invalid: spec.template.spec.containers[0].ports[1].name: Duplicate value: "downloads"
```

This was confirmed live on a cluster upgrading MCH from 2.17.0 to 5.0.0, where the operator logged this error on every reconcile and the MultiClusterHub stayed in an `Error` phase indefinitely.

## Related Issue

https://redhat.atlassian.net/browse/ACM-42783

## Changes Made

- Extended `detectContainerChanges` in `controllers/templates.go` to also compare each container's `ports` between the existing and desired Deployment (in addition to the existing container add/remove detection).
- When ports differ for a container that exists in both specs, the reconciler now uses `Update` instead of a server-side apply `Patch`. `Update` replaces the full container spec directly, avoiding the strategic-merge-by-name behavior that causes the duplicate port name.
- Added/updated unit test cases in `controllers/multiclusterhub_controller_test.go` covering: identical ports (no change), `containerPort` change with the same port name (the `acm-cli-downloads` 2.17 -> 5.0 scenario), port name change, protocol change, port count change, and containers with no `ports` field.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This only changes the code path for Deployments where a container's port set differs between the existing and desired specs; all other Deployments continue to use server-side apply as before.

## Definition of Done

- [ ] Code is reviewed.
- [x] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment updates now occur when a container’s port number changes.
  - Port names and protocol metadata changes alone no longer trigger unnecessary updates.
  - Container port comparisons now handle missing ports, empty port lists, and Kubernetes-defaulted protocols consistently.
  - Container additions and removals continue to trigger required deployment updates.
  - Explicitly configured port 8443 to use TCP for consistent connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->