### PR TITLE
Surface blocking resource in MCH status conditions

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -121,6 +121,17 @@ func (r *MultiClusterHubReconciler) ensureNoNamespace(m *operatorv1.MultiCluster
 	}
 }
 
+// resourceIdentifier formats a kind/namespace/name into a short, human-readable
+// identifier for use in HubCondition messages, e.g. "ServiceAccount
+// open-cluster-management/console-chart" or "ClusterRoleBinding
+// open-cluster-management:console:clusterrolebinding" for cluster-scoped resources.
+func resourceIdentifier(kind, namespace, name string) string {
+	if namespace != "" {
+		return fmt.Sprintf("%s %s/%s", kind, namespace, name)
+	}
+	return fmt.Sprintf("%s %s", kind, name)
+}
+
 func (r *MultiClusterHubReconciler) ensureUnstructuredResource(m *operatorv1.MultiClusterHub, u *unstructured.Unstructured) (ctrl.Result, error) {
 	obLog := r.Log.WithValues("Namespace", u.GetNamespace(), "Kind", u.GetKind(), "Name", u.GetName())
 
@@ -142,7 +153,8 @@ func (r *MultiClusterHubReconciler) ensureUnstructuredResource(m *operatorv1.Mul
 		}
 		// Creation was successful
 		obLog.Info("Created new resource")
-		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, "Created new resource")
+		msg := fmt.Sprintf("Created new resource: %s", resourceIdentifier(u.GetKind(), u.GetNamespace(), u.GetName()))
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, msg)
 		SetHubCondition(&m.Status, *condition)
 		return ctrl.Result{}, nil
 
@@ -160,20 +172,25 @@ func (r *MultiClusterHubReconciler) ensureNamespace(m *operatorv1.MultiClusterHu
 	ctx := context.Background()
 
 	existingNS := &corev1.Namespace{}
+	created := false
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: ns.GetName()}, existingNS); err != nil {
 		if errors.IsNotFound(err) {
 			if err = r.Client.Create(ctx, ns); err != nil {
 				r.Log.Info(fmt.Sprintf("Error creating namespace: %s", err.Error()))
 				return ctrl.Result{Requeue: true}, nil
 			}
+			created = true
 		} else {
 			r.Log.Info(fmt.Sprintf("error locating namespace: %s. Error: %s", ns.GetName(), err.Error()))
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}
 
-	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, "Created new resource")
-	SetHubCondition(&m.Status, *condition)
+	if created {
+		msg := fmt.Sprintf("Created new resource: %s", resourceIdentifier("Namespace", "", ns.GetName()))
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, msg)
+		SetHubCondition(&m.Status, *condition)
+	}
 
 	if existingNS.Status.Phase == corev1.NamespaceActive {
 		return ctrl.Result{}, nil
@@ -194,8 +211,16 @@ func (r *MultiClusterHubReconciler) ensureOperatorGroup(m *operatorv1.MultiClust
 	}
 
 	if len(operatorGroupList.Items) > 1 {
-		r.Log.Error(fmt.Errorf("found more than one operator group in namespace %s", og.GetNamespace()), "fatal error")
-		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
+		msg := fmt.Sprintf("Found more than one OperatorGroup in namespace %s", og.GetNamespace())
+		r.Log.Error(fmt.Errorf("multiple OperatorGroups found"),
+			"Cannot proceed with multiple OperatorGroups",
+			"namespace", og.GetNamespace())
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason, msg)
+		SetHubCondition(&m.Status, *condition)
+		// This is a terminal misconfiguration requiring manual intervention (not something
+		// that resolves by waiting), so don't requeue on a timer. A watch on OperatorGroup
+		// objects (or the periodic resync) will pick it up if/when it's fixed.
+		return ctrl.Result{}, nil
 	} else if len(operatorGroupList.Items) == 1 {
 		return ctrl.Result{}, nil
 	}
@@ -208,7 +233,8 @@ func (r *MultiClusterHubReconciler) ensureOperatorGroup(m *operatorv1.MultiClust
 		r.Log.Info(fmt.Sprintf("Error: %s", err.Error()))
 		return ctrl.Result{Requeue: true}, nil
 	}
-	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, "Created new resource")
+	msg := fmt.Sprintf("Created new resource: %s", resourceIdentifier("OperatorGroup", og.GetNamespace(), og.GetName()))
+	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, msg)
 	SetHubCondition(&m.Status, *condition)
 
 	existingOperatorGroup := &olmv1.OperatorGroup{}
@@ -254,7 +280,8 @@ func (r *MultiClusterHubReconciler) ensureServiceAccount(m *operatorv1.MultiClus
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, "Created new resource")
+	msg := fmt.Sprintf("Created new resource: %s", resourceIdentifier("ServiceAccount", sa.GetNamespace(), sa.GetName()))
+	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, msg)
 	SetHubCondition(&m.Status, *condition)
 
 	return ctrl.Result{}, nil
@@ -290,7 +317,8 @@ func (r *MultiClusterHubReconciler) ensureClusterRoleBinding(m *operatorv1.Multi
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, "Created new resource")
+	msg := fmt.Sprintf("Created new resource: %s", resourceIdentifier("ClusterRoleBinding", "", crb.GetName()))
+	condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, NewComponentReason, msg)
 	SetHubCondition(&m.Status, *condition)
 
 	return ctrl.Result{}, nil
@@ -300,10 +328,18 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 	mce, err := multiclusterengine.FindAndManageMCE(ctx, r.Client)
 	if err != nil {
 		if apimeta.IsNoMatchError(err) {
-			r.Log.WithName("WARNING").Info("MCE CRD not yet available, requeueing")
+			r.Log.Info("MCE CRD not yet available, requeueing")
+			condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, WaitingForMCEReason,
+				"Waiting for MultiClusterEngine CRD to become available")
+			SetHubCondition(&m.Status, *condition)
 			return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// CRD is available — clear any stale "waiting for CRD" condition
+	if cond := GetHubCondition(m.Status, operatorv1.Progressing); cond != nil && cond.Reason == WaitingForMCEReason {
+		RemoveHubCondition(&m.Status, operatorv1.Progressing)
 	}
 
 	if mce == nil {
@@ -334,6 +370,11 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngineCR(ctx context.Conte
 		mce = multiclusterengine.NewMultiClusterEngine(m, targetNS)
 		err = r.Client.Create(ctx, mce)
 		if err != nil {
+			// Commonly transient early in install (e.g. MCE's own admission webhook service
+			// isn't up yet), so surface it as a waiting condition rather than only an error.
+			condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, WaitingForMCEReason,
+				fmt.Sprintf("Waiting to create MultiClusterEngine: %s", err.Error()))
+			SetHubCondition(&m.Status, *condition)
 			return ctrl.Result{}, fmt.Errorf("error creating new MCE: %w", err)
 		}
 		return ctrl.Result{}, nil
@@ -608,6 +649,12 @@ func (r *MultiClusterHubReconciler) ensureMCEInstallation(ctx context.Context, m
 	}
 	overrides, err := v0.GetAnnotationOverrides(multiClusterHub)
 	if err != nil {
+		// A malformed override annotation is a user misconfiguration that needs to be
+		// noticed and fixed, not a transient condition — surface it on the hub instead of
+		// only logging it.
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+			fmt.Sprintf("Invalid MCE subscription override annotation: %s", err.Error()))
+		SetHubCondition(&multiClusterHub.Status, *condition)
 		return ctrl.Result{}, err
 	}
 
@@ -675,11 +722,29 @@ func (r *MultiClusterHubReconciler) ensureMCEInstallation(ctx context.Context, m
 	// Apply MCE sub
 	calcSub := v0.RenderSubscription(mceSub, subConfig, overrides, ctlSrc)
 	if createSub {
+		r.Log.Info("Creating MCE Subscription", "name", calcSub.Name, "namespace", calcSub.Namespace)
 		err = r.Client.Create(ctx, calcSub)
+		if err == nil {
+			r.Log.Info("MCE Subscription created successfully", "name", calcSub.Name, "namespace", calcSub.Namespace)
+		}
 	} else {
+		r.Log.Info("Updating MCE Subscription", "name", calcSub.Name, "namespace", calcSub.Namespace)
 		err = r.Client.Update(ctx, calcSub)
 	}
 	if err != nil {
+		if errors.IsConflict(err) {
+			// Transient: OLM concurrently updates the Subscription's status (e.g. during CSV
+			// install/upgrade), racing our spec update. This is normal and self-resolves on a
+			// later reconcile once the resourceVersion catches up — log it and move on with an
+			// empty result instead of an explicit Requeue. Callers (ensureMultiClusterEngine)
+			// treat any non-empty result as "stop here", so requesting a requeue here would
+			// block ensureMultiClusterEngineCR from running this cycle — starving MCE CR
+			// creation for as long as the Subscription keeps conflicting, which in practice can
+			// be most/every reconcile while OLM is actively installing the CSV.
+			r.Log.Info("Subscription was concurrently modified, will retry the update on a later reconcile",
+				"name", calcSub.Name)
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("error updating subscription %s: %w", calcSub.Name, err)
 	}
 
@@ -699,6 +764,12 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 	// Get annotation overrides for ClusterExtension
 	overrides, err := v1.GetAnnotationOverrides(multiClusterHub)
 	if err != nil {
+		// A malformed override annotation is a user misconfiguration that needs to be
+		// noticed and fixed, not a transient condition — surface it on the hub instead of
+		// only logging it.
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+			fmt.Sprintf("Invalid MCE ClusterExtension override annotation: %s", err.Error()))
+		SetHubCondition(&multiClusterHub.Status, *condition)
 		return ctrl.Result{}, err
 	}
 
@@ -766,6 +837,20 @@ func (r *MultiClusterHubReconciler) ensureMCEClusterExtension(ctx context.Contex
 		err = r.Client.Update(ctx, calcCE)
 	}
 	if err != nil {
+		if errors.IsConflict(err) {
+			// Transient: OLM v1's own controller concurrently updates the ClusterExtension's
+			// status (e.g. while resolving/installing the bundle), racing our spec update.
+			// This is normal and self-resolves on a later reconcile once the resourceVersion
+			// catches up — log it and move on with an empty result instead of an explicit
+			// Requeue. Callers (ensureMultiClusterEngine) treat any non-empty result as "stop
+			// here", so requesting a requeue here would block ensureMultiClusterEngineCR from
+			// running this cycle — starving MCE CR creation for as long as the ClusterExtension
+			// keeps conflicting, which in practice can be most/every reconcile while OLM v1 is
+			// actively resolving/installing the bundle.
+			r.Log.Info("ClusterExtension was concurrently modified, will retry the update on a later reconcile",
+				"name", calcCE.Name)
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("error updating ClusterExtension %s: %w", calcCE.Name, err)
 	}
 
@@ -788,14 +873,18 @@ func (r *MultiClusterHubReconciler) ensureMultiClusterEngine(ctx context.Context
 }
 
 // waitForMCE checks that MCE is in a running state and at the expected version.
-func (r *MultiClusterHubReconciler) waitForMCEReady(ctx context.Context) (ctrl.Result, error) {
+func (r *MultiClusterHubReconciler) waitForMCEReady(ctx context.Context,
+	m *operatorv1.MultiClusterHub) (ctrl.Result, error) {
 	// Wait for MCE to be ready
 	existingMCE, err := multiclusterengineutils.GetManagedMCE(ctx, r.Client)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to get managed MCE: %w", err)
 	}
 	if existingMCE == nil {
-		r.Log.Info("Multiclusterengine is not yet present")
+		r.Log.Info("MultiClusterEngine is not yet present")
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, WaitingForMCEReason,
+			"Waiting for MultiClusterEngine to be created")
+		SetHubCondition(&m.Status, *condition)
 		return ctrl.Result{Requeue: true}, nil
 	}
 	if utils.IsUnitTest() {
@@ -803,7 +892,17 @@ func (r *MultiClusterHubReconciler) waitForMCEReady(ctx context.Context) (ctrl.R
 	}
 
 	if existingMCE.Status.CurrentVersion == "" {
-		r.Log.Info(fmt.Sprintf("Multiclusterengine: %s is not yet available", existingMCE.GetName()))
+		r.Log.Info("MultiClusterEngine is not yet available",
+			"name", existingMCE.GetName(),
+			"requeueAfter", resyncPeriod.String())
+		msg := fmt.Sprintf("Waiting for MultiClusterEngine %s to report version", existingMCE.GetName())
+		// Surface MCE's own latest condition (e.g. "Not all components available") so the
+		// long window between MCE's CSV finishing and MCE reporting a version isn't opaque.
+		if mceCond := latestMCECondition(existingMCE); mceCond != nil && mceCond.Message != "" {
+			msg = fmt.Sprintf("%s (%s: %s)", msg, mceCond.Reason, mceCond.Message)
+		}
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, WaitingForMCEReason, msg)
+		SetHubCondition(&m.Status, *condition)
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
 
@@ -814,9 +913,20 @@ func (r *MultiClusterHubReconciler) waitForMCEReady(ctx context.Context) (ctrl.R
 		err = version.ValidMCEVersion(existingMCE.Status.CurrentVersion)
 	}
 	if err != nil {
-		r.Log.Info("Waiting for MCE upgrade to complete", "CurrentVersion", existingMCE.Status.CurrentVersion, "Reason", err.Error())
+		r.Log.Info("Waiting for MCE upgrade to complete",
+			"currentVersion", existingMCE.Status.CurrentVersion,
+			"reason", err.Error())
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionTrue, WaitingForMCEReason,
+			fmt.Sprintf("Waiting for MultiClusterEngine upgrade: %s", err.Error()))
+		SetHubCondition(&m.Status, *condition)
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
+
+	// MCE is ready — clear any stale WaitingForMCE condition
+	if cond := GetHubCondition(m.Status, operatorv1.Progressing); cond != nil && cond.Reason == WaitingForMCEReason {
+		RemoveHubCondition(&m.Status, operatorv1.Progressing)
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/common_olm_test.go
+++ b/controllers/common_olm_test.go
@@ -7,24 +7,34 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine"
+	v0 "github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine/olm/v0"
 	v1 "github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine/olm/v1"
+	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengineutils"
+	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
+	"github.com/stolostron/multiclusterhub-operator/pkg/version"
+	resources "github.com/stolostron/multiclusterhub-operator/test/unit-tests"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -179,6 +189,9 @@ func TestEnsureServiceAccount(t *testing.T) {
 				condition := FindCondition(tt.mch.Status.HubConditions, operatorsv1.Progressing)
 				if condition == nil {
 					t.Errorf("ensureServiceAccount() expected Progressing condition but not found")
+				} else if !strings.Contains(condition.Message, "ServiceAccount") || !strings.Contains(condition.Message, saName) {
+					t.Errorf("ensureServiceAccount() expected condition message to name the ServiceAccount %q, got %q",
+						saName, condition.Message)
 				}
 			}
 		})
@@ -330,6 +343,10 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 				condition := FindCondition(tt.mch.Status.HubConditions, operatorsv1.Progressing)
 				if condition == nil {
 					t.Errorf("ensureClusterRoleBinding() expected Progressing condition but not found")
+				} else if !strings.Contains(condition.Message, "ClusterRoleBinding") ||
+					!strings.Contains(condition.Message, crbName) {
+					t.Errorf("ensureClusterRoleBinding() expected condition message to name the ClusterRoleBinding %q, got %q",
+						crbName, condition.Message)
 				}
 			}
 		})
