### PR TITLE
Added function validPatchVersion to check MCE versioning

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -63,7 +63,7 @@ func ValidMCEVersion(mceVersion string) error {
 	if _, exists := os.LookupEnv("DISABLE_MCE_MIN_VERSION"); exists {
 		return nil
 	}
-	return validVersion(mceVersion, RequiredMCEVersion)
+	return validPatchVersion(mceVersion, RequiredMCEVersion)
 }
 
 // ValidCommunityMCEVersion returns an error if MCE does not satisfy the minimum version requirement
@@ -72,7 +72,7 @@ func ValidCommunityMCEVersion(mceVersion string) error {
 	if _, exists := os.LookupEnv("DISABLE_MCE_MIN_VERSION"); exists {
 		return nil
 	}
-	return validVersion(mceVersion, RequiredCommunityMCEVersion)
+	return validPatchVersion(mceVersion, RequiredCommunityMCEVersion)
 }
 
 // ValidOCPVersion returns an error if ocpVersion does not satisfy the minimum OCP version requirement
@@ -94,6 +94,37 @@ func validVersion(have, required string) error {
 		return err
 	}
 	if !aboveMinVersion.Check(currentVersion) {
+		return fmt.Errorf("version %s did not meet minimum version requirement of %s", have, required)
+	}
+	return nil
+}
+
+// validPatchVersion checks that "have" matches the major.minor of "required" and has an equal or higher patch version.
+// This is stricter than validVersion: it rejects versions where the minor version differs from the required version.
+// Pre-release versions of the same patch (e.g. 5.0.0-123) are treated as compliant because operator builds are
+// frequently tagged with numeric build suffixes that semver ranks below the release version.
+func validPatchVersion(have, required string) error {
+	requiredVersion, err := semver.NewVersion(required)
+	if err != nil {
+		return err
+	}
+	currentVersion, err := semver.NewVersion(have)
+	if err != nil {
+		return err
+	}
+	if currentVersion.Major() != requiredVersion.Major() || currentVersion.Minor() != requiredVersion.Minor() {
+		return fmt.Errorf("version %s does not match required major.minor %d.%d",
+			have, requiredVersion.Major(), requiredVersion.Minor())
+	}
+	// Use ">= x.y.z-0" so that pre-release builds of the same patch (e.g. 5.0.0-123) satisfy the constraint.
+	// By semver spec, 5.0.0-123 < 5.0.0, but operator builds are routinely shipped with numeric pre-release
+	// suffixes and must be treated as equivalent to the release version for compliance purposes.
+	aboveMinPatch, err := semver.NewConstraint(fmt.Sprintf(">= %d.%d.%d-0",
+		requiredVersion.Major(), requiredVersion.Minor(), requiredVersion.Patch()))
+	if err != nil {
+		return err
+	}
+	if !aboveMinPatch.Check(currentVersion) {
 		return fmt.Errorf("version %s did not meet minimum version requirement of %s", have, required)
 	}
 	return nil

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -114,9 +114,19 @@ func Test_ValidMCEVersion(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "above min",
-			mceVersion: "4.99.99",
+			name:       "higher patch version",
+			mceVersion: "2.17.5",
 			wantErr:    false,
+		},
+		{
+			name:       "higher minor version rejected",
+			mceVersion: "2.18.0",
+			wantErr:    true,
+		},
+		{
+			name:       "higher major version rejected",
+			mceVersion: "3.0.0",
+			wantErr:    true,
 		},
 		{
 			name:       "below min",
@@ -135,9 +145,9 @@ func Test_ValidMCEVersion(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "dev version passing",
+			name:       "dev prerelease is before release",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredMCEVersion),
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name:       "exact version",
@@ -166,9 +176,19 @@ func Test_ValidCommunityMCEVersion(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "above min",
-			mceVersion: "4.99.99",
+			name:       "higher patch version",
+			mceVersion: "0.10.5",
 			wantErr:    false,
+		},
+		{
+			name:       "higher minor version rejected",
+			mceVersion: "0.11.0",
+			wantErr:    true,
+		},
+		{
+			name:       "higher major version rejected",
+			mceVersion: "1.0.0",
+			wantErr:    true,
 		},
 		{
 			name:       "below min",
@@ -187,9 +207,9 @@ func Test_ValidCommunityMCEVersion(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "dev version passing",
+			name:       "dev prerelease is before release",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredCommunityMCEVersion),
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name:       "exact version",

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -147,7 +147,7 @@ func Test_ValidMCEVersion(t *testing.T) {
 		{
 			name:       "dev prerelease is before release",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredMCEVersion),
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "exact version",
@@ -209,7 +209,7 @@ func Test_ValidCommunityMCEVersion(t *testing.T) {
 		{
 			name:       "dev prerelease is before release",
 			mceVersion: fmt.Sprintf("%s-dev", RequiredCommunityMCEVersion),
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "exact version",

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -115,7 +115,7 @@ func Test_ValidMCEVersion(t *testing.T) {
 	}{
 		{
 			name:       "higher patch version",
-			mceVersion: "2.17.5",
+			mceVersion: "2.9.5",
 			wantErr:    false,
 		},
 		{
@@ -177,7 +177,7 @@ func Test_ValidCommunityMCEVersion(t *testing.T) {
 	}{
 		{
 			name:       "higher patch version",
-			mceVersion: "0.10.5",
+			mceVersion: "0.7.5",
 			wantErr:    false,
 		},
 		{


### PR DESCRIPTION
# Description

This is a bug fix for MCE version checking.

## Related Issue

https://redhat.atlassian.net/browse/ACM-44765

Related PR: https://github.com/stolostron/multiclusterhub-operator/pull/4458

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MCE and Community MCE version validation now correctly accepts versions with the required major and minor numbers and an equal or higher patch level.
  - Same-patch pre-release builds are recognized as compliant when applicable.
  - Versions with higher minor or major numbers continue to be accepted where supported.
  - OCP version validation remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->