### PR TITLE
Add missing operand images to the ACM 5.0 ART CSV

### DIFF
--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -1889,6 +1889,104 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: OPERAND_IMAGE_ACM_CLI
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cli-rhel9:latest
+                - name: OPERAND_IMAGE_ACM_MUST_GATHER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
+                - name: OPERAND_IMAGE_CERT_POLICY_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cert-policy-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_BACKUP_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-rhel9-operator:latest
+                - name: OPERAND_IMAGE_CONFIG_POLICY_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/config-policy-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CONSOLE
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/console-rhel9:latest
+                - name: OPERAND_IMAGE_ENDPOINT_MONITORING_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-rhel9-operator:latest
+                - name: OPERAND_IMAGE_GOVERNANCE_POLICY_ADDON_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-addon-controller-rhel9:latest
+                - name: OPERAND_IMAGE_GOVERNANCE_POLICY_FRAMEWORK_ADDON
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-framework-addon-rhel9:latest
+                - name: OPERAND_IMAGE_GOVERNANCE_POLICY_PROPAGATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-propagator-rhel9:latest
+                - name: OPERAND_IMAGE_GRAFANA
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-grafana-rhel9:latest
+                - name: OPERAND_IMAGE_GRAFANA_DASHBOARD_LOADER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-dashboard-loader-rhel9:latest
+                - name: OPERAND_IMAGE_INSIGHTS_CLIENT
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-client-rhel9:latest
+                - name: OPERAND_IMAGE_INSIGHTS_METRICS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-metrics-rhel9:latest
+                - name: OPERAND_IMAGE_KLUSTERLET_ADDON_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/klusterlet-addon-controller-rhel9:latest
+                - name: OPERAND_IMAGE_KUBE_RBAC_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-rbac-proxy-rhel9:latest
+                - name: OPERAND_IMAGE_KUBE_STATE_METRICS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-state-metrics-rhel9:latest
+                - name: OPERAND_IMAGE_MEMCACHED_EXPORTER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached-exporter-rhel9:latest
+                - name: OPERAND_IMAGE_METRICS_COLLECTOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/metrics-collector-rhel9:latest
+                - name: OPERAND_IMAGE_MTV_INTEGRATIONS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/mtv-integrations-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLOUD_INTEGRATIONS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OBSERVABILITY_ADDON
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-multicluster-observability-addon-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OBSERVABILITY_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-rhel9-operator:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_APPLICATION
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-application-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_CHANNEL
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-channel-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_SUBSCRIPTION
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-subscription-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_ROLE_ASSIGNMENT
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-role-assignment-rhel9:latest
+                - name: OPERAND_IMAGE_NODE_EXPORTER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
+                - name: OPERAND_IMAGE_OBO_PROMETHEUS_RHEL9_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/obo-prometheus-rhel9-operator:latest
+                - name: OPERAND_IMAGE_OBSERVATORIUM
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
+                - name: OPERAND_IMAGE_OBSERVATORIUM_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9-operator:latest
+                - name: OPERAND_IMAGE_PROMETHEUS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-rhel9:latest
+                - name: OPERAND_IMAGE_PROMETHEUS_ALERTMANAGER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-alertmanager-rhel9:latest
+                - name: OPERAND_IMAGE_PROMETHEUS_CONFIG_RELOADER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-config-reloader-rhel9:latest
+                - name: OPERAND_IMAGE_PROMETHEUS_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-rhel9:latest
+                - name: OPERAND_IMAGE_RBAC_QUERY_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/rbac-query-proxy-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_COLLECTOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-collector-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_INDEXER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-indexer-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_V2_API
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-api-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_V2_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-rhel9:latest
+                - name: OPERAND_IMAGE_SITECONFIG_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-siteconfig-rhel9:latest
+                - name: OPERAND_IMAGE_SUBMARINER_ADDON
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/submariner-addon-rhel9:latest
+                - name: OPERAND_IMAGE_THANOS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-rhel9:latest
+                - name: OPERAND_IMAGE_THANOS_RECEIVE_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-receive-controller-rhel9:latest
+                - name: OPERAND_IMAGE_VOLSYNC_ADDON_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-volsync-addon-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CONFIGMAP_RELOADER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest
+                - name: OPERAND_IMAGE_POSTGRESQL_16
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/postgresql_16:latest
+                - name: OPERAND_IMAGE_MEMCACHED
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached:latest
+                - name: OPERAND_IMAGE_VOLSYNC
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync-rhel9:latest
                 - name: OPERATOR_VERSION
                   value: "5.0.0"
                 - name: OPERATOR_PACKAGE