@@ -535,6 +552,295 @@ func TestEnsureMultiClusterEngineCR_NoMatchError(t *testing.T) {
 	}
 	if result.RequeueAfter != resyncPeriod {
 		t.Errorf("ensureMultiClusterEngineCR() expected RequeueAfter=%v, got %v", resyncPeriod, result.RequeueAfter)
+	}
+}
+
+// Test_ensureMultiClusterEngineCR_SetsWaitingCondition_OnCreateError verifies
+// that when creating the MultiClusterEngine CR fails (e.g. MCE's own
+// admission webhook service isn't up yet — common early in a fresh install),
+// a Progressing/WaitingForMCEReason condition including the underlying error
+// is recorded, instead of only returning a bare error with no status
+// visibility.
+func Test_ensureMultiClusterEngineCR_SetsWaitingCondition_OnCreateError(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-mce-create-error"
+
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*mcev1.MultiClusterEngine); ok {
+				return apierrors.NewInternalError(
+					fmt.Errorf(`failed calling webhook "multiclusterengines.multicluster.openshift.io"`))
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+
+	_, err := r.ensureMultiClusterEngineCR(context.Background(), &mch)
+	if err == nil {
+		t.Fatal("expected error when MCE creation fails, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != WaitingForMCEReason {
+		t.Errorf("expected reason %q, got %q", WaitingForMCEReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, "webhook") {
+		t.Errorf("expected message to include the underlying error detail, got %q", condition.Message)
+	}
+}
+
+// Test_ensureMCEInstallation_SetsCondition_OnInvalidAnnotation_V0 verifies
+// that a malformed MCE subscription override annotation (a user
+// misconfiguration, not a transient error) is surfaced as a
+// Progressing/RequirementsNotMetReason condition instead of only being
+// logged/returned as a bare error.
+func Test_ensureMCEInstallation_SetsCondition_OnInvalidAnnotation_V0(t *testing.T) {
+	registerScheme()
+	t.Setenv("POD_NAMESPACE", "test-ns")
+
+	mchOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.MCHOperatorName,
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "operator", Image: "test"}}},
+			},
+		},
+	}
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-invalid-annotation-v0"
+	mch.Namespace = "test-ns"
+	mch.Annotations = map[string]string{
+		utils.AnnotationMCESubscriptionSpec: "{not valid json",
+	}
+
+	r := newTestReconciler(mchOperatorDeployment)
+	r.OLMVersion = "v0"
+
+	_, err := r.ensureMCEInstallation(context.Background(), &mch)
+	if err == nil {
+		t.Fatal("expected error for invalid annotation, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != RequirementsNotMetReason {
+		t.Errorf("expected reason %q, got %q", RequirementsNotMetReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, "annotation") {
+		t.Errorf("expected message to mention the annotation, got %q", condition.Message)
+	}
+}
+
+// Test_ensureMCEInstallation_HandlesSubscriptionUpdateConflict_V0 verifies
+// that a resourceVersion conflict on the Subscription Update (e.g. racing
+// OLM's own controller writing status during CSV install) is retried
+// quietly instead of surfacing as a reconciler error.
+func Test_ensureMCEInstallation_HandlesSubscriptionUpdateConflict_V0(t *testing.T) {
+	registerScheme()
+	t.Setenv("POD_NAMESPACE", "test-ns")
+
+	mchOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.MCHOperatorName,
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "operator", Image: "test"}}},
+			},
+		},
+	}
+
+	// Owned by a different MCH so CreatedByMCH() is false, skipping the
+	// pull-secret/operator-group prerequisites and going straight to the
+	// render+Update path being tested.
+	otherMCH := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-mch", Namespace: "other-ns"},
+	}
+	existingSub := v0.NewSubscription(otherMCH, nil, nil)
+
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*subv1alpha1.Subscription); ok {
+				return apierrors.NewConflict(schema.GroupResource{Group: "operators.coreos.com", Resource: "subscriptions"},
+					obj.GetName(), fmt.Errorf("the object has been modified"))
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}, mchOperatorDeployment, existingSub)
+	r.OLMVersion = "v0"
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-sub-conflict"
+	mch.Namespace = "test-ns"
+	// Skip the ClusterSource package-manifest lookup entirely by supplying it via override.
+	mch.Annotations = map[string]string{
+		utils.AnnotationMCESubscriptionSpec: `{"source":"redhat-operators"}`,
+	}
+
+	result, err := r.ensureMCEInstallation(context.Background(), &mch)
+	if err != nil {
+		t.Fatalf("expected no error on conflict (should retry quietly), got: %v", err)
+	}
+	// Must be an empty result (not an explicit Requeue): ensureMultiClusterEngine treats any
+	// non-empty result as "stop here", so requesting a requeue on a benign, self-resolving
+	// conflict would block ensureMultiClusterEngineCR from running this cycle — starving MCE
+	// CR creation for as long as the Subscription keeps conflicting with OLM's own updates.
+	if result != (ctrl.Result{}) {
+		t.Errorf("expected empty result so the reconcile can proceed to create the MCE CR this cycle, got %+v", result)
+	}
+}
+
+// Test_ensureMultiClusterEngine_CreatesCR_DespiteSubscriptionConflict is an
+// end-to-end regression test for a livelock: ensureMultiClusterEngine only
+// proceeds from ensureMCEInstallation to ensureMultiClusterEngineCR when
+// ensureMCEInstallation returns an empty ctrl.Result. An earlier version of
+// the Subscription-conflict fix returned ctrl.Result{Requeue: true} on every
+// conflict, which — since OLM concurrently updates the Subscription's status
+// throughout CSV install — could starve MCE CR creation for as long as the
+// conflict kept recurring (observed live as several minutes with no CR
+// created at all). This verifies the MCE CR is actually created on the very
+// reconcile that hits the conflict, not just that ensureMCEInstallation
+// alone returns cleanly.
+func Test_ensureMultiClusterEngine_CreatesCR_DespiteSubscriptionConflict(t *testing.T) {
+	registerScheme()
+	t.Setenv("POD_NAMESPACE", "test-ns")
+	t.Setenv(utils.UnitTestEnvVar, "false")
+
+	mchOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.MCHOperatorName,
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "operator", Image: "test"}}},
+			},
+		},
+	}
+
+	otherMCH := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-mch", Namespace: "other-ns"},
+	}
+	existingSub := v0.NewSubscription(otherMCH, nil, nil)
+
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*subv1alpha1.Subscription); ok {
+				return apierrors.NewConflict(schema.GroupResource{Group: "operators.coreos.com", Resource: "subscriptions"},
+					obj.GetName(), fmt.Errorf("the object has been modified"))
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}, mchOperatorDeployment, existingSub)
+	r.OLMVersion = "v0"
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-e2e-livelock"
+	mch.Namespace = "test-ns"
+	mch.Annotations = map[string]string{
+		utils.AnnotationMCESubscriptionSpec: `{"source":"redhat-operators"}`,
+	}
+
+	if _, err := r.ensureMultiClusterEngine(context.Background(), &mch); err != nil {
+		t.Fatalf("ensureMultiClusterEngine() unexpected error: %v", err)
+	}
+
+	mceList := &mcev1.MultiClusterEngineList{}
+	if err := r.Client.List(context.Background(), mceList); err != nil {
+		t.Fatalf("failed to list MultiClusterEngine: %v", err)
+	}
+	if len(mceList.Items) == 0 {
+		t.Error("expected the MCE CR to be created on this reconcile despite the Subscription update conflict")
+	}
+}
+
+// Test_ensureMCEClusterExtension_SetsCondition_OnInvalidAnnotation is the
+// OLM v1 counterpart: a malformed MCE ClusterExtension override annotation
+// should be surfaced the same way as the v0 Subscription case.
+func Test_ensureMCEClusterExtension_SetsCondition_OnInvalidAnnotation(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-invalid-annotation-v1"
+	mch.Annotations = map[string]string{
+		utils.AnnotationMCEClusterExtensionSpec: "{not valid json",
+	}
+
+	r := newTestReconciler()
+
+	_, err := r.ensureMCEClusterExtension(context.Background(), &mch)
+	if err == nil {
+		t.Fatal("expected error for invalid annotation, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != RequirementsNotMetReason {
+		t.Errorf("expected reason %q, got %q", RequirementsNotMetReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, "annotation") {
+		t.Errorf("expected message to mention the annotation, got %q", condition.Message)
+	}
+}
+
+// Test_ensureMCEClusterExtension_HandlesUpdateConflict verifies that a
+// resourceVersion conflict on the ClusterExtension Update (e.g. racing OLM
+// v1's own controller writing status during bundle resolution) is retried
+// quietly instead of surfacing as a reconciler error, mirroring how the OLM
+// v0 Subscription path already handles this same class of conflict.
+func Test_ensureMCEClusterExtension_HandlesUpdateConflict(t *testing.T) {
+	registerScheme()
+
+	// Owned by a different MCH so CreatedByMCH() is false, skipping the
+	// pull-secret/service-account/cluster-role-binding prerequisites and going
+	// straight to the render+Update path being tested.
+	otherMCH := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-mch", Namespace: "other-ns"},
+	}
+	existingCE := v1.NewClusterExtension(otherMCH)
+
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*ocv1.ClusterExtension); ok {
+				gr := schema.GroupResource{Group: "operator-controller.operator-framework.io", Resource: "clusterextensions"}
+				return apierrors.NewConflict(gr, obj.GetName(), fmt.Errorf("the object has been modified"))
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}, existingCE)
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-ce-conflict"
+
+	result, err := r.ensureMCEClusterExtension(context.Background(), &mch)
+	if err != nil {
+		t.Fatalf("expected no error on conflict (should retry quietly), got: %v", err)
+	}
+	// Must be an empty result (not an explicit Requeue): ensureMultiClusterEngine treats any
+	// non-empty result as "stop here", so requesting a requeue on a benign, self-resolving
+	// conflict would block ensureMultiClusterEngineCR from running this cycle.
+	if result != (ctrl.Result{}) {
+		t.Errorf("expected empty result so the reconcile can proceed to create the MCE CR this cycle, got %+v", result)
 	}
 }
 
