### PR TITLE
ACM 5.0 to ART: Add relatedImages and OPERAND_IMAGE_* env vars to CSV

### DIFF
--- a/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/multiclusterhub-operator.clusterserviceversion.yaml
@@ -1889,6 +1889,132 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: OPERAND_IMAGE_ACM_CLI
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cli-rhel9:latest
+                - name: OPERAND_IMAGE_ACM_MUST_GATHER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
+                - name: OPERAND_IMAGE_CERT_POLICY_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cert-policy-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CLUSTER_BACKUP_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-rhel9-operator:latest
+                - name: OPERAND_IMAGE_CONFIG_POLICY_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/config-policy-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CONSOLE
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/console-rhel9:latest
+                - name: OPERAND_IMAGE_ENDPOINT_MONITORING_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-rhel9-operator:latest
+                - name: OPERAND_IMAGE_GOVERNANCE_POLICY_ADDON_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-addon-controller-rhel9:latest
+                - name: OPERAND_IMAGE_GOVERNANCE_POLICY_FRAMEWORK_ADDON
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-framework-addon-rhel9:latest
+                - name: OPERAND_IMAGE_GOVERNANCE_POLICY_PROPAGATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-propagator-rhel9:latest
+                - name: OPERAND_IMAGE_GRAFANA
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-grafana-rhel9:latest
+                - name: OPERAND_IMAGE_GRAFANA_DASHBOARD_LOADER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-dashboard-loader-rhel9:latest
+                - name: OPERAND_IMAGE_INSIGHTS_CLIENT
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-client-rhel9:latest
+                - name: OPERAND_IMAGE_INSIGHTS_METRICS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-metrics-rhel9:latest
+                - name: OPERAND_IMAGE_KLUSTERLET_ADDON_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/klusterlet-addon-controller-rhel9:latest
+                - name: OPERAND_IMAGE_KUBE_RBAC_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-rbac-proxy-rhel9:latest
+                - name: OPERAND_IMAGE_KUBE_STATE_METRICS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-state-metrics-rhel9:latest
+                - name: OPERAND_IMAGE_MEMCACHED_EXPORTER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached-exporter-rhel9:latest
+                - name: OPERAND_IMAGE_METRICS_COLLECTOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/metrics-collector-rhel9:latest
+                - name: OPERAND_IMAGE_MTV_INTEGRATIONS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/mtv-integrations-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLOUD_INTEGRATIONS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OBSERVABILITY_ADDON
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-multicluster-observability-addon-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OBSERVABILITY_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-rhel9-operator:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_APPLICATION
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-application-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_CHANNEL
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-channel-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_OPERATORS_SUBSCRIPTION
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-subscription-rhel9:latest
+                - name: OPERAND_IMAGE_MULTICLUSTER_ROLE_ASSIGNMENT
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-role-assignment-rhel9:latest
+                - name: OPERAND_IMAGE_NODE_EXPORTER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
+                - name: OPERAND_IMAGE_OBO_PROMETHEUS_RHEL9_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/obo-prometheus-rhel9-operator:latest
+                - name: OPERAND_IMAGE_OBSERVATORIUM
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
+                - name: OPERAND_IMAGE_OBSERVATORIUM_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9-operator:latest
+                - name: OPERAND_IMAGE_PROMETHEUS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-rhel9:latest
+                - name: OPERAND_IMAGE_PROMETHEUS_ALERTMANAGER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-alertmanager-rhel9:latest
+                - name: OPERAND_IMAGE_PROMETHEUS_CONFIG_RELOADER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-config-reloader-rhel9:latest
+                - name: OPERAND_IMAGE_PROMETHEUS_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-rhel9:latest
+                - name: OPERAND_IMAGE_RBAC_QUERY_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/rbac-query-proxy-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_COLLECTOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-collector-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_INDEXER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-indexer-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_V2_API
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-api-rhel9:latest
+                - name: OPERAND_IMAGE_SEARCH_V2_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-rhel9:latest
+                - name: OPERAND_IMAGE_SITECONFIG_OPERATOR
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-siteconfig-rhel9:latest
+                - name: OPERAND_IMAGE_SUBMARINER_ADDON
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/submariner-addon-rhel9:latest
+                - name: OPERAND_IMAGE_THANOS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-rhel9:latest
+                - name: OPERAND_IMAGE_THANOS_RECEIVE_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-receive-controller-rhel9:latest
+                - name: OPERAND_IMAGE_VOLSYNC_ADDON_CONTROLLER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-volsync-addon-controller-rhel9:latest
+                - name: OPERAND_IMAGE_CONFIGMAP_RELOADER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_API
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_api:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_OCP_UI
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_ocp_ui:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_PERIODIC
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_periodic:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_UI
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_ui:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_WORKER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_worker:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_CLI_ARTIFACTS
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_cli_artifacts:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_ALERT_EXPORTER
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_alert_exporter:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_ALERTMANAGER_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_alertmanager_proxy:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_DB_SETUP
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_db_setup:latest
+                - name: OPERAND_IMAGE_FLIGHTCTL_USERINFO_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_userinfo_proxy:latest
+                - name: OPERAND_IMAGE_UBI_MINIMAL
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/ubi_minimal:latest
+                - name: OPERAND_IMAGE_ORIGIN_CLI
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/origin_cli:latest
+                - name: OPERAND_IMAGE_REDIS_7_C9S
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/redis_7_c9s:latest
+                - name: OPERAND_IMAGE_POSTGRESQL_16
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/postgresql_16:latest
+                - name: OPERAND_IMAGE_MEMCACHED
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached:latest
+                - name: OPERAND_IMAGE_OSE_KUBE_RBAC_PROXY
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/ose_kube_rbac_proxy:latest
+                - name: OPERAND_IMAGE_VOLSYNC
+                  value: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync:latest
                 - name: OPERATOR_VERSION
                   value: "5.0.0"
                 - name: OPERATOR_PACKAGE