@@ -1993,4 +2091,103 @@ spec:
   maturity: alpha
   provider:
     name: Redhat
+  relatedImages:
+  - name: acm_cli
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cli-rhel9:latest
+  - name: acm_must_gather
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
+  - name: cert_policy_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cert-policy-controller-rhel9:latest
+  - name: cluster_backup_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-rhel9-operator:latest
+  - name: config_policy_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/config-policy-controller-rhel9:latest
+  - name: console
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/console-rhel9:latest
+  - name: endpoint_monitoring_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-rhel9-operator:latest
+  - name: governance_policy_addon_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-addon-controller-rhel9:latest
+  - name: governance_policy_framework_addon
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-framework-addon-rhel9:latest
+  - name: governance_policy_propagator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-propagator-rhel9:latest
+  - name: grafana
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-grafana-rhel9:latest
+  - name: grafana_dashboard_loader
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-dashboard-loader-rhel9:latest
+  - name: insights_client
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-client-rhel9:latest
+  - name: insights_metrics
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-metrics-rhel9:latest
+  - name: klusterlet_addon_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/klusterlet-addon-controller-rhel9:latest
+  - name: kube_rbac_proxy
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-rbac-proxy-rhel9:latest
+  - name: kube_state_metrics
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-state-metrics-rhel9:latest
+  - name: memcached_exporter
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached-exporter-rhel9:latest
+  - name: metrics_collector
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/metrics-collector-rhel9:latest
+  - name: mtv_integrations
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/mtv-integrations-rhel9:latest
+  - name: multicloud_integrations
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
+  - name: multicluster_observability_addon
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-multicluster-observability-addon-rhel9:latest
+  - name: multicluster_observability_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-rhel9-operator:latest
+  - name: multicluster_operators_application
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-application-rhel9:latest
+  - name: multicluster_operators_channel
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-channel-rhel9:latest
+  - name: multicluster_operators_subscription
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-subscription-rhel9:latest
+  - name: multicluster_role_assignment
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-role-assignment-rhel9:latest
+  - name: node_exporter
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
+  - name: obo_prometheus_rhel9_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/obo-prometheus-rhel9-operator:latest
+  - name: observatorium
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
+  - name: observatorium_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9-operator:latest
+  - name: prometheus
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-rhel9:latest
+  - name: prometheus_alertmanager
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-alertmanager-rhel9:latest
+  - name: prometheus_config_reloader
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-config-reloader-rhel9:latest
+  - name: prometheus_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-rhel9:latest
+  - name: rbac_query_proxy
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/rbac-query-proxy-rhel9:latest
+  - name: search_collector
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-collector-rhel9:latest
+  - name: search_indexer
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-indexer-rhel9:latest
+  - name: search_v2_api
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-api-rhel9:latest
+  - name: search_v2_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-rhel9:latest
+  - name: siteconfig_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-siteconfig-rhel9:latest
+  - name: submariner_addon
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/submariner-addon-rhel9:latest
+  - name: thanos
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-rhel9:latest
+  - name: thanos_receive_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-receive-controller-rhel9:latest
+  - name: volsync_addon_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-volsync-addon-controller-rhel9:latest
+  - name: configmap_reloader
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest
+  - name: postgresql_16
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/postgresql_16:latest
+  - name: memcached
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached:latest
+  - name: volsync
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync-rhel9:latest
   version: 5.0.0