@@ -1217,4 +1523,470 @@ func (l *testLogger) WithName(name string) logr.LogSink {
 	return l
 }
 func (l *testLogger) Init(info logr.RuntimeInfo) {
+}
+
+// --- HubCondition tests ---
+//
+// The following tests cover the status condition updates added so that
+// `kubectl get mch` surfaces what is blocking OperatorGroup reconciliation
+// and MultiClusterEngine readiness/creation.
+
+// Test_ensureOperatorGroup_SetsRequirementsNotMetCondition_MultipleGroups
+// verifies that finding more than one OperatorGroup in a namespace records a
+// Progressing/RequirementsNotMetReason condition naming the namespace,
+// instead of only logging the conflict. This is a terminal misconfiguration
+// requiring manual intervention, so it should not requeue on a timer.
+func Test_ensureOperatorGroup_SetsRequirementsNotMetCondition_MultipleGroups(t *testing.T) {
+	s := scheme.Scheme
+	_ = olmv1.AddToScheme(s)
+	_ = operatorsv1.AddToScheme(s)
+
+	ogNamespace := "test-namespace-multiple-og"
+	og1 := &olmv1.OperatorGroup{ObjectMeta: metav1.ObjectMeta{Name: "og-one", Namespace: ogNamespace}}
+	og2 := &olmv1.OperatorGroup{ObjectMeta: metav1.ObjectMeta{Name: "og-two", Namespace: ogNamespace}}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(og1, og2).Build()
+	reconciler := &MultiClusterHubReconciler{
+		Client: fakeClient,
+		Scheme: s,
+		Log:    clog.Log.WithName("test"),
+	}
+
+	mch := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mch", Namespace: ogNamespace},
+	}
+	desiredOG := &olmv1.OperatorGroup{ObjectMeta: metav1.ObjectMeta{Name: "desired-og", Namespace: ogNamespace}}
+
+	result, err := reconciler.ensureOperatorGroup(mch, desiredOG)
+	if err != nil {
+		t.Fatalf("ensureOperatorGroup() unexpected error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Errorf("ensureOperatorGroup() expected empty result (no requeue for a terminal misconfiguration), got %+v", result)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != RequirementsNotMetReason {
+		t.Errorf("expected reason %q, got %q", RequirementsNotMetReason, condition.Reason)
+	}
+	if condition.Status != metav1.ConditionFalse {
+		t.Errorf("expected status %q, got %q", metav1.ConditionFalse, condition.Status)
+	}
+	if !strings.Contains(condition.Message, ogNamespace) {
+		t.Errorf("expected message to mention namespace %q, got %q", ogNamespace, condition.Message)
+	}
+}
+
+// Test_ensureOperatorGroup_NoCondition_WhenSingleGroupExists verifies that no
+// condition is added when exactly one OperatorGroup already exists (the
+// no-op path).
+func Test_ensureOperatorGroup_NoCondition_WhenSingleGroupExists(t *testing.T) {
+	s := scheme.Scheme
+	_ = olmv1.AddToScheme(s)
+	_ = operatorsv1.AddToScheme(s)
+
+	ogNamespace := "test-namespace-single-og"
+	existingOG := &olmv1.OperatorGroup{ObjectMeta: metav1.ObjectMeta{Name: "og-existing", Namespace: ogNamespace}}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(existingOG).Build()
+	reconciler := &MultiClusterHubReconciler{
+		Client: fakeClient,
+		Scheme: s,
+		Log:    clog.Log.WithName("test"),
+	}
+
+	mch := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mch", Namespace: ogNamespace},
+	}
+	desiredOG := &olmv1.OperatorGroup{ObjectMeta: metav1.ObjectMeta{Name: "desired-og", Namespace: ogNamespace}}
+
+	result, err := reconciler.ensureOperatorGroup(mch, desiredOG)
+	if err != nil {
+		t.Fatalf("ensureOperatorGroup() unexpected error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("ensureOperatorGroup() expected empty result, got: %+v", result)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorsv1.Progressing); condition != nil {
+		t.Errorf("expected no Progressing condition, got: %+v", condition)
+	}
+}
+
+// Test_ensureMultiClusterEngineCR_NoMatchError_SetsWaitingCondition verifies
+// that when the MultiClusterEngine CRD isn't yet registered (NoKindMatchError),
+// a Progressing/WaitingForMCEReason condition is recorded instead of only
+// being logged as a WARNING.
+func Test_ensureMultiClusterEngineCR_NoMatchError_SetsWaitingCondition(t *testing.T) {
+	noMatchErr := &apimeta.NoKindMatchError{
+		GroupKind: schema.GroupKind{Group: "multicluster.openshift.io", Kind: "MultiClusterEngine"},
+	}
+
+	noMatchClient := &listErrorClient{
+		Client:  fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+		listErr: noMatchErr,
+	}
+
+	reconciler := &MultiClusterHubReconciler{
+		Client: noMatchClient,
+		Scheme: scheme.Scheme,
+		Log:    clog.Log.WithName("test"),
+	}
+
+	mch := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch-nomatch-condition",
+			Namespace: "test-namespace",
+		},
+	}
+
+	_, err := reconciler.ensureMultiClusterEngineCR(context.Background(), mch)
+	if err != nil {
+		t.Fatalf("ensureMultiClusterEngineCR() expected nil error for NoMatchError, got: %v", err)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != WaitingForMCEReason {
+		t.Errorf("expected reason %q, got %q", WaitingForMCEReason, condition.Reason)
+	}
+	if condition.Message != "Waiting for MultiClusterEngine CRD to become available" {
+		t.Errorf("unexpected condition message: %q", condition.Message)
+	}
+}
+
+// Test_waitForMCEReady_SetsWaitingCondition_NoMCE verifies that when no
+// managed MultiClusterEngine exists yet, a Progressing/WaitingForMCEReason
+// condition is recorded and the request is requeued.
+func Test_waitForMCEReady_SetsWaitingCondition_NoMCE(t *testing.T) {
+	registerScheme()
+	r := newTestReconciler()
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-mce-not-present"
+
+	result, err := r.waitForMCEReady(context.Background(), &mch)
+	if err != nil {
+		t.Fatalf("waitForMCEReady() unexpected error: %v", err)
+	}
+	if !result.Requeue {
+		t.Errorf("expected Requeue=true, got %+v", result)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != WaitingForMCEReason {
+		t.Errorf("expected reason %q, got %q", WaitingForMCEReason, condition.Reason)
+	}
+	if condition.Message != "Waiting for MultiClusterEngine to be created" {
+		t.Errorf("unexpected condition message: %q", condition.Message)
+	}
+}
+
+// Test_waitForMCEReady_SetsWaitingCondition_NoVersion verifies that once MCE
+// exists but hasn't reported a CurrentVersion yet, a
+// Progressing/WaitingForMCEReason condition naming the MCE is recorded.
+func Test_waitForMCEReady_SetsWaitingCondition_NoVersion(t *testing.T) {
+	registerScheme()
+
+	mce := resources.EmptyMCE()
+	mce.Name = "test-mce-no-version"
+	mce.Labels = map[string]string{multiclusterengineutils.MCEManagedByLabel: "true"}
+	// Status.CurrentVersion intentionally left empty.
+
+	r := newTestReconciler(&mce)
+	// waitForMCEReady short-circuits past this point under UNIT_TEST=true;
+	// pin it explicitly so this path is exercised deterministically.
+	t.Setenv(utils.UnitTestEnvVar, "false")
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-mce-no-version"
+
+	result, err := r.waitForMCEReady(context.Background(), &mch)
+	if err != nil {
+		t.Fatalf("waitForMCEReady() unexpected error: %v", err)
+	}
+	if result.RequeueAfter != resyncPeriod {
+		t.Errorf("expected RequeueAfter=%v, got %+v", resyncPeriod, result)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != WaitingForMCEReason {
+		t.Errorf("expected reason %q, got %q", WaitingForMCEReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, mce.GetName()) {
+		t.Errorf("expected message to mention MCE name %q, got %q", mce.GetName(), condition.Message)
+	}
+}
+
+// Test_waitForMCEReady_SetsWaitingCondition_VersionTooLow verifies that when
+// MCE reports a version that doesn't satisfy the minimum requirement, a
+// Progressing/WaitingForMCEReason condition mentioning the upgrade wait is
+// recorded.
+func Test_waitForMCEReady_SetsWaitingCondition_VersionTooLow(t *testing.T) {
+	registerScheme()
+
+	mce := resources.EmptyMCE()
+	mce.Name = "test-mce-low-version"
+	mce.Labels = map[string]string{multiclusterengineutils.MCEManagedByLabel: "true"}
+	mce.Status.CurrentVersion = "1.0.0"
+
+	r := newTestReconciler(&mce)
+	t.Setenv(utils.UnitTestEnvVar, "false")
+	// Pin the non-community version requirement (5.0.0) explicitly so this
+	// test doesn't depend on utils.IsCommunityMode()'s default.
+	t.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-mce-low-version"
+
+	result, err := r.waitForMCEReady(context.Background(), &mch)
+	if err != nil {
+		t.Fatalf("waitForMCEReady() unexpected error: %v", err)
+	}
+	if result.RequeueAfter != resyncPeriod {
+		t.Errorf("expected RequeueAfter=%v, got %+v", resyncPeriod, result)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != WaitingForMCEReason {
+		t.Errorf("expected reason %q, got %q", WaitingForMCEReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, "Waiting for MultiClusterEngine upgrade") {
+		t.Errorf("expected message to mention upgrade wait, got %q", condition.Message)
+	}
+}
+
+// Test_waitForMCEReady_NoCondition_WhenReady verifies that no condition is
+// added once MCE reports a version satisfying the minimum requirement.
+func Test_waitForMCEReady_NoCondition_WhenReady(t *testing.T) {
+	registerScheme()
+
+	mce := resources.EmptyMCE()
+	mce.Name = "test-mce-ready"
+	mce.Labels = map[string]string{multiclusterengineutils.MCEManagedByLabel: "true"}
+	mce.Status.CurrentVersion = version.RequiredMCEVersion
+
+	r := newTestReconciler(&mce)
+	t.Setenv(utils.UnitTestEnvVar, "false")
+	// Pin the non-community version requirement explicitly so this test doesn't depend on
+	// utils.IsCommunityMode()'s default, and derive the compliant version from
+	// version.RequiredMCEVersion instead of a hardcoded literal so a future version bump
+	// doesn't silently break this test (see version.RequiredCommunityMCEVersion usage
+	// elsewhere in status_test.go for the same pattern).
+	t.Setenv("OPERATOR_PACKAGE", "advanced-cluster-management")
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-mce-ready"
+	// Seed a stale waiting condition so this test actually exercises the
+	// RemoveHubCondition clearing branch, rather than trivially passing because no
+	// condition was ever present to begin with.
+	stale := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, WaitingForMCEReason,
+		"Waiting for MultiClusterEngine test-mce-ready to report version")
+	SetHubCondition(&mch.Status, *stale)
+
+	result, err := r.waitForMCEReady(context.Background(), &mch)
+	if err != nil {
+		t.Fatalf("waitForMCEReady() unexpected error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("expected empty result, got: %+v", result)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorsv1.Progressing); condition != nil {
+		t.Errorf("expected stale Progressing condition to be cleared, got: %+v", condition)
+	}
+}
+
+// Test_waitForMCEReady_EnrichesVersionWaitMessageWithMCECondition verifies
+// that while waiting for MCE to report a version, the Progressing message
+// incorporates MCE's own latest condition (e.g. "Not all components
+// available") instead of leaving that whole window opaque from MCH's status
+// alone.
+func Test_waitForMCEReady_EnrichesVersionWaitMessageWithMCECondition(t *testing.T) {
+	registerScheme()
+
+	mce := resources.EmptyMCE()
+	mce.Name = "test-mce-with-condition"
+	mce.Labels = map[string]string{multiclusterengineutils.MCEManagedByLabel: "true"}
+	// Status.CurrentVersion intentionally left empty.
+	mce.Status.Conditions = []mcev1.MultiClusterEngineCondition{
+		{
+			Type:               mcev1.MultiClusterEngineAvailable,
+			Status:             metav1.ConditionFalse,
+			Reason:             "ComponentsUnavailable",
+			Message:            "Not all components available",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+
+	r := newTestReconciler(&mce)
+	t.Setenv(utils.UnitTestEnvVar, "false")
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-mce-condition-detail"
+
+	_, err := r.waitForMCEReady(context.Background(), &mch)
+	if err != nil {
+		t.Fatalf("waitForMCEReady() unexpected error: %v", err)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	hasReason := strings.Contains(condition.Message, "ComponentsUnavailable")
+	hasDetail := strings.Contains(condition.Message, "Not all components available")
+	if !hasReason || !hasDetail {
+		t.Errorf("expected message to include MCE's own condition detail, got %q", condition.Message)
+	}
+}
+
+func Test_resourceIdentifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		kind      string
+		namespace string
+		resName   string
+		want      string
+	}{
+		{
+			"namespaced resource", "ServiceAccount", "open-cluster-management", "console-chart",
+			"ServiceAccount open-cluster-management/console-chart",
+		},
+		{
+			"cluster-scoped resource", "ClusterRoleBinding", "", "open-cluster-management:console:clusterrolebinding",
+			"ClusterRoleBinding open-cluster-management:console:clusterrolebinding",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resourceIdentifier(tt.kind, tt.namespace, tt.resName); got != tt.want {
+				t.Errorf("resourceIdentifier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_ensureUnstructuredResource_NamesResourceInCondition verifies that the
+// Progressing condition set on resource creation names the specific
+// kind/namespace/name created, instead of the generic, unattributable
+// "Created new resource" message.
+func Test_ensureUnstructuredResource_NamesResourceInCondition(t *testing.T) {
+	r := newTestReconciler()
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-unstructured-create"
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+	u.SetName("my-configmap")
+	u.SetNamespace("open-cluster-management")
+
+	result, err := r.ensureUnstructuredResource(&mch, u)
+	if err != nil {
+		t.Fatalf("ensureUnstructuredResource() unexpected error: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("expected empty result, got: %+v", result)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if !strings.Contains(condition.Message, "ConfigMap") || !strings.Contains(condition.Message, "my-configmap") {
+		t.Errorf("expected message to name the created resource, got %q", condition.Message)
+	}
+}
+
+// Test_ensureNamespace_NamesResourceInCondition_WhenCreated verifies the
+// created-namespace condition names the namespace, and is only set when the
+// namespace is actually newly created.
+func Test_ensureNamespace_NamesResourceInCondition_WhenCreated(t *testing.T) {
+	r := newTestReconciler()
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-namespace-create"
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "new-namespace"}}
+
+	if _, err := r.ensureNamespace(&mch, ns); err != nil {
+		t.Fatalf("ensureNamespace() unexpected error: %v", err)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if !strings.Contains(condition.Message, "Namespace") || !strings.Contains(condition.Message, "new-namespace") {
+		t.Errorf("expected message to name the created namespace, got %q", condition.Message)
+	}
+}
+
+// Test_ensureNamespace_NoCondition_WhenAlreadyExists verifies that no
+// "created" condition is set when the namespace already existed (regression
+// guard: previously this condition was set unconditionally on every call).
+func Test_ensureNamespace_NoCondition_WhenAlreadyExists(t *testing.T) {
+	existingNs := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing-namespace"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+	r := newTestReconciler(existingNs)
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-namespace-exists"
+
+	if _, err := r.ensureNamespace(&mch, existingNs); err != nil {
+		t.Fatalf("ensureNamespace() unexpected error: %v", err)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorsv1.Progressing); condition != nil {
+		t.Errorf("expected no Progressing condition for a pre-existing namespace, got: %+v", condition)
+	}
+}
+
+// Test_ensureOperatorGroup_NamesResourceInCondition_WhenCreated verifies that
+// creating a new OperatorGroup (the zero-existing-groups path) names the
+// specific OperatorGroup in its condition message. The fake client doesn't
+// support the Server-Side Apply patch used by the real create path, so an
+// interceptor substitutes a plain Create to reach the condition-setting code.
+func Test_ensureOperatorGroup_NamesResourceInCondition_WhenCreated(t *testing.T) {
+	registerScheme()
+
+	ogNamespace := "test-namespace-create-og"
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch,
+			opts ...client.PatchOption) error {
+			if og, ok := obj.(*olmv1.OperatorGroup); ok {
+				return c.Create(ctx, og)
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+	mch := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mch", Namespace: ogNamespace},
+	}
+	desiredOG := &olmv1.OperatorGroup{ObjectMeta: metav1.ObjectMeta{Name: "desired-og", Namespace: ogNamespace}}
+
+	if _, err := r.ensureOperatorGroup(mch, desiredOG); err != nil {
+		t.Fatalf("ensureOperatorGroup() unexpected error: %v", err)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if !strings.Contains(condition.Message, "OperatorGroup") || !strings.Contains(condition.Message, "desired-og") {
+		t.Errorf("expected message to name the created OperatorGroup, got %q", condition.Message)
+	}
 }

--- a/controllers/console_notification.go
+++ b/controllers/console_notification.go
@@ -118,8 +118,9 @@ func (r *MultiClusterHubReconciler) removeMCEComplianceBanner(ctx context.Contex
 	return r.Client.Delete(ctx, notification)
 }
 
-func (r *MultiClusterHubReconciler) cleanupConsoleNotifications(_ logr.Logger, m *operatorsv1.MultiClusterHub) error {
-	return r.Client.DeleteAllOf(context.TODO(), &consolev1.ConsoleNotification{}, client.MatchingLabels{
+func (r *MultiClusterHubReconciler) cleanupConsoleNotifications(ctx context.Context, _ logr.Logger,
+	m *operatorsv1.MultiClusterHub) error {
+	return r.Client.DeleteAllOf(ctx, &consolev1.ConsoleNotification{}, client.MatchingLabels{
 		"installer.name":      m.GetName(),
 		"installer.namespace": m.GetNamespace(),
 	})

--- a/controllers/finalizers.go
+++ b/controllers/finalizers.go
@@ -30,8 +30,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *MultiClusterHubReconciler) cleanupClusterRoles(reqLogger logr.Logger, m *operatorsv1.MultiClusterHub) error {
-	err := r.Client.DeleteAllOf(context.TODO(), &rbacv1.ClusterRole{}, client.MatchingLabels{
+func (r *MultiClusterHubReconciler) cleanupClusterRoles(ctx context.Context, reqLogger logr.Logger,
+	m *operatorsv1.MultiClusterHub) error {
+	err := r.Client.DeleteAllOf(ctx, &rbacv1.ClusterRole{}, client.MatchingLabels{
 		"installer.name":      m.GetName(),
 		"installer.namespace": m.GetNamespace(),
 	})
@@ -49,8 +50,9 @@ func (r *MultiClusterHubReconciler) cleanupClusterRoles(reqLogger logr.Logger, m
 	return nil
 }
 
-func (r *MultiClusterHubReconciler) cleanupClusterRoleBindings(reqLogger logr.Logger, m *operatorsv1.MultiClusterHub) error {
-	err := r.Client.DeleteAllOf(context.TODO(), &rbacv1.ClusterRoleBinding{}, client.MatchingLabels{
+func (r *MultiClusterHubReconciler) cleanupClusterRoleBindings(ctx context.Context, reqLogger logr.Logger,
+	m *operatorsv1.MultiClusterHub) error {
+	err := r.Client.DeleteAllOf(ctx, &rbacv1.ClusterRoleBinding{}, client.MatchingLabels{
 		"installer.name":      m.GetName(),
 		"installer.namespace": m.GetNamespace(),
 	})
@@ -67,9 +69,8 @@ func (r *MultiClusterHubReconciler) cleanupClusterRoleBindings(reqLogger logr.Lo
 	return nil
 }
 
-func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m *operatorsv1.MultiClusterHub) error {
-	ctx := context.Background()
-
+func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(ctx context.Context, log logr.Logger,
+	m *operatorsv1.MultiClusterHub) error {
 	mce, err := multiclusterengineutils.GetManagedMCE(ctx, r.Client)
 	if err != nil && !apimeta.IsNoMatchError(err) {
 		return err
@@ -85,6 +86,10 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 		if err != nil && (!errors.IsNotFound(err) || !errors.IsGone(err)) {
 			return err
 		}
+		log.Info("Waiting for MultiClusterEngine to terminate", "name", mce.GetName())
+		condition := NewHubCondition(operatorsv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason,
+			fmt.Sprintf("Waiting for MultiClusterEngine %s to terminate", mce.GetName()))
+		SetHubCondition(&m.Status, *condition)
 		return fmt.Errorf("MCE has not yet been terminated")
 	}
 
@@ -94,7 +99,8 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 
 	// Clean up OLM resources based on detected OLM version
 	operandNs := multiclusterengine.OperandNamespace()
-	if r.OLMVersion == "v1" {
+	switch r.OLMVersion {
+	case "v1":
 		// OLM v1 cleanup path (ClusterExtension + ServiceAccount)
 		mceCE, err := v1.GetManagedMCEClusterExtension(ctx, r.Client)
 		if err != nil {
@@ -115,6 +121,10 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 			// Check if still exists
 			err = r.Client.Get(ctx, types.NamespacedName{Name: mceCE.Name}, mceCE)
 			if err == nil {
+				log.Info("Waiting for ClusterExtension to terminate", "name", mceCE.Name)
+				condition := NewHubCondition(operatorsv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason,
+					fmt.Sprintf("Waiting for ClusterExtension %s to terminate", mceCE.Name))
+				SetHubCondition(&m.Status, *condition)
 				return fmt.Errorf("ClusterExtension has not yet been terminated")
 			}
 		}
@@ -126,7 +136,7 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 			return err
 		}
 
-	} else if r.OLMVersion == "v0" {
+	case "v0":
 		// OLM v0 cleanup path (Subscription + CSV + OperatorGroup)
 		mceSub, err := v0.GetManagedMCESubscription(ctx, r.Client)
 		if err != nil {
@@ -150,6 +160,10 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 					types.NamespacedName{Name: csv.GetName(), Namespace: namespace},
 					csv)
 				if err == nil {
+					log.Info("Waiting for CSV to terminate", "name", csv.GetName(), "namespace", namespace)
+					condition := NewHubCondition(operatorsv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason,
+						fmt.Sprintf("Waiting for CSV %s to terminate", csv.GetName()))
+					SetHubCondition(&m.Status, *condition)
 					return fmt.Errorf("CSV has not yet been terminated")
 				}
 			}
@@ -163,6 +177,10 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 				if err != nil && !errors.IsNotFound(err) {
 					return err
 				}
+				log.Info("Waiting for Subscription to terminate", "name", mceSub.Name, "namespace", namespace)
+				condition := NewHubCondition(operatorsv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason,
+					fmt.Sprintf("Waiting for Subscription %s to terminate", mceSub.Name))
+				SetHubCondition(&m.Status, *condition)
 				return fmt.Errorf("subscription has not yet been terminated")
 			}
 		}
@@ -179,10 +197,15 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 	err = r.Client.Get(ctx, types.NamespacedName{Name: multiclusterengine.Namespace().Name}, mceNamespace)
 	if m.Namespace != multiclusterengine.Namespace().Name {
 		if err == nil {
+			nsName := multiclusterengine.Namespace().Name
 			err = r.Client.Delete(ctx, multiclusterengine.Namespace())
 			if err != nil && !errors.IsNotFound(err) {
 				return err
 			}
+			log.Info("Waiting for MCE namespace to terminate", "namespace", nsName)
+			condition := NewHubCondition(operatorsv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason,
+				fmt.Sprintf("Waiting for namespace %s to terminate", nsName))
+			SetHubCondition(&m.Status, *condition)
 			return fmt.Errorf("namespace has not yet been terminated")
 		}
 	} else {
@@ -192,21 +215,51 @@ func (r *MultiClusterHubReconciler) cleanupMultiClusterEngine(log logr.Logger, m
 	log.Info("MultiClusterEngine finalized")
 	return nil
 }
-func (r *MultiClusterHubReconciler) cleanupNamespaces(reqLogger logr.Logger, m *operatorsv1.MultiClusterHub) error {
-	ctx := context.Background()
+func (r *MultiClusterHubReconciler) cleanupNamespaces(ctx context.Context, reqLogger logr.Logger,
+	m *operatorsv1.MultiClusterHub) error {
 	clusterBackupNamespace := &corev1.Namespace{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: utils.ClusterSubscriptionNamespace}, clusterBackupNamespace)
-	if err == nil {
-		err = r.Client.Delete(ctx, clusterBackupNamespace)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-		return fmt.Errorf("namespace has not yet been terminated")
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		// A real lookup failure (e.g. API server hiccup, RBAC issue) is not the same as
+		// "namespace doesn't exist" — return it instead of silently treating it as success,
+		// which would let finalization proceed as if the backup namespace were gone.
+		return err
 	}
 
-	return nil
+	err = r.Client.Delete(ctx, clusterBackupNamespace)
+	if errors.IsNotFound(err) {
+		// Already gone (e.g. deleted concurrently between the Get above and this
+		// Delete) — nothing left to wait for.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf("Waiting for namespace %s to terminate", utils.ClusterSubscriptionNamespace)
+	if clusterBackupNamespace.Status.Phase == corev1.NamespaceTerminating {
+		for _, c := range clusterBackupNamespace.Status.Conditions {
+			if c.Type == corev1.NamespaceDeletionContentFailure && c.Status == corev1.ConditionTrue {
+				msg = fmt.Sprintf("Namespace %s stuck terminating: %s",
+					utils.ClusterSubscriptionNamespace, c.Message)
+				break
+			}
+		}
+	}
+
+	reqLogger.Info("Waiting for namespace to terminate",
+		"namespace", utils.ClusterSubscriptionNamespace,
+		"phase", clusterBackupNamespace.Status.Phase)
+	condition := NewHubCondition(operatorsv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason, msg)
+	SetHubCondition(&m.Status, *condition)
+
+	return fmt.Errorf("namespace has not yet been terminated")
 }
-func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logger, m *operatorsv1.MultiClusterHub) error {
+func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(ctx context.Context, reqLogger logr.Logger,
+	m *operatorsv1.MultiClusterHub) error {
 	installerLabels := client.MatchingLabels{
 		"installer.name":      m.GetName(),
 		"installer.namespace": m.GetNamespace(),
@@ -226,13 +279,13 @@ func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logge
 		Version: "v1",
 	})
 
-	err := r.Client.List(context.TODO(), appSubList, installerLabels)
+	err := r.Client.List(ctx, appSubList, installerLabels)
 	if err != nil && !errors.IsNotFound(err) {
 		reqLogger.Error(err, "Error while listing appsubs")
 		return err
 	}
 
-	err = r.Client.List(context.TODO(), helmReleaseList, installerLabels)
+	err = r.Client.List(ctx, helmReleaseList, installerLabels)
 	if err != nil && !errors.IsNotFound(err) {
 		reqLogger.Error(err, "Error while listing helmreleases")
 		return err
@@ -250,7 +303,7 @@ func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logge
 				Version: "v1",
 			})
 
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Client.Get(ctx, types.NamespacedName{
 				Name:      helmReleaseName,
 				Namespace: appsub.GetNamespace(),
 			}, helmRelease)
@@ -264,7 +317,7 @@ func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logge
 			}
 
 			utils.AddInstallerLabel(helmRelease, m.GetName(), m.GetNamespace())
-			err = r.Client.Update(context.TODO(), helmRelease)
+			err = r.Client.Update(ctx, helmRelease)
 			if err != nil {
 				reqLogger.Error(err, fmt.Sprintf("Error updating helmrelease: %s", helmReleaseName))
 				return err
@@ -275,7 +328,7 @@ func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logge
 	if len(appSubList.Items) > 0 {
 		reqLogger.Info("Terminating App Subscriptions")
 		for i, appsub := range appSubList.Items {
-			err = r.Client.Delete(context.TODO(), &appSubList.Items[i])
+			err = r.Client.Delete(ctx, &appSubList.Items[i])
 			if err != nil {
 				reqLogger.Error(err, fmt.Sprintf("Error terminating sub: %s", appsub.GetName()))
 				return err
@@ -294,9 +347,8 @@ func (r *MultiClusterHubReconciler) cleanupAppSubscriptions(reqLogger logr.Logge
 	return nil
 }
 
-func (r *MultiClusterHubReconciler) orphanOwnedMultiClusterEngine(reqLogger logr.Logger, m *operatorsv1.MultiClusterHub) error {
-	ctx := context.Background()
-
+func (r *MultiClusterHubReconciler) orphanOwnedMultiClusterEngine(ctx context.Context, reqLogger logr.Logger,
+	m *operatorsv1.MultiClusterHub) error {
 	mce, err := multiclusterengineutils.GetManagedMCE(ctx, r.Client)
 	if mce == nil {
 		// MCE does not exist

--- a/controllers/finalizers_test.go
+++ b/controllers/finalizers_test.go
@@ -2,12 +2,27 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
+	subv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	backplanev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
+	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine"
+	mceolmv0 "github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine/olm/v0"
+	mceolmv1 "github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengine/olm/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengineutils"
+	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	resources "github.com/stolostron/multiclusterhub-operator/test/unit-tests"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestBackupNamespace(t *testing.T) {
@@ -102,11 +117,11 @@ func Test_cleanupMultiClusterEngine(t *testing.T) {
 			}
 
 			// If MCE exists the first time it will return an error.
-			if err := recon.cleanupMultiClusterEngine(log, &tt.mch); err == nil {
+			if err := recon.cleanupMultiClusterEngine(context.TODO(), log, &tt.mch); err == nil {
 				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
 			}
 
-			if err := recon.cleanupMultiClusterEngine(log, &tt.mch); err != nil {
+			if err := recon.cleanupMultiClusterEngine(context.TODO(), log, &tt.mch); err != nil {
 				t.Errorf("failed to cleanup MultiClusterEngine: %v", err)
 			}
 		})
@@ -138,13 +153,13 @@ func Test_cleanupMultiClusterEngine_OLMv1(t *testing.T) {
 	recon.OLMVersion = "v1"
 
 	// First call should return error (MCE still exists)
-	err := recon.cleanupMultiClusterEngine(log, &mch)
+	err := recon.cleanupMultiClusterEngine(context.TODO(), log, &mch)
 	if err == nil {
 		t.Error("expected error on first cleanup call, got nil")
 	}
 
 	// Second call should succeed (MCE deleted)
-	err = recon.cleanupMultiClusterEngine(log, &mch)
+	err = recon.cleanupMultiClusterEngine(context.TODO(), log, &mch)
 	if err != nil {
 		t.Errorf("expected no error on second cleanup call, got: %v", err)
 	}
@@ -178,17 +193,551 @@ func Test_cleanupMultiClusterEngine_OLMv0(t *testing.T) {
 	recon.OLMVersion = "v0"
 
 	// First call should return error (MCE still exists)
-	err := recon.cleanupMultiClusterEngine(log, &mch)
+	err := recon.cleanupMultiClusterEngine(context.TODO(), log, &mch)
 	if err == nil {
 		t.Error("expected error on first cleanup call, got nil")
 	}
 
 	// Second call should succeed (MCE deleted)
-	err = recon.cleanupMultiClusterEngine(log, &mch)
+	err = recon.cleanupMultiClusterEngine(context.TODO(), log, &mch)
 	if err != nil {
 		t.Errorf("expected no error on second cleanup call, got: %v", err)
 	}
 
 	// Reset OLM version
 	recon.OLMVersion = ""
+}
+
+// --- HubCondition tests ---
+//
+// The following tests cover the status condition updates added so that
+// `kubectl get mch` surfaces which resource is blocking finalization
+// (Terminating conditions) or component removal (Progressing conditions).
+
+// Test_cleanupMultiClusterEngine_SetsTerminatingCondition_MCE verifies that
+// while a preexisting MultiClusterEngine is still being deleted, a
+// Terminating/DeleteTimestampReason condition naming the MCE is recorded on
+// the MultiClusterHub status.
+func Test_cleanupMultiClusterEngine_SetsTerminatingCondition_MCE(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-mce-condition"
+
+	mce := resources.EmptyMCE()
+	mce.Name = "test-mce-condition"
+	mce.Labels = map[string]string{
+		"installer.name":                          mch.GetName(),
+		"installer.namespace":                     mch.GetNamespace(),
+		multiclusterengineutils.MCEManagedByLabel: "true",
+	}
+
+	r := newTestReconciler(&mce)
+
+	// First call finds the MCE still present, deletes it, and should report
+	// that it is waiting for termination.
+	err := r.cleanupMultiClusterEngine(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while MCE is still terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, mce.GetName()) {
+		t.Errorf("expected message to mention MCE name %q, got %q", mce.GetName(), condition.Message)
+	}
+}
+
+// Test_cleanupMultiClusterEngine_SetsTerminatingCondition_Namespace verifies
+// that when the MCE operand namespace is still present (and owned
+// separately from the MCH namespace), a Terminating condition naming the
+// namespace is recorded and the namespace delete is requested.
+func Test_cleanupMultiClusterEngine_SetsTerminatingCondition_Namespace(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-ns-condition"
+	// EmptyMCH() defaults to namespace "open-cluster-management", which is
+	// distinct from the MCE operand namespace ("multicluster-engine").
+
+	mceNamespace := multiclusterengine.Namespace()
+
+	r := newTestReconciler(mceNamespace)
+	// UNIT_TEST is normally forced to "true" by the Ginkgo suite's
+	// BeforeSuite; pin it explicitly here so this test's expected code path
+	// (past the IsUnitTest short-circuit) is exercised deterministically
+	// regardless of test execution order.
+	t.Setenv(utils.UnitTestEnvVar, "false")
+	r.OLMVersion = "" // skip OLM-specific cleanup, go straight to namespace check
+
+	err := r.cleanupMultiClusterEngine(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while MCE namespace is still terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, mceNamespace.GetName()) {
+		t.Errorf("expected message to mention namespace %q, got %q", mceNamespace.GetName(), condition.Message)
+	}
+
+	// The namespace should have a delete request issued against it.
+	ns := &corev1.Namespace{}
+	getErr := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(mceNamespace), ns)
+	if getErr == nil && ns.DeletionTimestamp == nil {
+		t.Error("expected namespace deletion to have been requested")
+	}
+}
+
+// Test_cleanupMultiClusterEngine_NoNamespaceCondition_WhenSharedNamespace
+// verifies that no Terminating condition is set (and no error returned) when
+// the MCH and MCE share a namespace, since the namespace shouldn't be
+// deleted out from under the MCH itself.
+func Test_cleanupMultiClusterEngine_NoNamespaceCondition_WhenSharedNamespace(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-shared-ns"
+	mch.Namespace = multiclusterengine.OperandNamespace()
+
+	r := newTestReconciler()
+	t.Setenv(utils.UnitTestEnvVar, "false")
+	r.OLMVersion = ""
+
+	err := r.cleanupMultiClusterEngine(context.TODO(), log, &mch)
+	if err != nil {
+		t.Fatalf("expected no error when MCH shares namespace with MCE, got: %v", err)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorv1.Terminating); condition != nil {
+		t.Errorf("expected no Terminating condition, got: %+v", condition)
+	}
+}
+
+// Test_cleanupMultiClusterEngine_OLMv1_SetsTerminatingCondition_ClusterExtension
+// verifies that when the OLM v1 MCE ClusterExtension is deleted but still
+// present (e.g. blocked by a finalizer), a Terminating condition naming the
+// ClusterExtension is recorded.
+func Test_cleanupMultiClusterEngine_OLMv1_SetsTerminatingCondition_ClusterExtension(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-ce-condition"
+
+	ce := mceolmv1.NewClusterExtension(&mch)
+	// Simulate a stuck deletion: the fake client keeps a finalized object
+	// around (with a DeletionTimestamp) until its finalizers are cleared.
+	ce.Finalizers = []string{"test.io/block-deletion"}
+
+	r := newTestReconciler(ce)
+	t.Setenv(utils.UnitTestEnvVar, "false")
+	r.OLMVersion = "v1"
+
+	err := r.cleanupMultiClusterEngine(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while ClusterExtension is still terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, ce.GetName()) {
+		t.Errorf("expected message to mention ClusterExtension name %q, got %q", ce.GetName(), condition.Message)
+	}
+}
+
+// Test_cleanupMultiClusterEngine_OLMv0_SetsTerminatingCondition_CSV verifies
+// that when the OLM v0 MCE ClusterServiceVersion is deleted but still
+// present, a Terminating condition naming the CSV is recorded.
+func Test_cleanupMultiClusterEngine_OLMv0_SetsTerminatingCondition_CSV(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-csv-condition"
+
+	sub := mceolmv0.NewSubscription(&mch, nil, nil)
+	sub.Status.CurrentCSV = "multiclusterengine.v1.0.0"
+
+	csv := &subv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       sub.Status.CurrentCSV,
+			Namespace:  sub.GetNamespace(),
+			Finalizers: []string{"test.io/block-deletion"},
+		},
+	}
+
+	r := newTestReconciler(sub, csv)
+	t.Setenv(utils.UnitTestEnvVar, "false")
+	r.OLMVersion = "v0"
+
+	err := r.cleanupMultiClusterEngine(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while CSV is still terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, csv.GetName()) {
+		t.Errorf("expected message to mention CSV name %q, got %q", csv.GetName(), condition.Message)
+	}
+}
+
+// Test_cleanupMultiClusterEngine_OLMv0_SetsTerminatingCondition_Subscription
+// verifies that when the OLM v0 MCE Subscription is deleted but still
+// present (no CSV to resolve), a Terminating condition naming the
+// Subscription is recorded.
+func Test_cleanupMultiClusterEngine_OLMv0_SetsTerminatingCondition_Subscription(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-sub-condition"
+
+	sub := mceolmv0.NewSubscription(&mch, nil, nil)
+	// Leave Status.CurrentCSV empty so the CSV lookup is skipped and the
+	// Subscription-terminating branch is what gets exercised.
+	sub.Finalizers = []string{"test.io/block-deletion"}
+
+	r := newTestReconciler(sub)
+	t.Setenv(utils.UnitTestEnvVar, "false")
+	r.OLMVersion = "v0"
+
+	err := r.cleanupMultiClusterEngine(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while Subscription is still terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, sub.GetName()) {
+		t.Errorf("expected message to mention Subscription name %q, got %q", sub.GetName(), condition.Message)
+	}
+}
+
+// Test_cleanupNamespaces_SetsTerminatingCondition verifies that while the
+// cluster-backup namespace is still present, a Terminating condition naming
+// the namespace is recorded.
+func Test_cleanupNamespaces_SetsTerminatingCondition(t *testing.T) {
+	backupNs := BackupNamespace()
+	r := newTestReconciler(backupNs)
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-backup-ns"
+
+	err := r.cleanupNamespaces(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while backup namespace is still terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, utils.ClusterSubscriptionNamespace) {
+		t.Errorf("expected message to mention namespace %q, got %q", utils.ClusterSubscriptionNamespace, condition.Message)
+	}
+}
+
+// Test_cleanupNamespaces_SetsTerminatingCondition_StuckMessage verifies that
+// when the backup namespace reports a NamespaceDeletionContentFailure
+// condition, the surfaced Terminating condition message includes the
+// underlying blocking-resource detail instead of the generic waiting text.
+func Test_cleanupNamespaces_SetsTerminatingCondition_StuckMessage(t *testing.T) {
+	backupNs := BackupNamespace()
+	backupNs.Status = corev1.NamespaceStatus{
+		Phase: corev1.NamespaceTerminating,
+		Conditions: []corev1.NamespaceCondition{
+			{
+				Type:    corev1.NamespaceDeletionContentFailure,
+				Status:  corev1.ConditionTrue,
+				Message: "some-resource.example.com \"blocker\" still present",
+			},
+		},
+	}
+
+	r := newTestReconciler(backupNs)
+	// Update status subresource explicitly since fake client Create ignores
+	// status by default for typed objects with a status subresource... use
+	// Status().Update to ensure the condition is persisted.
+	if err := r.Client.Status().Update(context.TODO(), backupNs); err != nil {
+		t.Fatalf("failed to set namespace status: %v", err)
+	}
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-backup-ns-stuck"
+
+	err := r.cleanupNamespaces(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while backup namespace is stuck terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if !strings.Contains(condition.Message, "stuck terminating") {
+		t.Errorf("expected message to mention 'stuck terminating', got %q", condition.Message)
+	}
+	if !strings.Contains(condition.Message, "blocker") {
+		t.Errorf("expected message to mention blocking resource, got %q", condition.Message)
+	}
+}
+
+// Test_cleanupNamespaces_NoCondition_WhenNamespaceAbsent verifies that no
+// error or condition is set once the backup namespace has been fully
+// removed.
+func Test_cleanupNamespaces_NoCondition_WhenNamespaceAbsent(t *testing.T) {
+	r := newTestReconciler()
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-backup-ns-absent"
+
+	if err := r.cleanupNamespaces(context.TODO(), log, &mch); err != nil {
+		t.Fatalf("expected no error when backup namespace is absent, got: %v", err)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorv1.Terminating); condition != nil {
+		t.Errorf("expected no Terminating condition, got: %+v", condition)
+	}
+}
+
+// Test_cleanupNamespaces_NoError_WhenDeleteRacesToNotFound verifies that if
+// the backup namespace is deleted concurrently between the initial Get and
+// the Delete call, cleanupNamespaces recognizes it's already gone and
+// returns nil immediately, instead of reporting "waiting to terminate" and
+// returning a retry error for a namespace that's no longer there.
+func Test_cleanupNamespaces_NoError_WhenDeleteRacesToNotFound(t *testing.T) {
+	backupNs := BackupNamespace()
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, ok := obj.(*corev1.Namespace); ok {
+				return apierrors.NewNotFound(corev1.Resource("namespaces"), obj.GetName())
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	}, backupNs)
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-backup-ns-delete-race"
+
+	if err := r.cleanupNamespaces(context.TODO(), log, &mch); err != nil {
+		t.Fatalf("expected no error when Delete races to NotFound, got: %v", err)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorv1.Terminating); condition != nil {
+		t.Errorf("expected no Terminating condition, got: %+v", condition)
+	}
+}
+
+// Test_cleanupNamespaces_ReturnsError_OnGetFailure verifies that a real
+// lookup failure (not NotFound) on the initial namespace Get is returned as
+// an error, instead of being silently treated the same as "namespace
+// doesn't exist" — which would let finalization proceed as if the backup
+// namespace were already gone.
+func Test_cleanupNamespaces_ReturnsError_OnGetFailure(t *testing.T) {
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object,
+			opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.Namespace); ok && key.Name == utils.ClusterSubscriptionNamespace {
+				return apierrors.NewInternalError(fmt.Errorf("simulated get failure"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-backup-ns-get-error"
+
+	err := r.cleanupNamespaces(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected the Get error to be returned, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated get failure") {
+		t.Errorf("expected the underlying Get error to propagate, got: %v", err)
+	}
+}
+
+func mchLabeledAppSubscription(name, namespace, mchName, mchNamespace string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apps.open-cluster-management.io",
+		Kind:    "Subscription",
+		Version: "v1",
+	})
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetUID(types.UID("test-uid-12345"))
+	u.SetLabels(map[string]string{
+		"installer.name":      mchName,
+		"installer.namespace": mchNamespace,
+	})
+	return u
+}
+
+// Test_cleanupAppSubscriptions_SetsProgressingCondition verifies that when
+// an MCH-owned app subscription still needs to be terminated, a
+// Progressing/HelmReleaseTerminatingReason condition is recorded and the
+// subscription is deleted.
+func Test_cleanupAppSubscriptions_SetsProgressingCondition(t *testing.T) {
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-appsub-condition"
+
+	appSub := mchLabeledAppSubscription("test-appsub", mch.GetNamespace(), mch.GetName(), mch.GetNamespace())
+	r := newTestReconciler(appSub)
+
+	err := r.cleanupAppSubscriptions(context.TODO(), log, &mch)
+	if err == nil {
+		t.Fatal("expected error while waiting for helmreleases to terminate, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != HelmReleaseTerminatingReason {
+		t.Errorf("expected reason %q, got %q", HelmReleaseTerminatingReason, condition.Reason)
+	}
+
+	// The app subscription should have been deleted as part of cleanup.
+	appSubList := &unstructured.UnstructuredList{}
+	appSubList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apps.open-cluster-management.io",
+		Kind:    "SubscriptionList",
+		Version: "v1",
+	})
+	if err := r.Client.List(context.TODO(), appSubList, client.MatchingLabels{
+		"installer.name":      mch.GetName(),
+		"installer.namespace": mch.GetNamespace(),
+	}); err != nil {
+		t.Fatalf("failed to list app subscriptions: %v", err)
+	}
+	if len(appSubList.Items) != 0 {
+		t.Errorf("expected app subscription to be deleted, found %d remaining", len(appSubList.Items))
+	}
+}
+
+// Test_cleanupAppSubscriptions_NoCondition_WhenNoneOwned verifies that no
+// error or condition is set when there are no MCH-owned app subscriptions or
+// helm releases left to terminate.
+func Test_cleanupAppSubscriptions_NoCondition_WhenNoneOwned(t *testing.T) {
+	r := newTestReconciler()
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-appsub-none"
+
+	if err := r.cleanupAppSubscriptions(context.TODO(), log, &mch); err != nil {
+		t.Fatalf("expected no error when no app subscriptions exist, got: %v", err)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorv1.Progressing); condition != nil {
+		t.Errorf("expected no Progressing condition, got: %+v", condition)
+	}
+}
+
+// Test_finalizeHub_SetsTerminatingCondition_ComponentName verifies that when
+// a component's teardown (via ensureNoComponent/InternalHubComponent) needs a
+// requeue, finalizeHub records a Terminating condition naming the specific
+// component still being torn down, instead of only logging it. This is the
+// first phase of finalization (looping over operatorv1.MCHComponents) which
+// runs before the more granular per-resource cleanup steps
+// (cleanupNamespaces, cleanupMultiClusterEngine, etc.) even start.
+func Test_finalizeHub_SetsTerminatingCondition_ComponentName(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-finalize-component"
+
+	// operatorv1.Appsub ("app-lifecycle") is the first entry in MCHComponents.
+	// Give its InternalHubComponent a finalizer so Delete() only marks it for
+	// deletion (fake client behavior), forcing ensureNoInternalHubComponent to
+	// report "still terminating" and requeue.
+	ihc := &operatorv1.InternalHubComponent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       operatorv1.Appsub,
+			Namespace:  mch.GetNamespace(),
+			Finalizers: []string{"test.io/block-deletion"},
+		},
+	}
+
+	r := newTestReconciler(ihc)
+
+	err := r.finalizeHub(context.TODO(), log, &mch, false, false)
+	if err == nil {
+		t.Fatal("expected error while component is still terminating, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, operatorv1.Appsub) {
+		t.Errorf("expected message to mention component %q, got %q", operatorv1.Appsub, condition.Message)
+	}
+}
+
+// Test_finalizeHub_SetsTerminatingCondition_ComponentError verifies that when
+// a component's teardown fails with a genuine error (not just "still
+// terminating, needs requeue"), finalizeHub also records a Terminating
+// condition naming the component and the underlying error, matching its
+// sibling "needs requeue" branch instead of leaving this path with no
+// condition at all.
+func Test_finalizeHub_SetsTerminatingCondition_ComponentError(t *testing.T) {
+	registerScheme()
+
+	mch := resources.EmptyMCH()
+	mch.Name = "test-mch-finalize-component-error"
+
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object,
+			opts ...client.GetOption) error {
+			if _, ok := obj.(*operatorv1.InternalHubComponent); ok && key.Name == operatorv1.Appsub {
+				return apierrors.NewInternalError(fmt.Errorf("simulated get failure"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	err := r.finalizeHub(context.TODO(), log, &mch, false, false)
+	if err == nil {
+		t.Fatal("expected error while component removal fails, got nil")
+	}
+
+	condition := GetHubCondition(mch.Status, operatorv1.Terminating)
+	if condition == nil {
+		t.Fatal("expected Terminating condition to be set")
+	}
+	if condition.Reason != DeleteTimestampReason {
+		t.Errorf("expected reason %q, got %q", DeleteTimestampReason, condition.Reason)
+	}
+	if !strings.Contains(condition.Message, operatorv1.Appsub) {
+		t.Errorf("expected message to mention component %q, got %q", operatorv1.Appsub, condition.Message)
+	}
+	if !strings.Contains(condition.Message, "simulated get failure") {
+		t.Errorf("expected message to include the underlying error detail, got %q", condition.Message)
+	}
 }

--- a/controllers/lifecycle.go
+++ b/controllers/lifecycle.go
@@ -39,9 +39,9 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operatorv1.MultiClusterHub, ocpConsole,
-	isSTSEnabled bool) error {
-	if err := r.cleanupAppSubscriptions(reqLogger, m); err != nil {
+func (r *MultiClusterHubReconciler) finalizeHub(ctx context.Context, reqLogger logr.Logger,
+	m *operatorv1.MultiClusterHub, ocpConsole, isSTSEnabled bool) error {
+	if err := r.cleanupAppSubscriptions(ctx, reqLogger, m); err != nil {
 		return err
 	}
 
@@ -53,24 +53,41 @@ func (r *MultiClusterHubReconciler) finalizeHub(reqLogger logr.Logger, m *operat
 			continue
 		}
 
-		result, err := r.ensureNoComponent(context.TODO(), m, c, r.CacheSpec, isSTSEnabled)
-		if err != nil {
-			return err
-		}
+		result, err := r.ensureNoComponent(ctx, m, c, r.CacheSpec, isSTSEnabled)
+		if err != nil || result != (ctrl.Result{}) {
+			msg := fmt.Sprintf("Waiting for component %s to terminate", c)
+			if err != nil {
+				msg = fmt.Sprintf("%s: %s", msg, err.Error())
+			}
+			condition := NewHubCondition(operatorv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason, msg)
+			SetHubCondition(&m.Status, *condition)
 
-		if result != (ctrl.Result{}) {
+			if err != nil {
+				reqLogger.Info("Component removal incomplete", "component", c, "reason", err.Error())
+				return err
+			}
+			reqLogger.Info("Component removal requires requeue", "component", c)
 			return errors.NewBadRequest(fmt.Sprintf("Requeue needed for component: %v", c))
 		}
 	}
 
-	cleanupFunctions := []func(reqLogger logr.Logger, m *operatorv1.MultiClusterHub) error{
-		r.cleanupNamespaces, r.cleanupClusterRoles, r.cleanupClusterRoleBindings,
-		r.cleanupMultiClusterEngine, r.orphanOwnedMultiClusterEngine,
-		r.cleanupConsoleNotifications,
+	type cleanupStep struct {
+		name string
+		fn   func(context.Context, logr.Logger, *operatorv1.MultiClusterHub) error
 	}
 
-	for _, cleanupFn := range cleanupFunctions {
-		if err := cleanupFn(reqLogger, m); err != nil {
+	steps := []cleanupStep{
+		{"Namespaces", r.cleanupNamespaces},
+		{"ClusterRoles", r.cleanupClusterRoles},
+		{"ClusterRoleBindings", r.cleanupClusterRoleBindings},
+		{"MultiClusterEngine", r.cleanupMultiClusterEngine},
+		{"OrphanMCE", r.orphanOwnedMultiClusterEngine},
+		{"ConsoleNotifications", r.cleanupConsoleNotifications},
+	}
+
+	for _, step := range steps {
+		if err := step.fn(ctx, reqLogger, m); err != nil {
+			reqLogger.Info("Finalization step incomplete", "step", step.name, "reason", err.Error())
 			return err
 		}
 	}
@@ -155,7 +172,7 @@ func (r *MultiClusterHubReconciler) deployResources(reqLogger logr.Logger, m *op
 		message := mergeErrors(errs)
 		err := fmt.Errorf("failed to render resources: %s", message)
 		reqLogger.Error(err, err.Error())
-		return CRDRenderReason, err
+		return ResourceRenderReason, err
 	}
 
 	for _, res := range resources {

--- a/controllers/managedcluster.go
+++ b/controllers/managedcluster.go
@@ -11,6 +11,7 @@ import (
 	utils "github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -65,22 +66,35 @@ func getKlusterletAddonConfig(m *operatorsv1.MultiClusterHub) *unstructured.Unst
 func (r *MultiClusterHubReconciler) ensureKlusterletAddonConfig(m *operatorsv1.MultiClusterHub) (ctrl.Result, error) {
 	ctx := context.Background()
 
-	r.Log.Info(fmt.Sprintf("Checking for ManagedCluster %v namespace", m.Spec.LocalClusterName))
+	r.Log.Info("Checking for ManagedCluster namespace", "namespace", m.Spec.LocalClusterName)
 	ns := &corev1.Namespace{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: m.Spec.LocalClusterName}, ns)
 	if err != nil && errors.IsNotFound(err) {
-		r.Log.Info(fmt.Sprintf("Waiting for %v namespace to be created", m.Spec.LocalClusterName))
+		r.Log.Info("Waiting for namespace to be created", "namespace", m.Spec.LocalClusterName)
+		condition := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, WaitingForNamespaceReason,
+			fmt.Sprintf("Waiting for ManagedCluster namespace %s to be created", m.Spec.LocalClusterName))
+		SetHubCondition(&m.Status, *condition)
+
 		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	} else if err != nil {
-		r.Log.Error(err, fmt.Sprintf("Failed to check for %v namespace", m.Spec.LocalClusterName))
+		r.Log.Error(err, "Failed to check for ManagedCluster namespace", "namespace", m.Spec.LocalClusterName)
 		return ctrl.Result{}, err
 	}
 
+	// Namespace exists — clear any stale "waiting for namespace" condition
+	cond := GetHubCondition(m.Status, operatorsv1.Progressing)
+	if cond != nil && cond.Reason == WaitingForNamespaceReason {
+		RemoveHubCondition(&m.Status, operatorsv1.Progressing)
+	}
+
+	// Ensure the KlusterletAddonConfig resource exists in the ManagedCluster namespace
+	// and reflects the desired state, creating or updating it as needed.
 	klusterletaddonconfig := getKlusterletAddonConfig(m)
 	nsn := types.NamespacedName{
 		Name:      m.Spec.LocalClusterName,
 		Namespace: m.Spec.LocalClusterName,
 	}
+
 	err = r.Client.Get(ctx, nsn, klusterletaddonconfig)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -92,6 +106,7 @@ func (r *MultiClusterHubReconciler) ensureKlusterletAddonConfig(m *operatorsv1.M
 				r.Log.Error(err, "Failed to create klusterletaddonconfig resource")
 				return ctrl.Result{}, err
 			}
+
 			// KlusterletAddonConfig was successful
 			r.Log.Info("Created a new KlusterletAddonConfig")
 			return ctrl.Result{}, nil

--- a/controllers/managedcluster_test.go
+++ b/controllers/managedcluster_test.go
@@ -1,8 +1,22 @@
+// Copyright Contributors to the Open Cluster Management project
+
 package controllers
 
 import (
+	"context"
+	"fmt"
+	"testing"
+
+	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func LocalClusterNamespace(name string) *corev1.Namespace {
@@ -14,5 +28,367 @@ func LocalClusterNamespace(name string) *corev1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
+	}
+}
+
+func newTestMCHForManagedCluster(localClusterName string,
+	components ...operatorsv1.ComponentConfig) *operatorsv1.MultiClusterHub {
+	mch := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mch",
+			Namespace: "open-cluster-management",
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			LocalClusterName: localClusterName,
+		},
+	}
+	if len(components) > 0 {
+		mch.Spec.Overrides = &operatorsv1.Overrides{
+			Components: components,
+		}
+	}
+	return mch
+}
+
+func getUnstructuredField(u *unstructured.Unstructured, fields ...string) (bool, bool) {
+	val, found, err := unstructured.NestedBool(u.Object, fields...)
+	if err != nil {
+		return false, false
+	}
+	return val, found
+}
+
+// Test_getKlusterletAddonConfig verifies the generated KlusterletAddonConfig
+// object's static fields (metadata, applicationManager, searchCollector) and
+// that certPolicyController/policyController track the GRC component's
+// enabled state from Spec.Overrides.
+func Test_getKlusterletAddonConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		mch            *operatorsv1.MultiClusterHub
+		expectGRC      bool
+		expectedName   string
+		expectedNsName string
+	}{
+		{
+			name:           "GRC enabled by default when no overrides set",
+			mch:            newTestMCHForManagedCluster("local-cluster"),
+			expectGRC:      true,
+			expectedName:   "local-cluster",
+			expectedNsName: "local-cluster",
+		},
+		{
+			name: "GRC explicitly enabled via override",
+			mch: newTestMCHForManagedCluster("local-cluster",
+				operatorsv1.ComponentConfig{Name: operatorsv1.GRC, Enabled: true},
+			),
+			expectGRC:      true,
+			expectedName:   "local-cluster",
+			expectedNsName: "local-cluster",
+		},
+		{
+			name: "GRC disabled via override",
+			mch: newTestMCHForManagedCluster("local-cluster",
+				operatorsv1.ComponentConfig{Name: operatorsv1.GRC, Enabled: false},
+			),
+			expectGRC:      false,
+			expectedName:   "local-cluster",
+			expectedNsName: "local-cluster",
+		},
+		{
+			name: "GRC unaffected by unrelated overrides",
+			mch: newTestMCHForManagedCluster("local-cluster",
+				operatorsv1.ComponentConfig{Name: "some-other-component", Enabled: false},
+			),
+			expectGRC:      true,
+			expectedName:   "local-cluster",
+			expectedNsName: "local-cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kac := getKlusterletAddonConfig(tt.mch)
+
+			if kac.GetAPIVersion() != "agent.open-cluster-management.io/v1" {
+				t.Errorf("unexpected apiVersion: %s", kac.GetAPIVersion())
+			}
+			if kac.GetKind() != "KlusterletAddonConfig" {
+				t.Errorf("unexpected kind: %s", kac.GetKind())
+			}
+			if kac.GetName() != tt.expectedName {
+				t.Errorf("expected name %q, got %q", tt.expectedName, kac.GetName())
+			}
+			if kac.GetNamespace() != tt.expectedNsName {
+				t.Errorf("expected namespace %q, got %q", tt.expectedNsName, kac.GetNamespace())
+			}
+
+			appEnabled, _ := getUnstructuredField(kac, "spec", "applicationManager", "enabled")
+			if !appEnabled {
+				t.Error("expected applicationManager.enabled to always be true")
+			}
+
+			searchEnabled, _ := getUnstructuredField(kac, "spec", "searchCollector", "enabled")
+			if searchEnabled {
+				t.Error("expected searchCollector.enabled to always be false")
+			}
+
+			certPolicyEnabled, _ := getUnstructuredField(kac, "spec", "certPolicyController", "enabled")
+			if certPolicyEnabled != tt.expectGRC {
+				t.Errorf("expected certPolicyController.enabled = %v, got %v", tt.expectGRC, certPolicyEnabled)
+			}
+
+			policyEnabled, _ := getUnstructuredField(kac, "spec", "policyController", "enabled")
+			if policyEnabled != tt.expectGRC {
+				t.Errorf("expected policyController.enabled = %v, got %v", tt.expectGRC, policyEnabled)
+			}
+		})
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_NamespaceNotFound verifies that when the
+// local-cluster namespace doesn't exist yet, reconciliation requeues and
+// records a Progressing/WaitingForNamespaceReason condition instead of
+// erroring.
+func Test_ensureKlusterletAddonConfig_NamespaceNotFound(t *testing.T) {
+	r := newTestReconciler()
+	mch := newTestMCHForManagedCluster("local-cluster")
+
+	result, err := r.ensureKlusterletAddonConfig(mch)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result.RequeueAfter != resyncPeriod {
+		t.Errorf("expected RequeueAfter %v, got %v", resyncPeriod, result.RequeueAfter)
+	}
+
+	condition := GetHubCondition(mch.Status, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to be set")
+	}
+	if condition.Reason != WaitingForNamespaceReason {
+		t.Errorf("expected reason %q, got %q", WaitingForNamespaceReason, condition.Reason)
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_ClearsStaleNamespaceCondition verifies
+// that once the local-cluster namespace exists, a previously-set
+// WaitingForNamespaceReason condition is cleared rather than left stale.
+func Test_ensureKlusterletAddonConfig_ClearsStaleNamespaceCondition(t *testing.T) {
+	ns := LocalClusterNamespace("local-cluster")
+	r := newTestReconciler(ns)
+	mch := newTestMCHForManagedCluster("local-cluster")
+	stale := NewHubCondition(operatorsv1.Progressing, metav1.ConditionTrue, WaitingForNamespaceReason,
+		"Waiting for ManagedCluster namespace local-cluster to be created")
+	SetHubCondition(&mch.Status, *stale)
+
+	if _, err := r.ensureKlusterletAddonConfig(mch); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if condition := GetHubCondition(mch.Status, operatorsv1.Progressing); condition != nil {
+		t.Errorf("expected stale WaitingForNamespaceReason condition to be cleared, got: %+v", condition)
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_NamespaceGetError verifies that a
+// non-NotFound error while checking for the namespace is propagated as-is
+// (using an interceptor to force a transient error, e.g. API server hiccup).
+func Test_ensureKlusterletAddonConfig_NamespaceGetError(t *testing.T) {
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object,
+			opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.Namespace); ok {
+				return fmt.Errorf("simulated get error")
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+	mch := newTestMCHForManagedCluster("local-cluster")
+
+	_, err := r.ensureKlusterletAddonConfig(mch)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_CreatesNew is the happy path: given an
+// existing namespace and no prior KlusterletAddonConfig, one is created and
+// stamped with the installer.name/installer.namespace labels.
+func Test_ensureKlusterletAddonConfig_CreatesNew(t *testing.T) {
+	ns := LocalClusterNamespace("local-cluster")
+	r := newTestReconciler(ns)
+	mch := newTestMCHForManagedCluster("local-cluster")
+
+	result, err := r.ensureKlusterletAddonConfig(mch)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("expected empty result, got: %v", result)
+	}
+
+	kac := &unstructured.Unstructured{}
+	kac.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "agent.open-cluster-management.io",
+		Version: "v1",
+		Kind:    "KlusterletAddonConfig",
+	})
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "local-cluster", Namespace: "local-cluster"}, kac)
+	if err != nil {
+		t.Fatalf("expected KlusterletAddonConfig to be created: %v", err)
+	}
+
+	labels := kac.GetLabels()
+	if labels["installer.name"] != mch.GetName() || labels["installer.namespace"] != mch.GetNamespace() {
+		t.Errorf("expected installer labels to be set, got: %v", labels)
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_GetErrorOtherThanNotFound verifies that a
+// KlusterletAddonConfig Get failure unrelated to "not found" is returned as
+// an error rather than treated as "needs creation".
+func Test_ensureKlusterletAddonConfig_GetErrorOtherThanNotFound(t *testing.T) {
+	ns := LocalClusterNamespace("local-cluster")
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object,
+			opts ...client.GetOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == "KlusterletAddonConfig" {
+				return fmt.Errorf("simulated get error")
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}, ns)
+	mch := newTestMCHForManagedCluster("local-cluster")
+
+	_, err := r.ensureKlusterletAddonConfig(mch)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_CreateError verifies Create failures on
+// the KlusterletAddonConfig are surfaced to the caller.
+func Test_ensureKlusterletAddonConfig_CreateError(t *testing.T) {
+	ns := LocalClusterNamespace("local-cluster")
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == "KlusterletAddonConfig" {
+				return fmt.Errorf("simulated create error")
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	}, ns)
+	mch := newTestMCHForManagedCluster("local-cluster")
+
+	_, err := r.ensureKlusterletAddonConfig(mch)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_UpdatesExisting verifies that when a
+// KlusterletAddonConfig already exists, it's updated (installer labels
+// applied) rather than recreated, and unrelated existing labels are kept.
+func Test_ensureKlusterletAddonConfig_UpdatesExisting(t *testing.T) {
+	ns := LocalClusterNamespace("local-cluster")
+
+	existingKac := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "agent.open-cluster-management.io/v1",
+			"kind":       "KlusterletAddonConfig",
+			"metadata": map[string]interface{}{
+				"name":      "local-cluster",
+				"namespace": "local-cluster",
+				"labels": map[string]interface{}{
+					"custom-label": "should-persist",
+				},
+			},
+			"spec": map[string]interface{}{
+				"applicationManager": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+		},
+	}
+
+	r := newTestReconciler(ns, existingKac)
+	mch := newTestMCHForManagedCluster("local-cluster")
+
+	result, err := r.ensureKlusterletAddonConfig(mch)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("expected empty result, got: %v", result)
+	}
+
+	kac := &unstructured.Unstructured{}
+	kac.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "agent.open-cluster-management.io",
+		Version: "v1",
+		Kind:    "KlusterletAddonConfig",
+	})
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "local-cluster", Namespace: "local-cluster"}, kac)
+	if err != nil {
+		t.Fatalf("expected KlusterletAddonConfig to still exist: %v", err)
+	}
+
+	labels := kac.GetLabels()
+	if labels["custom-label"] != "should-persist" {
+		t.Errorf("expected existing labels to persist, got: %v", labels)
+	}
+	if labels["installer.name"] != mch.GetName() || labels["installer.namespace"] != mch.GetNamespace() {
+		t.Errorf("expected installer labels to be set, got: %v", labels)
+	}
+}
+
+// Test_ensureKlusterletAddonConfig_UpdateError verifies Update failures on
+// an existing KlusterletAddonConfig are surfaced to the caller.
+func Test_ensureKlusterletAddonConfig_UpdateError(t *testing.T) {
+	ns := LocalClusterNamespace("local-cluster")
+
+	existingKac := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "agent.open-cluster-management.io/v1",
+			"kind":       "KlusterletAddonConfig",
+			"metadata": map[string]interface{}{
+				"name":      "local-cluster",
+				"namespace": "local-cluster",
+			},
+		},
+	}
+
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == "KlusterletAddonConfig" {
+				return fmt.Errorf("simulated update error")
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}, ns, existingKac)
+	mch := newTestMCHForManagedCluster("local-cluster")
+
+	_, err := r.ensureKlusterletAddonConfig(mch)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// sanity check that errors.IsNotFound behaves as expected for unstructured Get
+// results, matching the assumption made in ensureKlusterletAddonConfig.
+func Test_ensureKlusterletAddonConfig_NotFoundIsDetected(t *testing.T) {
+	ns := LocalClusterNamespace("local-cluster")
+	r := newTestReconciler(ns)
+
+	kac := &unstructured.Unstructured{}
+	kac.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "agent.open-cluster-management.io",
+		Version: "v1",
+		Kind:    "KlusterletAddonConfig",
+	})
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "local-cluster", Namespace: "local-cluster"}, kac)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("expected IsNotFound error, got: %v", err)
 	}
 }

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -139,8 +140,11 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Check if no image overrides were found using either prefix.
 	if len(imageOverrides) == 0 {
-		r.Log.Error(err, "Could not get map of image overrides")
-		return ctrl.Result{}, nil
+		r.Log.Error(fmt.Errorf("no image overrides found from environment"), "Could not get map of image overrides")
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+			"No image overrides found from environment variables")
+		SetHubCondition(&multiClusterHub.Status, *condition)
+		return ctrl.Result{}, fmt.Errorf("no image overrides found from environment")
 	}
 
 	// Apply image repository override from annotation if present.
@@ -154,9 +158,11 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		imageOverrides, err = overrides.GetOverridesFromConfigmap(r.Client, imageOverrides,
 			multiClusterHub.GetNamespace(), ioConfigmapName, false)
 		if err != nil {
-			r.Log.Error(err, fmt.Sprintf("Failed to find image override configmap: %s/%s",
-				multiClusterHub.GetNamespace(), ioConfigmapName))
-
+			r.Log.Error(err, "Failed to find image override configmap",
+				"namespace", multiClusterHub.GetNamespace(), "configmap", ioConfigmapName)
+			condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+				fmt.Sprintf("Image override configmap %s/%s not found", multiClusterHub.GetNamespace(), ioConfigmapName))
+			SetHubCondition(&multiClusterHub.Status, *condition)
 			return ctrl.Result{}, err
 		}
 	}
@@ -175,9 +181,11 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		templateOverrides, err = overrides.GetOverridesFromConfigmap(r.Client, templateOverrides,
 			multiClusterHub.GetNamespace(), toConfigmapName, true)
 		if err != nil {
-			r.Log.Error(err, fmt.Sprintf("Failed to find template override configmap: %s/%s",
-				multiClusterHub.GetNamespace(), toConfigmapName))
-
+			r.Log.Error(err, "Failed to find template override configmap",
+				"namespace", multiClusterHub.GetNamespace(), "configmap", toConfigmapName)
+			condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+				fmt.Sprintf("Template override configmap %s/%s not found", multiClusterHub.GetNamespace(), toConfigmapName))
+			SetHubCondition(&multiClusterHub.Status, *condition)
 			return ctrl.Result{}, err
 		}
 	}
@@ -192,6 +200,9 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 	if err != nil {
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+			fmt.Sprintf("Failed to set defaults: %s", err))
+		SetHubCondition(&multiClusterHub.Status, *condition)
 		return ctrl.Result{}, err
 	}
 
@@ -199,7 +210,10 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		Get the default storage class name and store it as an environment variable for components that need it.
 	*/
 	if result, err = r.SetDefaultStorageClassName(ctx, multiClusterHub); err != nil {
-		r.Log.Error(err, "failed to set the default StorageClass name")
+		r.Log.Error(err, "Failed to set default StorageClass name")
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+			fmt.Sprintf("Failed to set default StorageClass name: %s", err))
+		SetHubCondition(&multiClusterHub.Status, *condition)
 		return ctrl.Result{}, err
 	}
 
@@ -207,6 +221,13 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// indicated by the deletion timestamp being set.
 	isHubMarkedToBeDeleted := multiClusterHub.GetDeletionTimestamp() != nil
 	if isHubMarkedToBeDeleted {
+		// Snapshot the object BEFORE mutating its status below. This is used to compute a
+		// merge patch if finalization doesn't complete this reconcile. Capturing it after
+		// setting the Terminating condition would make the condition's addition invisible to
+		// the diff (both "before" and "after" would already have it), so the patch would never
+		// actually persist it to the API server.
+		beforeFinalization := multiClusterHub.DeepCopy()
+
 		terminating := NewHubCondition(operatorv1.Terminating, metav1.ConditionTrue, DeleteTimestampReason, "Multiclusterhub is being cleaned up.")
 		SetHubCondition(&multiClusterHub.Status, *terminating)
 
@@ -214,9 +235,16 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			// Run finalization logic. If the finalization
 			// logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
-			if err := r.finalizeHub(r.Log, multiClusterHub, ocpConsole, stsEnabled); err != nil {
-				// Logging err and returning nil to ensure 45 second wait
-				r.Log.Info(fmt.Sprintf("Finalizing: %s", err.Error()))
+			if err := r.finalizeHub(ctx, r.Log, multiClusterHub, ocpConsole, stsEnabled); err != nil {
+				r.Log.Info("Hub finalization incomplete, will retry",
+					"reason", err.Error(),
+					"requeueAfter", resyncPeriod.String())
+
+				statusErr := r.Client.Status().Patch(ctx, multiClusterHub, client.MergeFrom(beforeFinalization))
+				if statusErr != nil {
+					r.Log.Error(statusErr, "Failed to update MCH status during finalization")
+				}
+
 				return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 			}
 
@@ -240,14 +268,22 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	*/
 	_, err = r.ensureOpenShiftNamespaceLabel(ctx, multiClusterHub)
 	if err != nil {
-		r.Log.Error(err, "Failed to add to %s label to namespace: %s", utils.OpenShiftClusterMonitoringLabel,
-			multiClusterHub.GetNamespace())
+		r.Log.Error(err, "Failed to add label to namespace",
+			"label", utils.OpenShiftClusterMonitoringLabel,
+			"namespace", multiClusterHub.GetNamespace())
+		msg := fmt.Sprintf("Failed to add %s label to namespace %s",
+			utils.OpenShiftClusterMonitoringLabel, multiClusterHub.GetNamespace())
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason, msg)
+		SetHubCondition(&multiClusterHub.Status, *condition)
 		return ctrl.Result{}, err
 	}
 
 	err = r.maintainImageManifestConfigmap(multiClusterHub)
 	if err != nil {
-		r.Log.Error(err, "Error storing image manifests in configmap")
+		r.Log.Error(err, "Failed to store image manifests in configmap")
+		condition := NewHubCondition(operatorv1.Progressing, metav1.ConditionFalse, RequirementsNotMetReason,
+			fmt.Sprintf("Failed to maintain image manifest configmap: %s", err))
+		SetHubCondition(&multiClusterHub.Status, *condition)
 		return ctrl.Result{}, err
 	}
 
@@ -376,7 +412,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
-	// Install CRDs
+	// Deploy base resources (ClusterRoles)
 	reason, err = r.deployResources(r.Log, multiClusterHub)
 	if err != nil {
 		condition := NewHubCondition(
@@ -398,7 +434,7 @@ func (r *MultiClusterHubReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return result, err
 	}
 
-	result, err = r.waitForMCEReady(ctx)
+	result, err = r.waitForMCEReady(ctx, multiClusterHub)
 	if result != (ctrl.Result{}) || err != nil {
 		return result, err
 	}

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -29,59 +29,73 @@ import (
 )
 
 const (
-	// AwaitingCRDCreationReason is added in a hub when a desired CRD has not been installed yet
-	AwaitingCRDCreationReason = "AwaitingCRDCreation"
 	// ComponentsAvailableReason is added in a hub when all desired components are
 	// installed successfully
 	ComponentsAvailableReason = "ComponentsAvailable"
+
 	// ComponentsUnavailableReason is added in a hub when one or more components are
 	// in an unready state
 	ComponentsUnavailableReason = "ComponentsUnavailable"
-	// ComponentUpdatingReason is added when the hub is actively updating a component resource
+
+	// ComponentsUpdatingReason is added when the hub is actively updating a component resource
 	ComponentsUpdatingReason = "UpdatingComponentResource"
+
 	// NewComponentReason is added when the hub creates a new install resource successfully
 	NewComponentReason = "NewResourceCreated"
+
 	// DeployFailedReason is added when the hub fails to deploy a resource
 	DeployFailedReason = "FailedDeployingComponent"
-	//ResourceBlockReason is added when there is an existing resource that prevents an upgrade from progressing
-	ResourceBlockReason = "BlockingUpgrade"
+
 	// OldComponentRemovedReason is added when the hub calls delete on an old resource
 	OldComponentRemovedReason = "OldResourceDeleted"
+
 	// OldComponentNotRemovedReason is added when a component the hub is trying to delete has not been removed successfully
 	OldComponentNotRemovedReason = "OldResourceDeleteFailed"
+
 	// AllOldComponentsRemovedReason is added when the hub successfully prunes all old resources
 	AllOldComponentsRemovedReason = "AllOldResourcesDeleted"
-	// CertManagerReason is added when the hub is waiting for cert manager CRDs to come up
-	CertManagerReason = "CertManagerInitializing"
+
 	// DeleteTimestampReason is added when the multiclusterhub has been targeted for delete
 	DeleteTimestampReason = "DeletionTimestampPresent"
+
 	// PausedReason is added when the multiclusterhub is paused
 	PausedReason = "MCHPaused"
+
 	// ResumedReason is added when the multiclusterhub is resumed
 	ResumedReason = "MCHResumed"
+
 	// ReconcileReason is added when the multiclusterhub is actively reconciling
 	ReconcileReason = "MCHReconciling"
+
 	// HelmReleaseTerminatingReason is added when the multiclusterhub is waiting for the removal
 	// of helm releases
 	HelmReleaseTerminatingReason = "HelmReleaseTerminating"
-	// ManagedClusterTerminatingReason is added when a managed cluster has been deleted and
-	// is waiting to be finalized
-	ManagedClusterTerminatingReason = "ManagedClusterTerminating"
-	// NamespaceTerminatingReason is added when a managed cluster's namespace has been deleted and
-	// is waiting to be finalized
-	NamespaceTerminatingReason = "ManagedClusterNamespaceTerminating"
+
 	// ResourceRenderReason is added when an error occurs while rendering a deployable resource
 	ResourceRenderReason = "FailedRenderingResource"
+
 	// CRDRenderReason is added when an error occurs while rendering a CRD
 	CRDRenderReason = "FailedRenderingCRD"
+
 	// RequirementsNotMetReason is when there is something missing or misconfigured
 	// that is preventing progress
 	RequirementsNotMetReason = "RequirementsNotMet"
+
 	// WaitingForMCEUpgradeReason is added when the hub is blocked waiting for MultiClusterEngine
 	// to reach the version required by the current MCH release
 	WaitingForMCEUpgradeReason = "WaitingForMCEUpgrade"
 
+	// FailedApplyingComponent is added when a component template fails to apply
 	FailedApplyingComponent = "FailedApplyingComponent"
+
+	// WaitingForMCEReason is added when the hub is waiting for MultiClusterEngine to be ready
+	WaitingForMCEReason = "WaitingForMCE"
+
+	// WaitingForNamespaceReason is added when the hub is waiting for a namespace to be created
+	WaitingForNamespaceReason = "WaitingForNamespace"
+
+	// ComponentNotReadyReason is added when a prerequisite component is not yet available
+	ComponentNotReadyReason = "ComponentNotReady"
 )
 
 var (
@@ -133,7 +147,7 @@ func (r *MultiClusterHubReconciler) syncHubStatus(ctx context.Context, m *operat
 		r.Log.Error(err, "Failed to reconcile MCE compliance ConsoleNotification banner")
 	}
 
-	if reflect.DeepEqual(m.Status, original) {
+	if reflect.DeepEqual(m.Status, *original) {
 		r.Log.Info("Status hasn't changed")
 		return reconcile.Result{}, nil
 	}
@@ -146,6 +160,14 @@ func (r *MultiClusterHubReconciler) syncHubStatus(ctx context.Context, m *operat
 			// Error from object being modified is normal behavior and should not be treated like an error
 			r.Log.Info("Failed to update status", "Reason", "Object has been modified")
 			return reconcile.Result{RequeueAfter: resyncPeriod}, nil
+		}
+
+		if errors.IsNotFound(err) {
+			// The object was deleted (e.g. its last finalizer was just removed by this same
+			// reconcile, which triggers immediate garbage collection). There's nothing left to
+			// update, and this isn't a real error.
+			r.Log.Info("Skipping status update, MultiClusterHub no longer exists", "name", m.Name, "namespace", m.Namespace)
+			return reconcile.Result{}, nil
 		}
 
 		r.Log.Error(err, fmt.Sprintf("Failed to update %s/%s status ", m.Namespace, m.Name))
@@ -164,6 +186,27 @@ func (r *MultiClusterHubReconciler) syncHubStatus(ctx context.Context, m *operat
 // compliance. It does not mutate the cluster; callers are responsible for persisting the result.
 func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *operatorsv1.MultiClusterHub, allDeps []*appsv1.Deployment,
 	allCRs map[string]*unstructured.Unstructured, ocpConsole, isSTSEnabled bool) operatorsv1.MultiClusterHubStatus {
+
+	// While the hub is being deleted, the install-oriented component/version tracking below
+	// doesn't apply: components are intentionally being torn down, not rolled out, so
+	// re-evaluating "is this available" against them is actively misleading (e.g. logging
+	// "The component is now available" for a Subscription mid-termination, right before it
+	// disappears) and computing Progressing/Complete from it produces contradictory messages
+	// alongside the accurate Terminating condition finalization already sets. Preserve
+	// existing status as-is and just report the phase.
+	//
+	// Progressing/Complete are also removed rather than left stale: Terminating + Phase
+	// already fully describe the deletion state, so there's no information lost, and a
+	// leftover "Complete: True, All hub components ready." while actively tearing down would
+	// be actively wrong rather than merely uninformative. This mirrors the existing pattern
+	// of removing Progressing once Complete:True is set in the successful branch below.
+	if hub.GetDeletionTimestamp() != nil {
+		status := hub.Status.DeepCopy()
+		status.Phase = operatorsv1.HubUninstalling
+		RemoveHubCondition(status, operatorsv1.Progressing)
+		RemoveHubCondition(status, operatorsv1.Complete)
+		return *status
+	}
 
 	components := map[string]operatorsv1.StatusCondition{}
 	if paused := utils.IsPaused(hub); !paused {
@@ -239,8 +282,11 @@ func (r *MultiClusterHubReconciler) calculateStatus(ctx context.Context, hub *op
 				SetHubCondition(&status, *progressing)
 			}
 
-			// only add unavailable status if complete status already present
-			if HubConditionPresent(status, operatorsv1.Complete) {
+			// Always surface a Complete condition while not yet successful (and not paused), not
+			// just when one already existed. This gives consumers a stable, always-present
+			// Complete condition from the first reconcile (False while installing/updating, True
+			// once done) instead of an absence they have to interpret themselves.
+			if !utils.IsPaused(hub) {
 				unavailable := NewHubCondition(operatorsv1.Complete, metav1.ConditionFalse, ComponentsUnavailableReason, "Not all hub components ready.")
 				SetHubCondition(&status, *unavailable)
 			}
@@ -346,6 +392,23 @@ func latestDeployCondition(conditions []appsv1.DeploymentCondition) appsv1.Deplo
 		}
 	}
 	return latest
+}
+
+// latestMCECondition returns the most recently transitioned condition on the given
+// MultiClusterEngine, or nil if it has none. Used to surface MCE's own progress detail
+// (e.g. "Not all components available") while MCH is waiting on MCE to report a version,
+// instead of leaving that whole window opaque from the MCH's own status.
+func latestMCECondition(mce *mcev1.MultiClusterEngine) *mcev1.MultiClusterEngineCondition {
+	if mce == nil || len(mce.Status.Conditions) == 0 {
+		return nil
+	}
+	latest := mce.Status.Conditions[0]
+	for i := range mce.Status.Conditions {
+		if mce.Status.Conditions[i].LastTransitionTime.Time.After(latest.LastTransitionTime.Time) {
+			latest = mce.Status.Conditions[i]
+		}
+	}
+	return &latest
 }
 
 func progressingDeployCondition(conditions []appsv1.DeploymentCondition) appsv1.DeploymentCondition {

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -147,7 +147,7 @@ func (r *MultiClusterHubReconciler) syncHubStatus(ctx context.Context, m *operat
 		r.Log.Error(err, "Failed to reconcile MCE compliance ConsoleNotification banner")
 	}
 
-	if reflect.DeepEqual(m.Status, *original) {
+	if reflect.DeepEqual(newStatus, *original) {
 		r.Log.Info("Status hasn't changed")
 		return reconcile.Result{}, nil
 	}

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -15,12 +15,16 @@ import (
 	mcev1 "github.com/stolostron/backplane-operator/api/v1"
 	operatorsv1 "github.com/stolostron/multiclusterhub-operator/api/v1"
 	"github.com/stolostron/multiclusterhub-operator/pkg/multiclusterengineutils"
+	"github.com/stolostron/multiclusterhub-operator/pkg/utils"
 	"github.com/stolostron/multiclusterhub-operator/pkg/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var replicas int32 = 1
@@ -228,6 +232,39 @@ func TestSetHubCondition(t *testing.T) {
 		if !got.LastTransitionTime.Equal(&firstMessage.LastTransitionTime) {
 			t.Errorf("expected lastTransitionTime to be preserved at %v, got %v",
 				firstMessage.LastTransitionTime, got.LastTransitionTime)
+		}
+	})
+
+	// Regression test: many call sites (e.g. every stage of finalization) reuse the same
+	// Reason across an evolving sequence of more specific Messages, e.g.
+	// reconcile.go sets Terminating/DeletionTimestampPresent with a generic message the
+	// moment deletion starts, and cleanupMultiClusterEngine later tries to refine it to name
+	// MCE specifically, using the SAME reason. Bailing out on Status+Reason alone (without
+	// also checking Message) would silently drop that refinement, freezing the condition at
+	// whatever message was set first.
+	t.Run("Refines message when only Message differs (same Status and Reason)", func(t *testing.T) {
+		m := &operatorsv1.MultiClusterHub{}
+		generic := operatorsv1.HubCondition{
+			Type:    operatorsv1.Terminating,
+			Status:  metav1.ConditionTrue,
+			Reason:  DeleteTimestampReason,
+			Message: "Multiclusterhub is being cleaned up.",
+		}
+		specific := operatorsv1.HubCondition{
+			Type:    operatorsv1.Terminating,
+			Status:  metav1.ConditionTrue,
+			Reason:  DeleteTimestampReason,
+			Message: "Waiting for MultiClusterEngine multiclusterengine to terminate",
+		}
+
+		SetHubCondition(&m.Status, generic)
+		SetHubCondition(&m.Status, specific)
+
+		if len(m.Status.HubConditions) != 1 {
+			t.Fatalf("expected exactly 1 condition, got %d", len(m.Status.HubConditions))
+		}
+		if got := m.Status.HubConditions[0].Message; got != specific.Message {
+			t.Errorf("expected message to refine to %q, got %q (message got silently dropped)", specific.Message, got)
 		}
 	})
 }
@@ -802,6 +839,339 @@ func TestMCEUpgradeWaitCondition(t *testing.T) {
 				t.Errorf("Expected message %q, got %q", tt.wantMessage, got.Message)
 			}
 		})
+	}
+}
+
+// Test_calculateStatus_PreservesSpecificProgressingReason verifies that
+// calculateStatus does NOT downgrade an already-present, specific Progressing
+// reason (e.g. WaitingForMCEReason) to a generic message while the hub is
+// still not successful. Regression test for a bug where the "else" branch
+// unconditionally rewrote any existing WaitingForMCEReason condition to a
+// generic "Waiting for components to become ready." message on the very same
+// reconcile it was set, making the specific reason effectively unobservable.
+//
+// MCE is seeded as version-compliant so the MCE-upgrade-wait branch (added by
+// ACM-8659, which takes priority over this logic when MCE hasn't reached the
+// required version) doesn't apply here — this test is specifically about the
+// "hub is otherwise still reconciling" branch not clobbering a more specific
+// reason already set by an earlier stage (e.g. waitForMCEReady itself, before
+// MCE reports a version at all).
+func Test_calculateStatus_PreservesSpecificProgressingReason(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	mce := &mcev1.MultiClusterEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multiclusterengine",
+			Labels: map[string]string{
+				multiclusterengineutils.MCEManagedByLabel: "true",
+			},
+		},
+		Status: mcev1.MultiClusterEngineStatus{
+			CurrentVersion: version.RequiredCommunityMCEVersion,
+			Conditions: []mcev1.MultiClusterEngineCondition{
+				{
+					Type:    mcev1.MultiClusterEngineAvailable,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Available",
+					Message: "MCE is available",
+				},
+			},
+		},
+	}
+	if err := recon.Client.Create(ctx, mce); err != nil {
+		t.Fatalf("failed to create MCE: %v", err)
+	}
+	defer func() {
+		if err := recon.Client.Delete(ctx, mce); err != nil {
+			t.Errorf("failed to delete MCE: %v", err)
+		}
+	}()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch-preserve-progress",
+			Namespace: "open-cluster-management",
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			DisableHubSelfManagement: true,
+		},
+		Status: operatorsv1.MultiClusterHubStatus{
+			HubConditions: []operatorsv1.HubCondition{
+				{
+					Type:    operatorsv1.Progressing,
+					Status:  metav1.ConditionTrue,
+					Reason:  WaitingForMCEReason,
+					Message: "Waiting for MultiClusterEngine multiclusterengine to report version",
+				},
+			},
+		},
+	}
+
+	// ocpConsole=true so no components are tracked (DisableHubSelfManagement leaves the
+	// component list otherwise empty), guaranteeing allComponentsSuccessful() is false here.
+	newStatus := recon.calculateStatus(ctx, hub, []*appsv1.Deployment{},
+		map[string]*unstructured.Unstructured{}, true, false)
+
+	condition := GetHubCondition(newStatus, operatorsv1.Progressing)
+	if condition == nil {
+		t.Fatal("expected Progressing condition to remain present")
+	}
+	if condition.Reason != WaitingForMCEReason {
+		t.Errorf("expected specific WaitingForMCE reason to be preserved, got reason %q (message: %q)",
+			condition.Reason, condition.Message)
+	}
+	if condition.Message != "Waiting for MultiClusterEngine multiclusterengine to report version" {
+		t.Errorf("expected original message to be preserved, got %q", condition.Message)
+	}
+}
+
+// Test_calculateStatus_SetsCompleteFalse_OnFreshInstall verifies that a
+// Complete condition is set to False from the very first reconcile of a
+// fresh install (not just once a Complete condition already existed from a
+// prior success), so consumers always have a stable Complete condition to
+// observe instead of its absence.
+//
+// MCE is seeded as version-compliant so the MCE-upgrade-wait branch (added by
+// ACM-8659) doesn't take priority and remove the Complete condition before
+// this logic gets to run — this test is specifically about the "otherwise
+// still reconciling" branch always surfacing Complete:False.
+func Test_calculateStatus_SetsCompleteFalse_OnFreshInstall(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	mce := &mcev1.MultiClusterEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multiclusterengine",
+			Labels: map[string]string{
+				multiclusterengineutils.MCEManagedByLabel: "true",
+			},
+		},
+		Status: mcev1.MultiClusterEngineStatus{
+			CurrentVersion: version.RequiredCommunityMCEVersion,
+			Conditions: []mcev1.MultiClusterEngineCondition{
+				{
+					Type:    mcev1.MultiClusterEngineAvailable,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Available",
+					Message: "MCE is available",
+				},
+			},
+		},
+	}
+	if err := recon.Client.Create(ctx, mce); err != nil {
+		t.Fatalf("failed to create MCE: %v", err)
+	}
+	defer func() {
+		if err := recon.Client.Delete(ctx, mce); err != nil {
+			t.Errorf("failed to delete MCE: %v", err)
+		}
+	}()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch-fresh-install",
+			Namespace: "open-cluster-management",
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			DisableHubSelfManagement: true,
+		},
+	}
+
+	// ocpConsole=true so no components are tracked (DisableHubSelfManagement leaves the
+	// component list otherwise empty), guaranteeing allComponentsSuccessful() is false here.
+	newStatus := recon.calculateStatus(ctx, hub, []*appsv1.Deployment{},
+		map[string]*unstructured.Unstructured{}, true, false)
+
+	condition := GetHubCondition(newStatus, operatorsv1.Complete)
+	if condition == nil {
+		t.Fatal("expected Complete condition to be present even on a fresh install with no prior Complete condition")
+	}
+	if condition.Status != metav1.ConditionFalse {
+		t.Errorf("expected Complete status False, got %v", condition.Status)
+	}
+	if condition.Reason != ComponentsUnavailableReason {
+		t.Errorf("expected reason %q, got %q", ComponentsUnavailableReason, condition.Reason)
+	}
+}
+
+// Test_calculateStatus_NoCompleteCondition_WhenPaused verifies that a paused
+// hub does not get a Complete:False condition added, mirroring the existing
+// pause handling in the successful branch.
+func Test_calculateStatus_NoCompleteCondition_WhenPaused(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch-paused",
+			Namespace: "open-cluster-management",
+			Annotations: map[string]string{
+				utils.AnnotationMCHPause: "true",
+			},
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			DisableHubSelfManagement: true,
+		},
+	}
+
+	newStatus := recon.calculateStatus(ctx, hub, []*appsv1.Deployment{},
+		map[string]*unstructured.Unstructured{}, true, false)
+
+	if condition := GetHubCondition(newStatus, operatorsv1.Complete); condition != nil {
+		t.Errorf("expected no Complete condition while paused, got: %+v", condition)
+	}
+}
+
+// Test_calculateStatus_SkipsComponentTracking_WhenBeingDeleted verifies that
+// while the hub is marked for deletion, calculateStatus doesn't recompute
+// install-oriented component tracking or Progressing/Complete conditions
+// (which would otherwise produce misleading messages like "component is now
+// available" for something mid-termination, or a contradictory
+// "Not all hub components ready." alongside the accurate Terminating
+// condition finalization already set) — it just reports the phase and
+// otherwise leaves the existing status untouched. It also verifies that any
+// stale Progressing/Complete conditions left over from before deletion
+// started (e.g. "Complete: True, All hub components ready." from when the
+// hub was last Running) are stripped, rather than left sitting there
+// actively wrong during active teardown.
+func Test_calculateStatus_SkipsComponentTracking_WhenBeingDeleted(t *testing.T) {
+	registerScheme()
+	ctx := context.TODO()
+
+	now := metav1.Now()
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-mch-deleting",
+			Namespace:         "open-cluster-management",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test.io/keep-alive"},
+		},
+		Status: operatorsv1.MultiClusterHubStatus{
+			CurrentVersion: "5.0.0",
+			HubConditions: []operatorsv1.HubCondition{
+				// Stale, left over from before deletion started.
+				{
+					Type:    operatorsv1.Complete,
+					Status:  metav1.ConditionTrue,
+					Reason:  ComponentsAvailableReason,
+					Message: "All hub components ready.",
+				},
+				{
+					Type:    operatorsv1.Terminating,
+					Status:  metav1.ConditionTrue,
+					Reason:  DeleteTimestampReason,
+					Message: "Waiting for MultiClusterEngine multiclusterengine to terminate",
+				},
+			},
+		},
+	}
+
+	newStatus := recon.calculateStatus(ctx, hub, []*appsv1.Deployment{},
+		map[string]*unstructured.Unstructured{}, true, false)
+
+	if newStatus.Phase != operatorsv1.HubUninstalling {
+		t.Errorf("expected phase %q, got %q", operatorsv1.HubUninstalling, newStatus.Phase)
+	}
+	if len(newStatus.Components) != 0 {
+		t.Errorf("expected no component tracking during deletion, got %d components", len(newStatus.Components))
+	}
+	if condition := GetHubCondition(newStatus, operatorsv1.Progressing); condition != nil {
+		t.Errorf("expected no Progressing condition to be computed during deletion, got: %+v", condition)
+	}
+	if condition := GetHubCondition(newStatus, operatorsv1.Complete); condition != nil {
+		t.Errorf("expected no Complete condition to be computed during deletion, got: %+v", condition)
+	}
+	terminating := GetHubCondition(newStatus, operatorsv1.Terminating)
+	if terminating == nil {
+		t.Fatal("expected the existing Terminating condition to be preserved")
+	}
+	if terminating.Message != "Waiting for MultiClusterEngine multiclusterengine to terminate" {
+		t.Errorf("expected existing Terminating message to be preserved unchanged, got %q", terminating.Message)
+	}
+}
+
+// Test_syncHubStatus_HandlesNotFound verifies that when the MultiClusterHub
+// object no longer exists by the time syncHubStatus tries to persist its
+// computed status (e.g. its last finalizer was just removed, triggering
+// immediate garbage collection), the resulting NotFound error from
+// Status().Update() is treated as expected/benign rather than surfaced as a
+// reconciler error.
+func Test_syncHubStatus_HandlesNotFound(t *testing.T) {
+	registerScheme()
+	r := newTestReconciler() // empty client: hub was never created server-side
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch-notfound",
+			Namespace: "open-cluster-management",
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			DisableHubSelfManagement: true,
+		},
+	}
+	original := hub.Status.DeepCopy()
+
+	// Mutate in-memory status so it differs from `original`, forcing syncHubStatus
+	// past the "status hasn't changed" shortcut and into the actual Update() call.
+	hub.Status.HubConditions = []operatorsv1.HubCondition{
+		{Type: operatorsv1.Terminating, Status: metav1.ConditionTrue, Reason: DeleteTimestampReason},
+	}
+
+	result, err := r.syncHubStatus(context.TODO(), hub, original, []*appsv1.Deployment{},
+		map[string]*unstructured.Unstructured{}, true, false)
+	if err != nil {
+		t.Fatalf("expected no error when MultiClusterHub no longer exists, got: %v", err)
+	}
+	if result != (reconcile.Result{}) {
+		t.Errorf("expected empty result, got: %+v", result)
+	}
+}
+
+// Test_syncHubStatus_SkipsUpdate_WhenStatusUnchanged is a regression test for
+// a bug where the "status hasn't changed" shortcut compared m.Status (a
+// MultiClusterHubStatus value) against original (a *MultiClusterHubStatus
+// pointer) via reflect.DeepEqual. Because the two arguments had different
+// types, DeepEqual always returned false regardless of content, so every
+// single reconcile performed a full Status().Update() even when nothing had
+// changed. This verifies the shortcut now actually triggers (no Update call)
+// when the freshly computed status matches what's already there.
+func Test_syncHubStatus_SkipsUpdate_WhenStatusUnchanged(t *testing.T) {
+	registerScheme()
+
+	hub := &operatorsv1.MultiClusterHub{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mch-unchanged",
+			Namespace: "open-cluster-management",
+		},
+		Spec: operatorsv1.MultiClusterHubSpec{
+			DisableHubSelfManagement: true,
+		},
+	}
+
+	// Seed hub.Status with exactly what calculateStatus() would compute for it, so the
+	// upcoming syncHubStatus call's freshly recomputed status matches what's already there.
+	seedReconciler := newTestReconciler()
+	hub.Status = seedReconciler.calculateStatus(context.TODO(), hub, []*appsv1.Deployment{},
+		map[string]*unstructured.Unstructured{}, true, false)
+	original := hub.Status.DeepCopy()
+
+	updateCalled := false
+	r := newTestReconcilerWithInterceptor(interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object,
+			opts ...client.SubResourceUpdateOption) error {
+			updateCalled = true
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	})
+
+	_, err := r.syncHubStatus(context.TODO(), hub, original, []*appsv1.Deployment{},
+		map[string]*unstructured.Unstructured{}, true, false)
+	if err != nil {
+		t.Fatalf("syncHubStatus() unexpected error: %v", err)
+	}
+	if updateCalled {
+		t.Error("expected Status().Update() to be skipped since nothing changed, but it was called")
 	}
 }
 

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -1129,13 +1129,23 @@ func Test_syncHubStatus_HandlesNotFound(t *testing.T) {
 }
 
 // Test_syncHubStatus_SkipsUpdate_WhenStatusUnchanged is a regression test for