@@ -1993,4 +2119,133 @@ spec:
   maturity: alpha
   provider:
     name: Redhat
+  relatedImages:
+  - name: acm_cli
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-cli-rhel9:latest
+  - name: acm_must_gather
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-must-gather-rhel9:latest
+  - name: cert_policy_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cert-policy-controller-rhel9:latest
+  - name: cluster_backup_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/cluster-backup-rhel9-operator:latest
+  - name: config_policy_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/config-policy-controller-rhel9:latest
+  - name: console
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/console-rhel9:latest
+  - name: endpoint_monitoring_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/endpoint-monitoring-rhel9-operator:latest
+  - name: governance_policy_addon_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-addon-controller-rhel9:latest
+  - name: governance_policy_framework_addon
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-governance-policy-framework-addon-rhel9:latest
+  - name: governance_policy_propagator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/governance-policy-propagator-rhel9:latest
+  - name: grafana
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-grafana-rhel9:latest
+  - name: grafana_dashboard_loader
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/grafana-dashboard-loader-rhel9:latest
+  - name: insights_client
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-client-rhel9:latest
+  - name: insights_metrics
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/insights-metrics-rhel9:latest
+  - name: klusterlet_addon_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/klusterlet-addon-controller-rhel9:latest
+  - name: kube_rbac_proxy
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-rbac-proxy-rhel9:latest
+  - name: kube_state_metrics
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/kube-state-metrics-rhel9:latest
+  - name: memcached_exporter
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached-exporter-rhel9:latest
+  - name: metrics_collector
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/metrics-collector-rhel9:latest
+  - name: mtv_integrations
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/mtv-integrations-rhel9:latest
+  - name: multicloud_integrations
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicloud-integrations-rhel9:latest
+  - name: multicluster_observability_addon
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-multicluster-observability-addon-rhel9:latest
+  - name: multicluster_observability_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-observability-rhel9-operator:latest
+  - name: multicluster_operators_application
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-application-rhel9:latest
+  - name: multicluster_operators_channel
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-channel-rhel9:latest
+  - name: multicluster_operators_subscription
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-operators-subscription-rhel9:latest
+  - name: multicluster_role_assignment
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multicluster-role-assignment-rhel9:latest
+  - name: multiclusterhub_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/multiclusterhub-operator:latest
+  - name: node_exporter
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/node-exporter-rhel9:latest
+  - name: obo_prometheus_rhel9_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/obo-prometheus-rhel9-operator:latest
+  - name: observatorium
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9:latest
+  - name: observatorium_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/observatorium-rhel9-operator:latest
+  - name: prometheus
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-rhel9:latest
+  - name: prometheus_alertmanager
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/prometheus-alertmanager-rhel9:latest
+  - name: prometheus_config_reloader
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-config-reloader-rhel9:latest
+  - name: prometheus_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-prometheus-rhel9:latest
+  - name: rbac_query_proxy
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/rbac-query-proxy-rhel9:latest
+  - name: search_collector
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/search-collector-rhel9:latest
+  - name: search_indexer
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-indexer-rhel9:latest
+  - name: search_v2_api
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-api-rhel9:latest
+  - name: search_v2_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-search-v2-rhel9:latest
+  - name: siteconfig_operator
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-siteconfig-rhel9:latest
+  - name: submariner_addon
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/submariner-addon-rhel9:latest
+  - name: thanos
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-rhel9:latest
+  - name: thanos_receive_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/thanos-receive-controller-rhel9:latest
+  - name: volsync_addon_controller
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/acm-volsync-addon-controller-rhel9:latest
+  - name: configmap_reloader
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/configmap_reloader:latest
+  - name: flightctl_api
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_api:latest
+  - name: flightctl_ocp_ui
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_ocp_ui:latest
+  - name: flightctl_periodic
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_periodic:latest
+  - name: flightctl_ui
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_ui:latest
+  - name: flightctl_worker
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_worker:latest
+  - name: flightctl_cli_artifacts
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_cli_artifacts:latest
+  - name: flightctl_alert_exporter
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_alert_exporter:latest
+  - name: flightctl_alertmanager_proxy
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_alertmanager_proxy:latest
+  - name: flightctl_db_setup
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_db_setup:latest
+  - name: flightctl_userinfo_proxy
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/flightctl_userinfo_proxy:latest
+  - name: ubi_minimal
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/ubi_minimal:latest
+  - name: origin_cli
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/origin_cli:latest
+  - name: redis_7_c9s
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/redis_7_c9s:latest
+  - name: postgresql_16
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/postgresql_16:latest
+  - name: memcached
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/memcached:latest
+  - name: ose_kube_rbac_proxy
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/ose_kube_rbac_proxy:latest
+  - name: volsync
+    image: image-registry.openshift-image-registry.svc:5000/open-cluster-management/volsync:latest
   version: 5.0.0


### PR DESCRIPTION
The 5.0 CSV was scaffolded from main and was missing two ART-critical sections that were present in the 2.16 CSV (which evolved over the 2.x release line). Both use internal registry placeholders that ART substitutes with pinned digests during rebase.

1. relatedImages: Required for disconnected/air-gapped mirroring (oc-mirror) and OLM image discovery. 50 entries matching bundle/image-references.

2. OPERAND_IMAGE_* env vars: Required for the operator to resolve operand images at runtime. 63 entries (2.16 had 64; minus cluster_permission which moved to MCE in 5.0).

Root cause: The 5.0 CSV (multiclusterhub-operator.csv.yaml) was regenerated via operator-sdk scaffolding from main, not ported from the 2.16 CSV (advanced-cluster-management.csv.yaml). The scaffolding tools do not preserve hand-maintained ART metadata.