--- a/pkg/overrides/csv_placeholders_test.go
+++ b/pkg/overrides/csv_placeholders_test.go
@@ -4,6 +4,7 @@
 package overrides
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -46,33 +47,8 @@ func TestBundleCSVHasARTPlaceholders(t *testing.T) {
 		t.Errorf("relatedImages count %d != OPERAND_IMAGE count %d", len(related), len(operandEnv))
 	}
 
-	envByDummy := map[string]string{}
-	for key, dummy := range operandEnv {
-		envByDummy[dummy] = key
-		if _, ok := related[key]; !ok {
-			t.Errorf("relatedImages missing name %q (from OPERAND_IMAGE_%s)", key, strings.ToUpper(key))
-		} else if related[key] != dummy {
-			t.Errorf("relatedImages[%s]=%s, want %s", key, related[key], dummy)
-		}
-	}
-
-	for _, dummy := range operandDummies {
-		if _, ok := envByDummy[dummy]; !ok {
-			t.Errorf("CSV is missing OPERAND_IMAGE env for dummy pullspec %s", dummy)
-		}
-	}
-
-	for key, dummy := range operandEnv {
-		found := false
-		for _, refDummy := range operandDummies {
-			if dummy == refDummy {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("OPERAND_IMAGE_%s value %s is not an image-references dummy", strings.ToUpper(key), dummy)
-		}
+	for _, err := range validateOperandIdentity(operandEnv, related, operandDummies) {
+		t.Error(err)
 	}
 
 	helmKeys := helmImageOverrideKeys(t, filepath.Join(root, "pkg", "templates"))
@@ -81,6 +57,138 @@ func TestBundleCSVHasARTPlaceholders(t *testing.T) {
 			t.Errorf("helm imageOverrides.%s has no OPERAND_IMAGE_%s in the CSV", key, strings.ToUpper(key))
 		}
 	}
+}
+
+func TestValidateOperandIdentityRejectsSwappedPullspecs(t *testing.T) {
+	cliDummy := "image-registry.example/open-cluster-management/acm-cli-rhel9:latest"
+	consoleDummy := "image-registry.example/open-cluster-management/console-rhel9:latest"
+	operandDummies := map[string]string{
+		"acm-cli-rhel9": cliDummy,
+		"console-rhel9": consoleDummy,
+	}
+	// Same pullspecs, swapped across OPERAND_IMAGE keys and relatedImages.
+	operandEnv := map[string]string{
+		"acm_cli": consoleDummy,
+		"console": cliDummy,
+	}
+	related := map[string]string{
+		"acm_cli": consoleDummy,
+		"console": cliDummy,
+	}
+
+	errs := validateOperandIdentity(operandEnv, related, operandDummies)
+	if len(errs) == 0 {
+		t.Fatal("swapped OPERAND_IMAGE pullspecs passed validation; component identity must be checked")
+	}
+}
+
+func TestValidateOperandIdentityAcceptsMatchingKeys(t *testing.T) {
+	cliDummy := "image-registry.example/open-cluster-management/acm-cli-rhel9:latest"
+	consoleDummy := "image-registry.example/open-cluster-management/console-rhel9:latest"
+	operandDummies := map[string]string{
+		"acm-cli-rhel9": cliDummy,
+		"console-rhel9": consoleDummy,
+	}
+	operandEnv := map[string]string{
+		"acm_cli": cliDummy,
+		"console": consoleDummy,
+	}
+	related := map[string]string{
+		"acm_cli": cliDummy,
+		"console": consoleDummy,
+	}
+
+	if errs := validateOperandIdentity(operandEnv, related, operandDummies); len(errs) != 0 {
+		t.Fatalf("expected matching component identity to pass, got %v", errs)
+	}
+}
+
+func TestComponentKeyFromImageRefName(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"acm-cli-rhel9", "acm_cli"},
+		{"acm-must-gather-rhel9", "acm_must_gather"},
+		{"acm-grafana-rhel9", "grafana"},
+		{"acm-prometheus-rhel9", "prometheus_operator"},
+		{"acm-search-v2-rhel9", "search_v2_operator"},
+		{"acm-siteconfig-rhel9", "siteconfig_operator"},
+		{"cluster-backup-rhel9-operator", "cluster_backup_controller"},
+		{"obo-prometheus-rhel9-operator", "obo_prometheus_rhel9_operator"},
+		{"endpoint-monitoring-rhel9-operator", "endpoint_monitoring_operator"},
+		{"observatorium-rhel9-operator", "observatorium_operator"},
+		{"configmap_reloader", "configmap_reloader"},
+		{"postgresql_16", "postgresql_16"},
+		{"console-rhel9", "console"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := componentKeyFromImageRefName(tt.name); got != tt.key {
+				t.Errorf("componentKeyFromImageRefName(%q)=%q, want %q", tt.name, got, tt.key)
+			}
+		})
+	}
+}
+
+// imageRefComponentKeys maps image-references tag names whose delivery-repo
+// spelling does not match the extras image-key used as the OPERAND_IMAGE
+// suffix, relatedImages name, and helm imageOverrides key.
+var imageRefComponentKeys = map[string]string{
+	"acm-cli-rhel9":                 "acm_cli",
+	"acm-must-gather-rhel9":         "acm_must_gather",
+	"acm-prometheus-rhel9":          "prometheus_operator",
+	"acm-search-v2-rhel9":           "search_v2_operator",
+	"acm-siteconfig-rhel9":          "siteconfig_operator",
+	"cluster-backup-rhel9-operator": "cluster_backup_controller",
+	"obo-prometheus-rhel9-operator": "obo_prometheus_rhel9_operator",
+}
+
+// componentKeyFromImageRefName maps an image-references tag name to the
+// component key produced by parseEnvVarByPrefix for OPERAND_IMAGE_*.
+func componentKeyFromImageRefName(name string) string {
+	if key, ok := imageRefComponentKeys[name]; ok {
+		return key
+	}
+	s := strings.ReplaceAll(name, "-rhel9-", "-")
+	s = strings.TrimSuffix(s, "-rhel9")
+	s = strings.ReplaceAll(s, "-", "_")
+	return strings.TrimPrefix(s, "acm_")
+}
+
+// validateOperandIdentity checks OPERAND_IMAGE env and relatedImages against
+// image-references by component key, not just pullspec membership.
+func validateOperandIdentity(operandEnv, related, operandDummies map[string]string) []string {
+	var errs []string
+	seenKeys := map[string]string{}
+	for name, dummy := range operandDummies {
+		key := componentKeyFromImageRefName(name)
+		if prev, ok := seenKeys[key]; ok {
+			errs = append(errs, fmt.Sprintf("image-references %q and %q both map to component key %q", prev, name, key))
+		}
+		seenKeys[key] = name
+
+		envDummy, ok := operandEnv[key]
+		if !ok {
+			errs = append(errs, fmt.Sprintf("CSV is missing OPERAND_IMAGE_%s for image-references %s", strings.ToUpper(key), name))
+		} else if envDummy != dummy {
+			errs = append(errs, fmt.Sprintf("OPERAND_IMAGE_%s=%s, want image-references dummy %s (%s)", strings.ToUpper(key), envDummy, dummy, name))
+		}
+
+		relatedDummy, ok := related[key]
+		if !ok {
+			errs = append(errs, fmt.Sprintf("relatedImages missing name %q (from image-references %s)", key, name))
+		} else if relatedDummy != dummy {
+			errs = append(errs, fmt.Sprintf("relatedImages[%s]=%s, want %s (image-references %s)", key, relatedDummy, dummy, name))
+		}
+	}
+
+	for key := range operandEnv {
+		if _, ok := seenKeys[key]; !ok {
+			errs = append(errs, fmt.Sprintf("OPERAND_IMAGE_%s is not mapped from any image-references tag", strings.ToUpper(key)))
+		}
+	}
+	return errs
 }
 
 func repoRoot(t *testing.T) string {

--- a/pkg/overrides/csv_placeholders_test.go
+++ b/pkg/overrides/csv_placeholders_test.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package overrides
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestBundleCSVHasARTPlaceholders checks that the ART CSV template contains a
+// dummy pullspec for every image-references operand (except the operator
+// image itself) as OPERAND_IMAGE_* env vars and spec.relatedImages. ART
+// search-replaces those pullspecs at bundle rebase time; the env var names
+// are the image-keys MCH looks up at runtime.
+func TestBundleCSVHasARTPlaceholders(t *testing.T) {
+	root := repoRoot(t)
+
+	csvPath := mustGlobOne(t, filepath.Join(root, "bundle", "manifests", "*clusterserviceversion.yaml"))
+	csv := loadYAML(t, csvPath)
+
+	container := csvContainer(t, csv)
+	operatorImage := asString(t, container["image"])
+	operandEnv := operandImageEnv(t, container)
+	related := relatedImages(t, csv)
+
+	refDummies := imageReferenceDummies(t, filepath.Join(root, "bundle", "image-references"))
+	operandDummies := map[string]string{}
+	for name, dummy := range refDummies {
+		if dummy == operatorImage {
+			continue
+		}
+		operandDummies[name] = dummy
+	}
+
+	if len(operandEnv) != len(operandDummies) {
+		t.Errorf("OPERAND_IMAGE count %d != image-references operands %d", len(operandEnv), len(operandDummies))
+	}
+	if len(related) != len(operandEnv) {
+		t.Errorf("relatedImages count %d != OPERAND_IMAGE count %d", len(related), len(operandEnv))
+	}
+
+	envByDummy := map[string]string{}
+	for key, dummy := range operandEnv {
+		envByDummy[dummy] = key
+		if _, ok := related[key]; !ok {
+			t.Errorf("relatedImages missing name %q (from OPERAND_IMAGE_%s)", key, strings.ToUpper(key))
+		} else if related[key] != dummy {
+			t.Errorf("relatedImages[%s]=%s, want %s", key, related[key], dummy)
+		}
+	}
+
+	for _, dummy := range operandDummies {
+		if _, ok := envByDummy[dummy]; !ok {
+			t.Errorf("CSV is missing OPERAND_IMAGE env for dummy pullspec %s", dummy)
+		}
+	}
+
+	for key, dummy := range operandEnv {
+		found := false
+		for _, refDummy := range operandDummies {
+			if dummy == refDummy {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("OPERAND_IMAGE_%s value %s is not an image-references dummy", strings.ToUpper(key), dummy)
+		}
+	}
+
+	helmKeys := helmImageOverrideKeys(t, filepath.Join(root, "pkg", "templates"))
+	for _, key := range helmKeys {
+		if operandEnv[key] == "" {
+			t.Errorf("helm imageOverrides.%s has no OPERAND_IMAGE_%s in the CSV", key, strings.ToUpper(key))
+		}
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to determine test file path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "../.."))
+}
+
+func mustGlobOne(t *testing.T, pattern string) string {
+	t.Helper()
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %s: %v", pattern, err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match for %s, got %v", pattern, matches)
+	}
+	return matches[0]
+}
+
+func loadYAML(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := map[string]interface{}{}
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return out
+}
+
+func csvContainer(t *testing.T, csv map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	deployments := mustSlice(t, mustMap(t, mustMap(t, mustMap(t, csv["spec"])["install"])["spec"])["deployments"])
+	if len(deployments) == 0 {
+		t.Fatal("CSV has no deployments")
+	}
+	containers := mustSlice(t, mustMap(t, mustMap(t, mustMap(t, mustMap(t, deployments[0])["spec"])["template"])["spec"])["containers"])
+	if len(containers) == 0 {
+		t.Fatal("CSV deployment has no containers")
+	}
+	return mustMap(t, containers[0])
+}
+
+func operandImageEnv(t *testing.T, container map[string]interface{}) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, item := range mustSlice(t, container["env"]) {
+		env := mustMap(t, item)
+		name := asString(t, env["name"])
+		if !strings.HasPrefix(name, OperandImagePrefix) {
+			continue
+		}
+		key := strings.ToLower(strings.TrimPrefix(name, OperandImagePrefix))
+		out[key] = asString(t, env["value"])
+	}
+	return out
+}
+
+func relatedImages(t *testing.T, csv map[string]interface{}) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	raw, ok := mustMap(t, csv["spec"])["relatedImages"]
+	if !ok {
+		return out
+	}
+	for _, item := range mustSlice(t, raw) {
+		ri := mustMap(t, item)
+		out[asString(t, ri["name"])] = asString(t, ri["image"])
+	}
+	return out
+}
+
+func imageReferenceDummies(t *testing.T, path string) map[string]string {
+	t.Helper()
+	doc := loadYAML(t, path)
+	out := map[string]string{}
+	for _, item := range mustSlice(t, mustMap(t, doc["spec"])["tags"]) {
+		tag := mustMap(t, item)
+		from := mustMap(t, tag["from"])
+		out[asString(t, tag["name"])] = asString(t, from["name"])
+	}
+	if len(out) == 0 {
+		t.Fatalf("no tags in %s", path)
+	}
+	return out
+}
+
+func helmImageOverrideKeys(t *testing.T, templatesDir string) []string {
+	t.Helper()
+	re := regexp.MustCompile(`imageOverrides\.([A-Za-z0-9_]+)`)
+	seen := map[string]struct{}{}
+	err := filepath.Walk(templatesDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !(strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")) {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, match := range re.FindAllStringSubmatch(string(raw), -1) {
+			seen[match[1]] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", templatesDir, err)
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func mustMap(t *testing.T, v interface{}) map[string]interface{} {
+	t.Helper()
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", v)
+	}
+	return m
+}
+
+func mustSlice(t *testing.T, v interface{}) []interface{} {
+	t.Helper()
+	s, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("expected slice, got %T", v)
+	}
+	return s
+}
+
+func asString(t *testing.T, v interface{}) string {
+	t.Helper()
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", v)
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- ART bundle rebase only rewrites pullspecs that already appear in the CSV. The 5.0 `image-references` file listed operands, but the CSV had no `OPERAND_IMAGE_*` env vars or `spec.relatedImages`, so Doozer could not pin those images.
- This ports the 2.16 ART template: dummy `OPERAND_IMAGE_*` values (CPaaS extras image-keys) and matching `relatedImages`, using the dummy pullspecs from `bundle/image-references`.
- Adds a test that the CSV placeholders stay in sync with `image-references` and helm `imageOverrides` keys.

## Test plan
- [x] `go test ./pkg/overrides -run TestBundleCSVHasARTPlaceholders`
- [ ] Doozer/Konflux bundle rebase for `acm-5.0` rewrites every dummy pullspec and writes digest `relatedImages`
- [ ] Installed MCH from that bundle still resolves operand images (`OPERAND_IMAGE_*` present on the operator deployment)

/cc @cameronmwall @dislbenn @ngraham20

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive image references for ACM operand components to the operator installation bundle.
  - Installation metadata now includes the required operand images, supporting more reliable image discovery and deployment in disconnected or mirrored environments.

- **Tests**
  - Added validation to ensure all configured operand images are consistently represented in the installation bundle metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->