-// a bug where the "status hasn't changed" shortcut compared m.Status (a
-// MultiClusterHubStatus value) against original (a *MultiClusterHubStatus
-// pointer) via reflect.DeepEqual. Because the two arguments had different
-// types, DeepEqual always returned false regardless of content, so every
-// single reconcile performed a full Status().Update() even when nothing had
-// changed. This verifies the shortcut now actually triggers (no Update call)
-// when the freshly computed status matches what's already there.
+// two compounding bugs in the "status hasn't changed" shortcut:
+//  1. It compared m.Status (a MultiClusterHubStatus value) against original
+//     (a *MultiClusterHubStatus pointer) via reflect.DeepEqual without
+//     dereferencing. Because the two arguments had different types,
+//     DeepEqual always returned false regardless of content.
+//  2. Even after dereferencing, it compared the wrong operand: m.Status
+//     (which calculateStatus() never mutates) against original, instead of
+//     the freshly computed newStatus against original. Since almost all of
+//     the condition-setting in this codebase happens by mutating m.Status
+//     directly during Reconcile() (not via calculateStatus()'s return
+//     value), m.Status equals original in the common case, so the shortcut
+//     would trigger and silently skip persisting newStatus even when it
+//     legitimately differs (e.g. a component's availability or the overall
+//     phase changed).
+//
+// This verifies the shortcut now actually compares newStatus against
+// original, and correctly skips the Update() call only when they match.
 func Test_syncHubStatus_SkipsUpdate_WhenStatusUnchanged(t *testing.T) {
 	registerScheme()
 


### PR DESCRIPTION
# Description

Surface what is actually blocking during MCH finalization, MCE readiness, and reconciler stall scenarios so that `kubectl get mch` shows actionable status messages instead of generic "Multiclusterhub is being cleaned up."

This is a clean re-submission of #4532, rebased on top of `main` as a fresh branch (`feature/surface-blocking-resource-v2`) to properly integrate with the MCE-upgrade-wait status changes from #4613 (ACM-8659), which landed on `main` while #4532 was in review and could not be cleanly rebased in place. #4532 is superseded by this PR and will be closed.

## Related Issue

Part of MCH operator observability improvements.

## Changes Made

**Finalization observability:**
- Persist status update on finalization retry path — `SetHubCondition` was modifying in-memory struct but `r.Client.Status().Update()`/`Patch()` was never called before returning, so condition updates were lost each loop
- Set `Terminating` condition with specific resource name in all 6 cleanup functions (`cleanupNamespaces`, `cleanupMultiClusterEngine` MCE/ClusterExtension/CSV/Subscription/namespace)
- Surface stuck namespace reason from `NamespaceDeletionContentFailure` condition
- Replace anonymous cleanup function slice with named `cleanupStep` struct for better logging
- Propagate `context.Context` through finalization cleanup instead of ad-hoc `context.Background()`/`context.TODO()`

**MCE readiness conditions:**
- Add `WaitingForMCE` conditions for: CRD not available, MCE not present, version not reported (enriched with MCE's own latest condition), version mismatch
- Fix import alias typo (`operatorsv1` → `operatorv1`) in common.go
- Retry Subscription/ClusterExtension update conflicts with OLM's own status writes quietly instead of an explicit requeue, so concurrent OLM updates don't starve MCE CR creation

**Reconciler path conditions (RequirementsNotMet):**
- Image/template override configmap errors
- `setDefaults` failure
- `SetDefaultStorageClassName` failure
- Namespace label failure
- Image manifest configmap failure
- Multiple OperatorGroups (was permanent silent stall)

**KlusterletAddonConfig:**
- Add `WaitingForMCE`/`WaitingForNamespace` condition when ManagedCluster namespace not yet created

**Status/deletion handling:**
- `calculateStatus()` now short-circuits while the hub is being deleted, preserving existing status and just reporting the `Uninstalling` phase, instead of recomputing install-oriented component/version tracking against resources that are intentionally being torn down
- Always surface a `Complete:False` condition once the hub is no longer successful (and not paused), not just when one already existed
- Fix `reflect.DeepEqual(m.Status, original)` comparing a value against a pointer (always false), which made the "status hasn't changed" shortcut in `syncHubStatus` never trigger
- Treat a `NotFound` error from the status update as benign (object's last finalizer was likely just removed)
- Integrated with the MCE-upgrade-wait status logic from #4613 (ACM-8659) so the two sets of conditions (MCE not yet *ready*, vs. MCE ready but below the *required version*) coexist correctly, with the version-wait condition taking priority when applicable

**Bug fixes:**
- Fix `CRDRenderReason` misuse in `deployResources` — should be `ResourceRenderReason` (was reporting RBAC rendering failures as CRD failures)
- Fix broken `r.Log.Error` calls using `%s` format verbs (logr doesn't support printf-style formatting)
- Fix misleading `// Install CRDs` comment on `deployResources` call (deploys ClusterRoles)

**Cleanup:**
- Remove 5 unused status reason constants: `AwaitingCRDCreationReason`, `ResourceBlockReason`, `CertManagerReason`, `ManagedClusterTerminatingReason`, `NamespaceTerminatingReason`
- Add comments to all undocumented reason constants

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

- All condition updates use existing `SetHubCondition`/`NewHubCondition` helpers — no new API surface beyond the reason constants noted above
- `go build`, `go vet`, and `go test ./controllers/... ./api/... ./pkg/...` all pass locally

## Reviewers

/cc @cameronmwall @ngraham20

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer status conditions identifying resources being created, awaited, or removed.
  - Added specific reasons for waiting on the MultiClusterEngine, namespaces, unmet requirements, and component readiness.
  - Status messages now identify affected resources.

- **Bug Fixes**
  - Improved handling of transient update conflicts so installation can continue without unnecessary retries.
  - Prevented stale waiting and progress conditions from remaining after resources become ready.
  - Improved status handling during deletion, finalization failures, and resource cleanup.
  - Improved reporting when installation requirements or resource configuration cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->